### PR TITLE
Make removing the last semicolon in postcss-normalize-whitespace configurable

### DIFF
--- a/packages/postcss-normalize-whitespace/README.md
+++ b/packages/postcss-normalize-whitespace/README.md
@@ -15,18 +15,28 @@ npm install postcss-normalize-whitespace --save
 ### Input
 
 ```css
-h1{
-    width: calc(10px - ( 100px / var(--test) )) 
+h1 {
+    width: calc(10px - ( 100px / var(--test) ));
+    height: 20px;
 }
 ```
 
 ### Output
 
 ```css
-h1{
-    width: calc(10px - 100px / var(--test))
-}
-``` 
+h1{width:calc(10px - 100px / var(--test));height:20px}
+```
+
+## API
+
+### Options
+
+#### removeLastSemicolon
+
+type: `boolean`<br/>
+default: `true`
+
+Removes semicolon from the last declaration in the rule.
 
 ## Usage
 

--- a/packages/postcss-normalize-whitespace/src/__tests__/index.js
+++ b/packages/postcss-normalize-whitespace/src/__tests__/index.js
@@ -50,6 +50,18 @@ test(
 );
 
 test(
+  'should remove last semicolon',
+  processCSS('h1{width:10px;height:10px;}', 'h1{width:10px;height:10px}')
+);
+
+test(
+  'should keep last semicolon, with a flag',
+  processCSS('h1{width:10px;height:10px;}', 'h1{width:10px;height:10px;}', {
+    removeLastSemicolon: false,
+  })
+);
+
+test(
   'should trim whitespace from nested functions (preset)',
   withDefaultPreset(
     'h1{width:calc(10px - ( 100px / var(--test) ))}',

--- a/packages/postcss-normalize-whitespace/src/index.js
+++ b/packages/postcss-normalize-whitespace/src/index.js
@@ -28,7 +28,14 @@ function reduceWhitespaces(node) {
   }
 }
 
-export default plugin('postcss-normalize-whitespace', () => {
+export default plugin('postcss-normalize-whitespace', (opts) => {
+  const { removeLastSemicolon } = Object.assign(
+    {},
+    {
+      removeLastSemicolon: true,
+    },
+    opts
+  );
   return (css) => {
     const cache = {};
 
@@ -74,7 +81,9 @@ export default plugin('postcss-normalize-whitespace', () => {
         node.raws.semicolon = false;
       } else if (type === rule || type === atrule) {
         node.raws.between = node.raws.after = '';
-        node.raws.semicolon = false;
+        if (removeLastSemicolon) {
+          node.raws.semicolon = false;
+        }
       }
     });
 


### PR DESCRIPTION
I hope that it's ok to make this configurable, it would be really useful to me because then I could use [RTLCSS](https://rtlcss.com) after minification, which doesn't handle lack of semicolons well. I know that this isn't a great reason to add this option, but pretty please? 🙏 