### PR TITLE
bug(minification): add failing test for incorrectly merging border st…

### DIFF
--- a/packages/cssnano/src/__tests__/postcss-merge-longhand.js
+++ b/packages/cssnano/src/__tests__/postcss-merge-longhand.js
@@ -100,6 +100,13 @@ test(
 );
 
 test(
+    'should keep shorthand styles above longhand when merging',
+    processCss,
+    'h1{border-width:1px;border-top-width:0;border-left-width:0;border-style:solid;border-color:#000;}',
+    'h1{border:1px solid #000;border-top-width:0;border-left-width:0;}',
+);
+
+test(
     'should convert 4 values to 1',
     processCss,
     'h1{margin:10px 10px 10px 10px}',


### PR DESCRIPTION
…yles

Added a failing test for an issue I'm seeing that is producing incorrect CSS when merging border styles.

Given input CSS:

```css
.some-cool-style {
    border-width: 1px;
    border-top-width: 0;
    border-left-width: 0;
    border-style: solid;
    border-color: #000;
}
```

The minifier outputs:

```css
  border-top-width: 0;
  border-left-width: 0;
  border: 1px solid #000;
```

Which the browser applies the shorthand property and ignores the longhand styles. If the minifier instead outputs:

```css
  border: 1px solid #000;
  border-top-width: 0;
  border-left-width: 0;
```

The browser reads the styles correctly.