### PR TITLE
chore: added plugin options validation for postcss-covert-value

### DIFF
--- a/packages/postcss-convert-values/package.json
+++ b/packages/postcss-convert-values/package.json
@@ -28,7 +28,8 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "postcss": "^7.0.16",
-    "postcss-value-parser": "^3.3.1"
+    "postcss-value-parser": "^3.3.1",
+    "schema-utils": "^2.6.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-convert-values/src/__tests__/options.test.js
+++ b/packages/postcss-convert-values/src/__tests__/options.test.js
@@ -1,0 +1,90 @@
+/* eslint-disable no-console */
+import postcss from 'postcss';
+import plugin from '..';
+
+function process(input, options = {}) {
+  try {
+    let result = postcss([plugin(options)]).process(input, {
+      from: undefined,
+    });
+    return result;
+  } catch (validationError) {
+    return validationError;
+  }
+}
+
+const toMatchlongFormattedString = (received, toMatchString) => {
+  let _received = received
+    .split('\n')
+    .map((str) => str.trimStart().trimEnd())
+    .join('\n');
+  let _toMatchString = toMatchString
+    .split('\n')
+    .map((str) => str.trimStart().trimEnd())
+    .join('\n');
+
+  if (_received === _toMatchString) {
+    return {
+      message: () => `expected ${received} matched with ${toMatchString}`,
+      pass: true,
+    };
+  }
+  return {
+    message: () =>
+      `expected ${received} doesnt match ${toMatchString} after formatting`,
+    pass: false,
+  };
+};
+
+expect.extend({ toMatchlongFormattedString });
+
+test('should output error of having wrong property', () => {
+  const result = process(
+    'h1{transition-duration:.005s;transform: rotate(45deg);}',
+    {
+      wrongprecision: 2,
+      angle: false,
+    }
+  );
+  expect(Array.isArray(result.errors)).toBe(true);
+  expect(result.message)
+    .toMatchlongFormattedString(`Invalid configuration object. postcss-convert-values has been initialised using a configuration object that does not match the API schema.
+     - configuration has an unknown property 'wrongprecision'. These properties are valid:
+       object { length?, time?, angle?, precision? }`);
+});
+
+test('should work with correct options', () => {
+  const result = process(
+    'h1{transition-duration:.005s;transform: rotate(45deg);}',
+    {
+      precision: 2,
+      angle: false,
+    }
+  );
+  expect(result.errors).toBe(undefined);
+});
+
+test('should output error of having wrong value ', () => {
+  const result = process(
+    'h1{transition-duration:.005s;transform: rotate(45deg);}',
+    {
+      precision: '2',
+    }
+  );
+  expect(Array.isArray(result.errors)).toBe(true);
+  expect(result.message)
+    .toMatchlongFormattedString(`Invalid configuration object. postcss-convert-values has been initialised using a configuration object that does not match the API schema.
+     - configuration.precision should be one of these:
+       boolean | number
+       -> Specify any numeric value here to round px values to that many decimal places; for example, using {precision: 2} will round 6.66667px to 6.67px, and {precision: 0} will round it to 7px. Passing false (the default) will leave these values as is.
+       Details:
+        * configuration.precision should be a boolean.
+        * configuration.precision should be a number.`);
+});
+
+test('should work when no options are passed', () => {
+  const result = process(
+    'h1{transition-duration:.005s;transform: rotate(45deg);}'
+  );
+  expect(result.errors).toBe(undefined);
+});

--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -1,6 +1,8 @@
 import postcss from 'postcss';
 import valueParser, { unit, walk } from 'postcss-value-parser';
+import validateOptions from 'schema-utils';
 import convert from './lib/convert';
+import schema from './options.json';
 
 const LENGTH_UNITS = [
   'em',
@@ -117,5 +119,6 @@ function transform(opts, decl) {
 const plugin = 'postcss-convert-values';
 
 export default postcss.plugin(plugin, (opts = { precision: false }) => {
+  validateOptions(schema, opts, { name: plugin });
   return (css) => css.walkDecls(transform.bind(null, opts));
 });

--- a/packages/postcss-convert-values/src/options.json
+++ b/packages/postcss-convert-values/src/options.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "length": {
+      "description": "Pass false to disable conversion from px to other absolute length units, such as pc & pt & vice versa.",
+      "type": "boolean"
+    },
+    "time": {
+      "description": "Pass false to disable conversion from ms to s & vice versa.",
+      "type": "boolean"
+    },
+    "angle": {
+      "description": "Pass false to disable conversion from deg to turn & vice versa.",
+      "type": "boolean"
+    },
+    "precision": {
+      "description": "Specify any numeric value here to round px values to that many decimal places; for example, using {precision: 2} will round 6.66667px to 6.67px, and {precision: 0} will round it to 7px. Passing false (the default) will leave these values as is.",
+      "anyOf": [{ "type": "boolean" }, { "type": "number" }]
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/postcss-convert-values/yarn.lock
+++ b/packages/postcss-convert-values/yarn.lock
@@ -2,6 +2,21 @@
 # yarn lockfile v1
 
 
+ajv-keywords@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
+  integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
+
+ajv@^6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
+  integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -35,10 +50,25 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 postcss-value-parser@^3.3.1:
   version "3.3.1"
@@ -53,6 +83,19 @@ postcss@^7.0.16:
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+schema-utils@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.1.tgz#eb78f0b945c7bcfa2082b3565e8db3548011dc4f"
+  integrity sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==
+  dependencies:
+    ajv "^6.10.2"
+    ajv-keywords "^3.4.1"
 
 source-map@^0.6.1:
   version "0.6.1"
@@ -72,3 +115,10 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"


### PR DESCRIPTION
Added `schema-utils` as dep for `postcss-convert-values` to validate the options.

This PR is more like a PoC, so if its good to have, then I will go on with adding it to the rest of the packages.

> Added a custom jest matcher in order to match the error message in a formatted way.
