### PR TITLE
fix: change mask-repeat initial value on repeat

### DIFF
--- a/packages/postcss-reduce-initial/data/toInitial.json
+++ b/packages/postcss-reduce-initial/data/toInitial.json
@@ -18,7 +18,7 @@
   "mask-clip": "border-box",
   "mask-mode": "match-source",
   "mask-origin": "border-box",
-  "mask-repeat": "no-repeat",
+  "mask-repeat": "repeat",
   "mask-type": "luminance",
   "ruby-align": "space-around",
   "ruby-merge": "separate",


### PR DESCRIPTION
Hello. I think `postcss-reduce-initial` should convert `mask-repeat: repeat;` into `initial` according to [spec](https://drafts.fxtf.org/css-masking-1/#the-mask-repeat).