### PR TITLE
fix(postcss-merge-longhand): Should not merge if there is a shorthand prop between them

### DIFF
--- a/packages/postcss-merge-longhand/src/__tests__/borders.js
+++ b/packages/postcss-merge-longhand/src/__tests__/borders.js
@@ -378,3 +378,15 @@ test(
     passthroughCSS,
     'h1{border-top-color: rgba(85, 85, 85, 0.95);border-bottom: none}',
 );
+
+test(
+    'Should not merge if there is a shorthand property between them (#557) (1)',
+    passthroughCSS,
+    'h1{border:1px solid #d3d6db;border:1px solid var(--gray-lighter);border-left-width:0;}',
+);
+
+test(
+    'Should not merge if there is a shorthand property between them (#557) (2)',
+    passthroughCSS,
+    'h1{border-left-style:solid;border-left-color:#d3d6db;border:1px solid var(--gray-lighter);border-left-width:0;}',
+);

--- a/packages/postcss-merge-longhand/src/lib/decl/borders.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/borders.js
@@ -425,6 +425,7 @@ function merge (rule) {
         const lesser = decls.filter(node =>
             !detect(lastNode) &&
             !detect(node) &&
+            !isCustomProp(lastNode)  &&
             node !== lastNode &&
             node.important === lastNode.important &&
             getLevel(node.prop) > getLevel(lastNode.prop) &&

--- a/packages/postcss-merge-longhand/src/lib/mergeRules.js
+++ b/packages/postcss-merge-longhand/src/lib/mergeRules.js
@@ -2,13 +2,30 @@ import hasAllProps from './hasAllProps';
 import getDecls from './getDecls';
 import getRules from './getRules';
 
+function isConflictingProp (propA, propB) {
+    if (!propB.prop || propB.important !== propA.important) {
+        return;
+    }
+    const parts = propA.prop.split('-');
+    return parts.some(() => {
+        parts.pop();
+        return parts.join('-') === propB.prop;
+    });
+}
+function hasConflicts (match, nodes) {
+    const firstNode = Math.min.apply(null, match.map(n => nodes.indexOf(n)));
+    const lastNode = Math.max.apply(null, match.map(n => nodes.indexOf(n)));
+    const between = nodes.slice(firstNode + 1, lastNode);
+    return match.some(a => between.some(b => isConflictingProp(a, b)));
+}
+
 export default function mergeRules (rule, properties, callback) {
     let decls = getDecls(rule, properties);
     while (decls.length) {
         const last = decls[decls.length - 1];
         const props = decls.filter(node => node.important === last.important);
         const rules = getRules(props, properties);
-        if (hasAllProps(rules, ...properties)) {
+        if (hasAllProps(rules, ...properties) && !hasConflicts(rules, rule.nodes)) {
             if (callback(rules, last, props)) {
                 decls = decls.filter(node => !~rules.indexOf(node));
             }


### PR DESCRIPTION
Fixes #557