### PR TITLE
chore: npm scripts for release and switch to version mode

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
-  "lerna": "2.5.1",
+  "lerna": "2.11.0",
+  "version": "4.0.0",
   "npmClient": "yarn",
   "commands": {
     "publish": {
@@ -10,6 +11,5 @@
   },
   "packages": [
     "packages/*"
-  ],
-  "version": "independent"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test-only": "cross-env BABEL_ENV=test ava",
     "test-only:coverage": "nyc --reporter=lcov --reporter=text npm run test-only",
     "test": "npm run test-only",
-    "deploy": "gh-pages -d site/dist"
+    "deploy": "gh-pages -d site/dist",
+    "publish": "lerna publish"
   },
   "engines": {
     "node": ">=6.9.0"


### PR DESCRIPTION
It is hard to maintenance independent mode,also a lot of monoreps also use version field, better switch on this mode