### PR TITLE
fix(postcss-merge-longhand): Fix crash on empty declarations.

### DIFF
--- a/packages/postcss-merge-longhand/src/__tests__/borders.js
+++ b/packages/postcss-merge-longhand/src/__tests__/borders.js
@@ -830,6 +830,12 @@ test(
   'h1{border:UNSET}'
 );
 
+test(
+  'should not explode border with revert properties (uppercase)',
+  passthroughCSS,
+  'h1{BORDER:revert}'
+);
+
 trbl.forEach((direction) => {
   test(
     `should not explode border-${direction} with custom properties`,
@@ -1135,3 +1141,5 @@ test(
   'h1{border: 2px solid red;border-bottom-width:0;border-right-width:0;border-top-width:0;}',
   'h1{border:solid red;border-width:0 0 0 2px;}'
 );
+
+test('should handle empty border', processCSS, 'h1{border:;}', 'h1{border:;}');

--- a/packages/postcss-merge-longhand/src/__tests__/boxBase.js
+++ b/packages/postcss-merge-longhand/src/__tests__/boxBase.js
@@ -313,5 +313,10 @@ addTests(
     fixture:
       'h1{box-bottom:INHERIT;box-top:INHERIT;box-left:INHERIT;box-right:INHERIT}',
     expected: 'h1{box:INHERIT}',
+  },
+  {
+    message: 'should handle empty box properties',
+    fixture: 'h1{box:;}',
+    expected: (prop) => `h1{${prop}:;}`,
   }
 );

--- a/packages/postcss-merge-longhand/src/__tests__/columns.js
+++ b/packages/postcss-merge-longhand/src/__tests__/columns.js
@@ -215,3 +215,10 @@ test(
   'h1{COLUMN-WIDTH:12em;COLUMN-COUNT:auto;COLUMNS:12em}',
   'h1{columns:12em}'
 );
+
+test(
+  'should handle empty columns',
+  processCSS,
+  'h1{columns:;}',
+  'h1{columns:;}'
+);

--- a/packages/postcss-merge-longhand/src/lib/canExplode.js
+++ b/packages/postcss-merge-longhand/src/lib/canExplode.js
@@ -1,13 +1,17 @@
 import isCustomProp from './isCustomProp';
 
-const hasInherit = (node) => node.value.toLowerCase().includes('inherit');
-const hasInitial = (node) => node.value.toLowerCase().includes('initial');
-const hasUnset = (node) => node.value.toLowerCase().includes('unset');
+const hasGlobalKeyword = (prop) =>
+  prop &&
+  prop.value &&
+  ['inherit', 'initial', 'unset', 'revert'].includes(prop.value.toLowerCase());
 
 export default (prop, includeCustomProps = true) => {
-  if (includeCustomProps && isCustomProp(prop)) {
+  if (
+    !prop.value ||
+    (includeCustomProps && isCustomProp(prop)) ||
+    hasGlobalKeyword(prop)
+  ) {
     return false;
   }
-
-  return !hasInherit(prop) && !hasInitial(prop) && !hasUnset(prop);
+  return true;
 };


### PR DESCRIPTION
Closes https://github.com/cssnano/cssnano/issues/769 & https://github.com/cssnano/cssnano/issues/714. Also adds support for the global `revert` keyword.