### PR TITLE
fix(postcss-merge-longhand): Should not drop border-width with custom property from border shorthand

### DIFF
--- a/packages/postcss-merge-longhand/src/__tests__/borders.js
+++ b/packages/postcss-merge-longhand/src/__tests__/borders.js
@@ -396,3 +396,9 @@ test(
     passthroughCSS,
     'h1{border:2px solid transparent;border-top-color:currentColor;}',
 );
+
+test(
+    'should not drop border-width with custom property from border shorthand (#561)',
+    passthroughCSS,
+    'h1{border:var(--border-width) solid grey}',
+);

--- a/packages/postcss-merge-longhand/src/lib/decl/borders.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/borders.js
@@ -396,12 +396,12 @@ function merge (rule) {
 
     // clean-up values
     rule.walkDecls(/^border($|-(top|right|bottom|left)$)/, decl => {
-        const value = [...parseWsc(decl.value), ''].reduceRight((prev, cur, i, arr) => {
+        const value = !isCustomProp(decl) ? [...parseWsc(decl.value), ''].reduceRight((prev, cur, i, arr) => {
             if (cur === defaults[i] && arr[i-1] !== cur) {
                 return prev;
             }
             return cur + ' ' + prev;
-        }).trim() || defaults[0];
+        }).trim() || defaults[0] : decl.value;
         decl.value = minifyTrbl(value || defaults[0]);
     });
 


### PR DESCRIPTION
Fixes #561 