### PR TITLE
fix(postcss-merge-longhand): Should not throw error when a border property value is undefined

### DIFF
--- a/packages/postcss-merge-longhand/src/__tests__/borders.js
+++ b/packages/postcss-merge-longhand/src/__tests__/borders.js
@@ -533,3 +533,10 @@ test(
     passthroughCSS,
     'h1{border-color:red green blue magenta;border-top-color:var(--color-var)}',
 );
+
+test(
+    'Should not throw error when a border property value is undefined (#639)',
+    processCSS,
+    'h1{border:2px solid #fff;border-color:inherit}',
+    'h1{border:2px solid;border-color:inherit}',
+);

--- a/packages/postcss-merge-longhand/src/lib/decl/borders.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/borders.js
@@ -50,7 +50,7 @@ function getLevel (prop) {
     }
 }
 
-const isValueCustomProp = value => !!~value.search(/var\s*\(\s*--/i);
+const isValueCustomProp = value => value && !!~value.search(/var\s*\(\s*--/i);
 
 function canMergeValues (values) {
     return !values.some(isValueCustomProp) || values.every(isValueCustomProp);


### PR DESCRIPTION
Fixes #639.
