### PR TITLE
fix: do not mangle `@page :first` rules (closes #677)

### DIFF
--- a/packages/postcss-minify-params/src/__tests__/index.js
+++ b/packages/postcss-minify-params/src/__tests__/index.js
@@ -156,6 +156,18 @@ test(
 );
 
 test(
+    'should not mangle @page',
+    passthroughCSS,
+    '@page :first { margin: 0; }'
+);
+
+test(
+    'should not mangle @page (uppercase)',
+    passthroughCSS,
+    '@PAGE :first { margin: 0; }'
+);
+
+test(
     'should use the postcss plugin api',
     usePostCSSPlugin,
     plugin()

--- a/packages/postcss-minify-params/src/index.js
+++ b/packages/postcss-minify-params/src/index.js
@@ -34,7 +34,13 @@ function transform (legacy, rule) {
     // at-rule. For example:
     //
     // @value vertical, center from "./foo.css";
-    if (!rule.params || rule.name.toLowerCase() === 'value') {
+    //
+    // We should also not re-arrange pseudo-classes for @page at-rule.
+    // For example:
+    //
+    // @page :first { margin: 0; }
+    const ruleName = rule.name.toLocaleLowerCase();
+    if (!rule.params || ruleName === 'value' || ruleName === 'page') {
         return;
     }
 


### PR DESCRIPTION
The `:first` pseudo-class is meant to be used with the `@page` at-rule to apply some style to the first page of a printed document (https://developer.mozilla.org/en-US/docs/Web/CSS/:first).

The `minifyParams` optimization causes it to be mangled :
it's transformed from
`@page :first { margin: 0 }`
to
`@page ,first { margin: 0 }`.

This commit fixes this behavior and closes cssnano/cssnano#677