### PR TITLE
Remove v4 notice on homepage

### DIFF
--- a/site/src/layouts/Homepage/index.js
+++ b/site/src/layouts/Homepage/index.js
@@ -53,9 +53,6 @@ const Homepage = (props) => {
             </Button>
         </Hero>
         <CoverPage { ...props }>
-            <p><strong>This documentation is for the upcoming version 4 release,
-            which can be installed with <code>npm install cssnano@next</code>.
-            Please test it out and report any bugs that you may find!</strong></p>
             <h2>What it does</h2>
             <p>cssnano takes your nicely formatted CSS and runs it through
             many focused optimisations, to ensure that the final result is


### PR DESCRIPTION
The website has the following notice on the homepage which no longer applies since v4 is released: 

>This documentation is for the upcoming version 4 release, which can be installed with npm install cssnano@next. Please test it out and report any bugs that you may find!