### PR TITLE
chore: added support for grid-*

### DIFF
--- a/packages/postcss-ordered-values/src/__tests__/index.js
+++ b/packages/postcss-ordered-values/src/__tests__/index.js
@@ -581,3 +581,75 @@ test(
     'border-inline: 5px dashed blue; border-inline-end: .5em solid red; border-block-end: 5px dashed blue; border-block: 5px solid red;border-block-start: 1px solid rgba(0, 30, 105, 0.8);'
   )
 );
+
+test(
+  'should order grid-auto-flow',
+  processCSS(
+    'grid-auto-flow: column;grid-auto-flow: dense column; grid-auto-flow: unset;grid-auto-flow: row dense;',
+    'grid-auto-flow: column;grid-auto-flow: column dense; grid-auto-flow: unset;grid-auto-flow: row dense;'
+  )
+);
+
+test(
+  'should order grid-column-gap',
+  processCSS(
+    'grid-column-gap: normal; grid-column-gap: normal 3%; grid-column-gap: 3em normal;',
+    'grid-column-gap: normal; grid-column-gap: normal 3%; grid-column-gap: normal 3em;'
+  )
+);
+
+test(
+  'should order grid-row-gap',
+  processCSS(
+    'grid-row-gap: normal; grid-row-gap: normal 3%; grid-row-gap: 3em normal;',
+    'grid-row-gap: normal; grid-row-gap: normal 3%; grid-row-gap: normal 3em;'
+  )
+);
+
+test(
+  'should order grid-column',
+  processCSS(
+    'grid-column: 2 / 4; grid-column: 2 span / 7; grid-column: auto;grid-column: 3;grid-column: custom-indent-name / 3;',
+    'grid-column: 2 /  4; grid-column: span 2 /  7; grid-column: auto;grid-column: 3;grid-column: custom-indent-name /  3;'
+  )
+);
+
+test(
+  'should order grid-row',
+  processCSS(
+    'grid-row: 2 / 4; grid-row: 2 span / 7; grid-row: auto;grid-row: 3;grid-row: custom-indent-name / 3;',
+    'grid-row: 2 /  4; grid-row: span 2 /  7; grid-row: auto;grid-row: 3;grid-row: custom-indent-name /  3;'
+  )
+);
+
+test(
+  'should order grid-row-start',
+  processCSS(
+    'grid-row-start: 2 / 4; grid-row-start: 2 span / 7; grid-row-start: auto;grid-row-start: 3;grid-row-start: custom-indent-name / 3;',
+    'grid-row-start: 2 /  4; grid-row-start: span 2 /  7; grid-row-start: auto;grid-row-start: 3;grid-row-start: custom-indent-name /  3;'
+  )
+);
+
+test(
+  'should order grid-row-end',
+  processCSS(
+    'grid-row-end: 2 / 4; grid-row-end: 2 span / 7; grid-row-end: auto;grid-row-end: 3;grid-row-end: custom-indent-name / 3;',
+    'grid-row-end: 2 /  4; grid-row-end: span 2 /  7; grid-row-end: auto;grid-row-end: 3;grid-row-end: custom-indent-name /  3;'
+  )
+);
+
+test(
+  'should order grid-column-start',
+  processCSS(
+    'grid-column-start: 2 / 4; grid-column-start: 2 span / 7; grid-column-start: auto;grid-column-start: 3;grid-column-start: custom-indent-name / 3;',
+    'grid-column-start: 2 /  4; grid-column-start: span 2 /  7; grid-column-start: auto;grid-column-start: 3;grid-column-start: custom-indent-name /  3;'
+  )
+);
+
+test(
+  'should order grid-column-end',
+  processCSS(
+    'grid-column-end: 2 / 4; grid-column-end: 2 span / 7; grid-column-end: auto;grid-column-end: 3;grid-column-end: custom-indent-name / 3;',
+    'grid-column-end: 2 /  4; grid-column-end: span 2 /  7; grid-column-end: auto;grid-column-end: 3;grid-column-end: custom-indent-name /  3;'
+  )
+);

--- a/packages/postcss-ordered-values/src/index.js
+++ b/packages/postcss-ordered-values/src/index.js
@@ -7,6 +7,11 @@ import border from './rules/border';
 import boxShadow from './rules/boxShadow';
 import flexFlow from './rules/flexFlow';
 import transition from './rules/transition';
+import {
+  normalizeGridAutoFlow,
+  normalizeGridColumnRowGap,
+  normalizeGridColumnRow,
+} from './rules/grid';
 
 const borderRules = {
   border: border,
@@ -22,6 +27,18 @@ const borderRules = {
   'border-left': border,
 };
 
+const grid = {
+  'grid-auto-flow': normalizeGridAutoFlow,
+  'grid-column-gap': normalizeGridColumnRowGap, // normal | <length-percentage>
+  'grid-row-gap': normalizeGridColumnRowGap, // normal | <length-percentage>
+  'grid-column': normalizeGridColumnRow, // <grid-line>+
+  'grid-row': normalizeGridColumnRow, // <grid-line>+
+  'grid-row-start': normalizeGridColumnRow, // <grid-line>
+  'grid-row-end': normalizeGridColumnRow, // <grid-line>
+  'grid-column-start': normalizeGridColumnRow, // <grid-line>
+  'grid-column-end': normalizeGridColumnRow, // <grid-line>
+};
+
 const rules = {
   animation: animation,
   outline: border,
@@ -29,6 +46,7 @@ const rules = {
   'flex-flow': flexFlow,
   transition: transition,
   ...borderRules,
+  ...grid,
 };
 
 function isVariableFunctionNode(node) {

--- a/packages/postcss-ordered-values/src/lib/joinGridValue.js
+++ b/packages/postcss-ordered-values/src/lib/joinGridValue.js
@@ -1,0 +1,3 @@
+export default function joinGridVal(grid) {
+  return grid.join(' / ').trim();
+}

--- a/packages/postcss-ordered-values/src/rules/grid.js
+++ b/packages/postcss-ordered-values/src/rules/grid.js
@@ -1,0 +1,83 @@
+export const normalizeGridAutoFlow = (gridAutoFlow) => {
+  let newValue = { front: '', back: '' };
+  let shouldNormalize = false;
+  gridAutoFlow.walk((node) => {
+    if (node.value === 'dense') {
+      shouldNormalize = true;
+      newValue.back = node.value;
+    } else if (['row', 'column'].includes(node.value.trim().toLowerCase())) {
+      shouldNormalize = true;
+      newValue.front = node.value;
+    } else {
+      shouldNormalize = false;
+    }
+  });
+  if (shouldNormalize) {
+    return `${newValue.front.trim()} ${newValue.back.trim()}`;
+  }
+  return gridAutoFlow;
+};
+
+export const normalizeGridColumnRowGap = (gridGap) => {
+  let newValue = { front: '', back: '' };
+  let shouldNormalize = false;
+  gridGap.walk((node) => {
+    // console.log(node);
+    if (node.value === 'normal') {
+      shouldNormalize = true;
+      newValue.front = node.value;
+    } else {
+      newValue.back = `${newValue.back} ${node.value}`;
+    }
+  });
+  if (shouldNormalize) {
+    return `${newValue.front.trim()} ${newValue.back.trim()}`;
+  }
+  return gridGap;
+};
+
+export const normalizeGridColumnRow = (grid) => {
+  // cant do normalization here using node, so copy it as a string
+  let gridValue = grid.toString(); // node -> string value
+  gridValue = gridValue.split('/'); // " 2 / 3 span " ->  [' 2','3 span ']
+  if (gridValue.length > 1) {
+    gridValue = gridValue.map((gridLine) => {
+      let normalizeValue = {
+        front: '',
+        back: '',
+      };
+      gridLine = gridLine.trimStart().trimEnd(); // '3 span ' -> '3 span'
+      gridLine.split(' ').forEach((node) => {
+        // ['3','span']
+        if (node === 'span') {
+          normalizeValue.front = node; // span _
+        } else {
+          normalizeValue.back = `${normalizeValue.back} ${node}`; // _ 3
+        }
+      });
+      return `${normalizeValue.front.trim()} ${normalizeValue.back.trim()}`; // span 3
+    });
+    // returns "2 / span 3"
+    return gridValue
+      .join(' / ')
+      .trimStart()
+      .trimEnd();
+  }
+  // doing this separating if `/` is not present as while joining('/') , it will add `/` at the end
+  gridValue = gridValue.map((gridLine) => {
+    let normalizeValue = {
+      front: '',
+      back: '',
+    };
+    gridLine = gridLine.trimStart().trimEnd();
+    gridLine.split(' ').forEach((node) => {
+      if (node === 'span') {
+        normalizeValue.front = node;
+      } else {
+        normalizeValue.back = `${normalizeValue.back} ${node}`;
+      }
+    });
+    return `${normalizeValue.front.trim()} ${normalizeValue.back.trim()}`;
+  });
+  return gridValue;
+};

--- a/packages/postcss-ordered-values/src/rules/grid.js
+++ b/packages/postcss-ordered-values/src/rules/grid.js
@@ -1,3 +1,5 @@
+import joinGridValue from '../lib/joinGridValue';
+
 export const normalizeGridAutoFlow = (gridAutoFlow) => {
   let newValue = { front: '', back: '' };
   let shouldNormalize = false;
@@ -38,33 +40,30 @@ export const normalizeGridColumnRowGap = (gridGap) => {
 
 export const normalizeGridColumnRow = (grid) => {
   // cant do normalization here using node, so copy it as a string
-  let gridValue = grid.toString(); // node -> string value
-  gridValue = gridValue.split('/'); // " 2 / 3 span " ->  [' 2','3 span ']
+  let gridValue = grid.toString().split('/'); // node -> string value, split ->  " 2 / 3 span " ->  [' 2','3 span ']
   if (gridValue.length > 1) {
-    gridValue = gridValue.map((gridLine) => {
-      let normalizeValue = {
-        front: '',
-        back: '',
-      };
-      gridLine = gridLine.trimStart().trimEnd(); // '3 span ' -> '3 span'
-      gridLine.split(' ').forEach((node) => {
-        // ['3','span']
-        if (node === 'span') {
-          normalizeValue.front = node; // span _
-        } else {
-          normalizeValue.back = `${normalizeValue.back} ${node}`; // _ 3
-        }
-      });
-      return `${normalizeValue.front.trim()} ${normalizeValue.back.trim()}`; // span 3
-    });
-    // returns "2 / span 3"
-    return gridValue
-      .join(' / ')
-      .trimStart()
-      .trimEnd();
+    return joinGridValue(
+      gridValue.map((gridLine) => {
+        let normalizeValue = {
+          front: '',
+          back: '',
+        };
+        gridLine = gridLine.trimStart().trimEnd(); // '3 span ' -> '3 span'
+        gridLine.split(' ').forEach((node) => {
+          // ['3','span']
+          if (node === 'span') {
+            normalizeValue.front = node; // span _
+          } else {
+            normalizeValue.back = `${normalizeValue.back} ${node}`; // _ 3
+          }
+        });
+        return `${normalizeValue.front.trim()} ${normalizeValue.back.trim()}`; // span 3
+      })
+      // returns "2 / span 3"
+    );
   }
   // doing this separating if `/` is not present as while joining('/') , it will add `/` at the end
-  gridValue = gridValue.map((gridLine) => {
+  return gridValue.map((gridLine) => {
     let normalizeValue = {
       front: '',
       back: '',
@@ -79,5 +78,4 @@ export const normalizeGridColumnRow = (grid) => {
     });
     return `${normalizeValue.front.trim()} ${normalizeValue.back.trim()}`;
   });
-  return gridValue;
 };

--- a/packages/postcss-ordered-values/src/rules/grid.js
+++ b/packages/postcss-ordered-values/src/rules/grid.js
@@ -48,7 +48,7 @@ export const normalizeGridColumnRow = (grid) => {
           front: '',
           back: '',
         };
-        gridLine = gridLine.trimStart().trimEnd(); // '3 span ' -> '3 span'
+        gridLine = gridLine.trim(); // '3 span ' -> '3 span'
         gridLine.split(' ').forEach((node) => {
           // ['3','span']
           if (node === 'span') {
@@ -68,7 +68,7 @@ export const normalizeGridColumnRow = (grid) => {
       front: '',
       back: '',
     };
-    gridLine = gridLine.trimStart().trimEnd();
+    gridLine = gridLine.trim();
     gridLine.split(' ').forEach((node) => {
       if (node === 'span') {
         normalizeValue.front = node;


### PR DESCRIPTION
Ref #756
Added normalization for grid-\*

- [X] grid-auto-flow `[ row | column ] || dense`
- [X] grid-column-gap `normal | <length-percentage>`
- [X] grid-row-gap `normal | <length-percentage>`
- [X] grid-column `<grid-line>+`
- [X] grid-row  `<grid-line>+`
- [X] grid-row-start  `<grid-line>`
- [X] grid-row-end  `<grid-line>`
- [X] grid-column-start  `<grid-line>`
- [X] grid-column-end  `<grid-line>`
