### PR TITLE
Preserve case of css custom variables. Fixes #648

### DIFF
--- a/packages/postcss-merge-longhand/src/__tests__/borders.js
+++ b/packages/postcss-merge-longhand/src/__tests__/borders.js
@@ -540,3 +540,16 @@ test(
     'h1{border:2px solid #fff;border-color:inherit}',
     'h1{border:2px solid;border-color:inherit}',
 );
+
+test(
+    'Should preserve case of css custom properties #648',
+    passthroughCSS,
+    'h1{border:1px solid rgba(var(--fooBar));}',
+);
+
+test(
+    'should overwrite some border-width props and save fallbacks and preserve case #648 2',
+    processCSS,
+    'h1{border-top-width:10px;border-right-width:var(--fooBar);border-right-width:15px;border-bottom-width:var(--fooBar);border-bottom-width:20px;border-left-width:25px;border-top-width:var(--fooBar);border-left-width:var(--fooBar)}',
+    'h1{border-width:10px 15px 20px 25px;border-top-width:var(--fooBar);border-left-width:var(--fooBar)}'
+);

--- a/packages/postcss-merge-longhand/src/__tests__/boxBase.js
+++ b/packages/postcss-merge-longhand/src/__tests__/boxBase.js
@@ -118,6 +118,10 @@ addTests({
     fixture: 'h1{box-bottom:var(--variable)}',
     expected: 'h1{box-bottom:var(--variable)}',
 }, {
+    message: 'should preserve case of custom properties',
+    fixture: 'h1{box-top:10px;box-right:var(--fooBar);box-right:15px;box-bottom:var(--fooBar);box-bottom:20px;box-left:25px;box-top:var(--fooBar);box-left:var(--fooBar)}',
+    expected: 'h1{box:10px 15px 20px 25px;box-top:var(--fooBar);box-left:var(--fooBar)}',
+}, {
     message: 'should not merge incomplete box props where one has an unset property',
     fixture: 'h1{box-bottom:10px;box-top:unset;box-left:20px}',
     expected: 'h1{box-bottom:10px;box-top:unset;box-left:20px}',

--- a/packages/postcss-merge-longhand/src/__tests__/columns.js
+++ b/packages/postcss-merge-longhand/src/__tests__/columns.js
@@ -82,3 +82,10 @@ test(
     passthroughCSS,
     'h1{columns:var(--variable)}',
 );
+
+test(
+    'should preserve case of custom properties',
+    passthroughCSS,
+    'h1{columns:var(--fooBar)}',
+);
+

--- a/packages/postcss-merge-longhand/src/lib/parseWsc.js
+++ b/packages/postcss-merge-longhand/src/lib/parseWsc.js
@@ -3,13 +3,20 @@ import {isWidth, isStyle, isColor} from './validateWsc';
 
 const none = /^\s*(none|medium)(\s+none(\s+(none|currentcolor))?)?\s*$/i;
 
+const varRE = /(^.*var)(.*\(.*--.*\))(.*)/i;
+const varPreserveCase = p => `${p[1].toLowerCase()}${p[2]}${p[3].toLowerCase()}`;
+const toLower = v => {
+    const match = varRE.exec(v);
+    return match ? varPreserveCase(match) : v.toLowerCase();
+};
+
 export default function parseWsc (value) {
     if (none.test(value)) {
         return [ 'medium', 'none', 'currentcolor'];
     }
 
     let width, style, color;
-    
+
     const values = list.space(value);
     if (values.length > 1 && isStyle(values[1]) && values[0].toLowerCase() === 'none') {
         values.unshift();
@@ -20,11 +27,11 @@ export default function parseWsc (value) {
 
     values.forEach(v => {
         if (isStyle(v)) {
-            style = v.toLowerCase();
+            style = toLower(v);
         } else if (isWidth(v)) {
-            width = v.toLowerCase();
+            width = toLower(v);
         } else if (isColor(v)) {
-            color = v.toLowerCase();
+            color = toLower(v);
         } else {
             unknown.push(v);
         }


### PR DESCRIPTION
Fix matches var(--somename) and preserve case of the variable name.

Fixes #648 