### PR TITLE
Update gh-pages to version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-import": "^2.0.0",
     "get-pkg-repo": "^1.3.0",
-    "gh-pages": "^0.11.0",
+    "gh-pages": "^1.0.0",
     "glob": "^7.0.0",
     "lerna": "^2.0.0-rc.5",
     "mdast-util-heading-range": "^2.0.1",


### PR DESCRIPTION
Update the gh-pages dependency to a stable range and gets rid of
deprecation warnings during npm dependency installation.

:warning: seems like I can not test this locally because the `docs` script fails to run.