### PR TITLE
chore(ordered-values): added support for columns and column-rule

### DIFF
--- a/packages/postcss-ordered-values/src/__tests__/index.js
+++ b/packages/postcss-ordered-values/src/__tests__/index.js
@@ -585,8 +585,8 @@ test(
 test(
   'should order columns only if unit is mentioned',
   processCSS(
-    'h1 {columns: 2 auto;columns: auto 12em;columns: auto auto;columns: auto 12em auto 13em;}',
-    'h1 {columns: 2 auto;columns: 12em auto;columns: auto auto;columns: 12em 13em auto auto;}'
+    'h1 {columns: 2 auto;columns: auto 12em;columns: auto auto;}',
+    'h1 {columns: 2 auto;columns: 12em auto;columns: auto auto;}'
   )
 );
 

--- a/packages/postcss-ordered-values/src/__tests__/index.js
+++ b/packages/postcss-ordered-values/src/__tests__/index.js
@@ -573,3 +573,11 @@ test(
 );
 
 test('should use the postcss plugin api', usePostCSSPlugin(plugin()));
+
+test(
+  'should order border-block',
+  processCSS(
+    'border-inline: dashed blue 5px; border-inline-end: red solid .5em; border-block-end: dashed blue 5px; border-block: 5px solid red;border-block-start: rgba(0, 30, 105, 0.8) solid 1px;',
+    'border-inline: 5px dashed blue; border-inline-end: .5em solid red; border-block-end: 5px dashed blue; border-block: 5px solid red;border-block-start: 1px solid rgba(0, 30, 105, 0.8);'
+  )
+);

--- a/packages/postcss-ordered-values/src/__tests__/index.js
+++ b/packages/postcss-ordered-values/src/__tests__/index.js
@@ -581,3 +581,19 @@ test(
     'border-inline: 5px dashed blue; border-inline-end: .5em solid red; border-block-end: 5px dashed blue; border-block: 5px solid red;border-block-start: 1px solid rgba(0, 30, 105, 0.8);'
   )
 );
+
+test(
+  'should order columns only if unit is mentioned',
+  processCSS(
+    'h1 {columns: 2 auto;columns: auto 12em;columns: auto auto;columns: auto 12em auto 13em;}',
+    'h1 {columns: 2 auto;columns: 12em auto;columns: auto auto;columns: 12em 13em auto auto;}'
+  )
+);
+
+test(
+  'should order column-rule like border',
+  processCSS(
+    'h1 {column-rule: solid 8px;column-rule: inset 2px #33f;}',
+    'h1 {column-rule: 8px solid;column-rule: 2px inset #33f;}'
+  )
+);

--- a/packages/postcss-ordered-values/src/index.js
+++ b/packages/postcss-ordered-values/src/index.js
@@ -8,17 +8,27 @@ import boxShadow from './rules/boxShadow';
 import flexFlow from './rules/flexFlow';
 import transition from './rules/transition';
 
-const rules = {
-  animation: animation,
+const borderRules = {
   border: border,
+  'border-block': border,
+  'border-inline': border,
+  'border-block-end': border,
+  'border-block-start': border,
+  'border-inline-end': border,
+  'border-inline-start': border,
   'border-top': border,
   'border-right': border,
   'border-bottom': border,
   'border-left': border,
+};
+
+const rules = {
+  animation: animation,
   outline: border,
   'box-shadow': boxShadow,
   'flex-flow': flexFlow,
   transition: transition,
+  ...borderRules,
 };
 
 function isVariableFunctionNode(node) {

--- a/packages/postcss-ordered-values/src/index.js
+++ b/packages/postcss-ordered-values/src/index.js
@@ -7,6 +7,7 @@ import border from './rules/border';
 import boxShadow from './rules/boxShadow';
 import flexFlow from './rules/flexFlow';
 import transition from './rules/transition';
+import columns from './rules/columns';
 
 const borderRules = {
   border: border,
@@ -22,6 +23,11 @@ const borderRules = {
   'border-left': border,
 };
 
+const columnRules = {
+  'column-rule': border,
+  columns,
+};
+
 const rules = {
   animation: animation,
   outline: border,
@@ -29,6 +35,7 @@ const rules = {
   'flex-flow': flexFlow,
   transition: transition,
   ...borderRules,
+  ...columnRules,
 };
 
 function isVariableFunctionNode(node) {

--- a/packages/postcss-ordered-values/src/index.js
+++ b/packages/postcss-ordered-values/src/index.js
@@ -7,7 +7,7 @@ import border from './rules/border';
 import boxShadow from './rules/boxShadow';
 import flexFlow from './rules/flexFlow';
 import transition from './rules/transition';
-import columns from './rules/columns';
+import { columnsRule, column } from './rules/columns';
 
 const borderRules = {
   border: border,
@@ -24,8 +24,8 @@ const borderRules = {
 };
 
 const columnRules = {
-  'column-rule': border,
-  columns,
+  'column-rule': columnsRule,
+  columns: column,
 };
 
 const rules = {

--- a/packages/postcss-ordered-values/src/rules/columns.js
+++ b/packages/postcss-ordered-values/src/rules/columns.js
@@ -1,0 +1,27 @@
+import { unit } from 'postcss-value-parser';
+
+const strValues = ['auto', 'inherit', 'unset', 'initial'];
+
+export default (columns) => {
+  let newValue = { front: '', back: '' };
+  let shouldNormalize = false;
+  columns.walk((node) => {
+    const { type, value } = node;
+    if (type === 'word' && strValues.indexOf(value.toLowerCase())) {
+      const parsedVal = unit(value);
+      if (parsedVal.unit !== '') {
+        // surely its the column's width
+        // it needs to be at the front
+        newValue.front = `${newValue.front} ${value}`;
+        shouldNormalize = true;
+      }
+    } else if (type === 'word') {
+      newValue.back = `${newValue.back} ${value}`;
+    }
+    // console.log({ type, value });
+  });
+  if (shouldNormalize) {
+    return `${newValue.front.trimStart()} ${newValue.back.trimStart()}`;
+  }
+  return columns;
+};

--- a/packages/postcss-ordered-values/src/rules/columns.js
+++ b/packages/postcss-ordered-values/src/rules/columns.js
@@ -1,8 +1,9 @@
 import { unit } from 'postcss-value-parser';
+import border from './border.js';
 
 const strValues = ['auto', 'inherit', 'unset', 'initial'];
 
-export default (columns) => {
+export const column = (columns) => {
   let newValue = { front: '', back: '' };
   let shouldNormalize = false;
   columns.walk((node) => {
@@ -18,10 +19,11 @@ export default (columns) => {
     } else if (type === 'word') {
       newValue.back = `${newValue.back} ${value}`;
     }
-    // console.log({ type, value });
   });
   if (shouldNormalize) {
     return `${newValue.front.trimStart()} ${newValue.back.trimStart()}`;
   }
   return columns;
 };
+
+export const columnsRule = border;


### PR DESCRIPTION
Ref #756

- `columns`
  In this, they takes two values, `width` and `count`, they both can be numbers and string(auto, inherit, unset etc. ) but `count` can't have `units`, and as per MDN's formal format, `width` should come first. So based on this, the function will change the order only if `unit` are mentioned.

- `column-rule`
  should be ordered like `border`
