### PR TITLE
Meta improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "all-contributors": "all-contributors add",
     "lint": "eslint --ignore-path .gitignore packages/**/src util",
     "fixlint": "eslint --fix --ignore-path .gitignore packages/**/src util",
-    "postinstall": "lerna bootstrap --npm-client=\"yarn\"",
+    "postinstall": "lerna bootstrap",
     "build:packages": "babel-node ./util/buildPackages.js",
     "build:aliases": "babel-node ./util/buildAliases.js",
     "build:metadata": "babel-node ./util/buildMetadata.js",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:aliases": "babel-node ./util/buildAliases.js",
     "build:metadata": "babel-node ./util/buildMetadata.js",
     "build:site": "remark site/content/**/*.md -o && npm run build:metadata && babel-node ./util/buildSiteMarkdown.js && cd site && npm run build",
+    "build:integration": "babel-node ./util/buildFrameworks.js",
     "pretest": "npm run lint",
     "test-only": "cross-env BABEL_ENV=test ava",
     "test-only:coverage": "nyc --reporter=lcov --reporter=text npm run test-only",

--- a/util/testHelpers.js
+++ b/util/testHelpers.js
@@ -15,7 +15,7 @@ export function processCSSFactory (plugin) {
     if (Array.isArray(plugin)) {
         processor = (fixture, options) => postcss(plugin).process(
             fixture,
-            Object.assign({}, { from: undefined }, options)
+            Object.assign({}, {from: undefined}, options)
         );
 
         processCSS = (t, fixture, expected, options) => {
@@ -32,7 +32,7 @@ export function processCSSFactory (plugin) {
         processor = (fixture, options) => {
             return postcss(plugin(options)).process(
                 fixture,
-                Object.assign({}, { from: undefined }, options),
+                Object.assign({}, {from: undefined}, options),
             );
         };
 
@@ -63,7 +63,7 @@ export function integrationTests (t, preset, integrations) {
     return Promise.all(Object.keys(frameworks).map(framework => {
         const css = frameworks[framework];
         return postcss([cssnano({preset}), formatter])
-            .process(css, { from: undefined })
+            .process(css, {from: undefined})
             .then(result => {
                 t.is(
                     result.css,

--- a/util/testHelpers.js
+++ b/util/testHelpers.js
@@ -13,7 +13,10 @@ export function processCSSFactory (plugin) {
     let processor, processCSS, passthroughCSS;
 
     if (Array.isArray(plugin)) {
-        processor = (fixture, options) => postcss(plugin).process(fixture, options);
+        processor = (fixture, options) => postcss(plugin).process(
+            fixture,
+            Object.assign({}, { from: undefined }, options)
+        );
 
         processCSS = (t, fixture, expected, options) => {
             return processor(fixture, options).then(result => {
@@ -27,7 +30,10 @@ export function processCSSFactory (plugin) {
         };
     } else {
         processor = (fixture, options) => {
-            return postcss(plugin(options)).process(fixture, options);
+            return postcss(plugin(options)).process(
+                fixture,
+                Object.assign({}, { from: undefined }, options),
+            );
         };
 
         processCSS = (t, fixture, expected, options) => {
@@ -56,8 +62,13 @@ export function loadPreset (preset) {
 export function integrationTests (t, preset, integrations) {
     return Promise.all(Object.keys(frameworks).map(framework => {
         const css = frameworks[framework];
-        return postcss([cssnano({preset}), formatter]).process(css).then(result => {
-            t.is(result.css, fs.readFileSync(`${integrations}/${framework}.css`, 'utf8'));
-        });
+        return postcss([cssnano({preset}), formatter])
+            .process(css, { from: undefined })
+            .then(result => {
+                t.is(
+                    result.css,
+                    fs.readFileSync(`${integrations}/${framework}.css`, 'utf8')
+                );
+            });
     }));
 }


### PR DESCRIPTION
While working on https://github.com/cssnano/cssnano/pull/580 I was struggling with the setup of this project. Made some small changes to hopefully make contributing a bit easier.

- running tests cause a lot of warnings in the console littering the test output, I first thought I did something wrong, setting `from` in the utils prevents this for most tests.
- got huge diffs from the frameworks, quickly found the `buildFrameworks` script but couldn't get it to run with `node`. After troubleshooting I found out `babel-node` should be used, putting it into a npm task/script clarifies this.
- I don't have `yarn` installed so wanting to install with `npm` I changed the client option in `lerna.json` however it still used `yarn`, removed this double option definition for easier switching.