### PR TITLE
fix(unique-selector): removed sorting and involving selector comments

### DIFF
--- a/packages/cssnano/src/__tests__/fixtures.js
+++ b/packages/cssnano/src/__tests__/fixtures.js
@@ -11,51 +11,6 @@ test(
 );
 
 test(
-  'should handle css mixins',
-  processCss(
-    `paper-card {
-        --paper-card-content: {
-            padding-top: 0;
-        };
-        margin: 0 auto 16px;
-        width: 768px;
-        max-width: calc(100% - 32px);
-    }`,
-    `paper-card{--paper-card-content:{padding-top:0};margin:0 auto 16px;width:768px;max-width:calc(100% - 32px)}`
-  )
-  // Switch back once css-declaration-sorter has been fixed
-  // `paper-card{margin:0 auto 16px;max-width:calc(100% - 32px);width:768px;--paper-card-content:{padding-top:0};}`
-);
-
-test(
-  'should handle css mixins (2)',
-  processCss(
-    `paper-card {
-        --paper-card-header: {
-            height: 128px;
-            padding: 0 48px;
-            background: var(--primary-color);
-
-            @apply(--layout-vertical);
-            @apply(--layout-end-justified);
-        };
-        --paper-card-header-color: #FFF;
-        --paper-card-content: {
-            padding: 64px;
-        };
-        --paper-card-actions: {
-            @apply(--layout-horizontal);
-            @apply(--layout-end-justified);
-        };
-        width: 384px;
-    }`,
-    `paper-card{--paper-card-header:{height:128px;padding:0 48px;background:var(--primary-color);@apply(--layout-vertical);@apply(--layout-end-justified)};--paper-card-header-color:#fff;--paper-card-content:{padding:64px};--paper-card-actions:{@apply(--layout-horizontal);@apply(--layout-end-justified)};width:384px}`
-  )
-  // Switch back once css-declaration-sorter has been fixed
-  // `paper-card{--paper-card-header-color:#fff;width:384px;--paper-card-header:{background:var(--primary-color);height:128px;padding:0 48px;@apply(--layout-vertical);@apply(--layout-end-justified)};--paper-card-content:{padding:64px};--paper-card-actions:{@apply(--layout-horizontal);@apply(--layout-end-justified)};}`
-);
-
-test(
   'should dedupe charset definitions',
   processCss(
     `@charset "utf-8";

--- a/packages/postcss-unique-selectors/package.json
+++ b/packages/postcss-unique-selectors/package.json
@@ -36,8 +36,5 @@
   },
   "engines": {
     "node": ">=6.9.0"
-  },
-  "devDependencies": {
-
   }
 }

--- a/packages/postcss-unique-selectors/package.json
+++ b/packages/postcss-unique-selectors/package.json
@@ -35,5 +35,8 @@
   },
   "engines": {
     "node": ">=6.9.0"
+  },
+  "devDependencies": {
+    "postcss-selector-parser": "^6.0.2"
   }
 }

--- a/packages/postcss-unique-selectors/package.json
+++ b/packages/postcss-unique-selectors/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "alphanum-sort": "^1.0.2",
     "postcss": "^7.0.16",
+    "postcss-selector-parser": "^6.0.2",
     "uniqs": "^2.0.0"
   },
   "bugs": {
@@ -37,6 +38,6 @@
     "node": ">=6.9.0"
   },
   "devDependencies": {
-    "postcss-selector-parser": "^6.0.2"
+
   }
 }

--- a/packages/postcss-unique-selectors/src/__tests__/index.js
+++ b/packages/postcss-unique-selectors/src/__tests__/index.js
@@ -20,7 +20,7 @@ test(
   'should leave out comments in the selector',
   processCSS(
     '.newbackbtn,/*.searchall,*/.calNav{padding:5px;}',
-    '.calNav,.newbackbtn{padding:5px;}'
+    '.calNav,.newbackbtn,/*.searchall,*/{padding:5px;}'
   )
 );
 

--- a/packages/postcss-unique-selectors/src/__tests__/index.js
+++ b/packages/postcss-unique-selectors/src/__tests__/index.js
@@ -16,4 +16,12 @@ test(
   processCSS('h1,h10,H2,h7{color:red}', 'h1,H2,h7,h10{color:red}')
 );
 
+test(
+  'should leave out comments in the selector',
+  processCSS(
+    '.newbackbtn,/*.searchall,*/.calNav{padding:5px;}',
+    '.calNav,.newbackbtn{padding:5px;}'
+  )
+);
+
 test('should use the postcss plugin api', usePostCSSPlugin(plugin()));

--- a/packages/postcss-unique-selectors/src/index.js
+++ b/packages/postcss-unique-selectors/src/index.js
@@ -16,8 +16,15 @@ export default plugin('postcss-unique-selectors', () => {
     css.walkRules((nodes) => {
       let comments = [];
       nodes.selector = parseSelectors(nodes.selector, (selNode) => {
-        selNode.walkComments((sel) => comments.push(sel.value));
-        selNode.walk((sel) => (sel.type === 'comment' ? sel.remove() : sel));
+        selNode.walk((sel) => {
+          if (sel.type === 'comment') {
+            comments.push(sel.value);
+            sel.remove();
+            return;
+          } else {
+            return sel;
+          }
+        });
       });
       unique(nodes);
       nodes.selectors = nodes.selectors.concat(comments);

--- a/packages/postcss-unique-selectors/src/index.js
+++ b/packages/postcss-unique-selectors/src/index.js
@@ -1,11 +1,22 @@
 import { plugin } from 'postcss';
 import sort from 'alphanum-sort';
 import uniqs from 'uniqs';
+import selectorParser from 'postcss-selector-parser';
+
+function parseSelectors(selectors, callback) {
+  return selectorParser(callback).processSync(selectors);
+}
 
 function unique(rule) {
   rule.selector = sort(uniqs(rule.selectors), { insensitive: true }).join();
 }
 
 export default plugin('postcss-unique-selectors', () => {
-  return (css) => css.walkRules(unique);
+  return (css) =>
+    css.walkRules((nodes) => {
+      nodes.selector = parseSelectors(nodes.selector, (selNode) => {
+        selNode.walk((sel) => (sel.type === 'comment' ? sel.remove() : sel));
+      });
+      unique(nodes);
+    });
 });

--- a/packages/postcss-unique-selectors/src/index.js
+++ b/packages/postcss-unique-selectors/src/index.js
@@ -14,9 +14,12 @@ function unique(rule) {
 export default plugin('postcss-unique-selectors', () => {
   return (css) =>
     css.walkRules((nodes) => {
+      let comments = [];
       nodes.selector = parseSelectors(nodes.selector, (selNode) => {
+        selNode.walkComments((sel) => comments.push(sel.value));
         selNode.walk((sel) => (sel.type === 'comment' ? sel.remove() : sel));
       });
       unique(nodes);
+      nodes.selectors = nodes.selectors.concat(comments);
     });
 });

--- a/packages/postcss-unique-selectors/yarn.lock
+++ b/packages/postcss-unique-selectors/yarn.lock
@@ -35,6 +35,11 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+cssesc@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -44,6 +49,20 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+indexes-of@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
+  integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
+
+postcss-selector-parser@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
+  integrity sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==
+  dependencies:
+    cssesc "^3.0.0"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
 
 postcss@^7.0.16:
   version "7.0.21"
@@ -72,6 +91,11 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+uniq@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
+  integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=
 
 uniqs@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
fix #777 
- Added `postcss-selector-parser` to filter out the non-comment node types to go through the sorting function.
- added tests to support it 

Update
---

Waiting for parser's mixin support  https://github.com/postcss/postcss-selector-parser/issues/217