### PR TITLE
Don't unsafe merge 'all' declaration

### DIFF
--- a/packages/postcss-merge-rules/src/__tests__/index.js
+++ b/packages/postcss-merge-rules/src/__tests__/index.js
@@ -620,22 +620,6 @@ test('should not crash when node.raws.value is null (2)', () => {
 });
 
 test(
-  'should place rules with "all" at the top',
-  processCSS(
-    '.a{margin: 10px 20px;display: flex;all: initial;font-size: 10px;border-radius: 2px;color: blue;}.b{margin: 10px 30px;display: flex;all: initial;font-size: 20px;border-radius: 2px;color: blue;}',
-    '.a,.b{display: flex;all: initial;border-radius: 2px;color: blue;}.a{margin: 10px 20px;font-size: 10px;}.b{margin: 10px 30px;font-size: 20px;}'
-  )
-);
-
-test(
-  'should place rules with "all" at the top (2)',
-  processCSS(
-    '.a{margin: 10px 20px;display: flex;ALL: initial;font-size: 10px;border-radius: 2px;color: blue;}.b{margin: 10px 30px;display: flex;ALL: initial;font-size: 20px;border-radius: 2px;color: blue;}',
-    '.a,.b{display: flex;ALL: initial;border-radius: 2px;color: blue;}.a{margin: 10px 20px;font-size: 10px;}.b{margin: 10px 30px;font-size: 20px;}'
-  )
-);
-
-test(
   'should merge multiple media queries',
   processCSS(
     '@media print{h1{display:block}}@media print{h1{color:red}}',
@@ -772,5 +756,28 @@ test(
       '@media (width:40px){h1{color:black}h2,h3{color:black;font-weight:bold}}',
       '@media (width:40px){}',
     ].join('')
+  )
+);
+
+test(
+  'should not merge properties with "all"',
+  passthroughCSS(
+    '.a{color:red;display:flex;font-size:10px;}.c{all:unset;color:red;display:flex;font-size:10px;}'
+  )
+);
+
+test(
+  'should merge "direction" property with "all"',
+  processCSS(
+    '.a{color:red;display:flex;font-size:10px;direction:tlr;}.c{all:unset;color:red;display:flex;font-size:10px;direction:tlr;}',
+    '.a{color:red;display:flex;font-size:10px;}.a,.c{direction:tlr;}.c{all:unset;color:red;display:flex;font-size:10px;}'
+  )
+);
+
+test(
+  'should merge "unicode-bidi" property with "all"',
+  processCSS(
+    '.a{color:red;display:flex;font-size:10px;unicode-bidi:normal;}.c{all:unset;color:red;display:flex;font-size:10px;unicode-bidi:normal;}',
+    '.a{color:red;display:flex;font-size:10px;}.a,.c{unicode-bidi:normal;}.c{all:unset;color:red;display:flex;font-size:10px;}'
   )
 );

--- a/packages/postcss-merge-rules/src/__tests__/index.js
+++ b/packages/postcss-merge-rules/src/__tests__/index.js
@@ -767,6 +767,11 @@ test(
 );
 
 test(
+  'should not merge properties with "all" (2)',
+  passthroughCSS('.foo{color:red}.bar{all:unset;color:red}')
+);
+
+test(
   'should merge "direction" property with "all"',
   processCSS(
     '.a{color:red;display:flex;font-size:10px;direction:tlr;}.c{all:unset;color:red;display:flex;font-size:10px;direction:tlr;}',

--- a/packages/postcss-merge-rules/src/index.js
+++ b/packages/postcss-merge-rules/src/index.js
@@ -268,6 +268,15 @@ function partialMerge(first, second) {
     if (!declarationIsEqual(secondDecls[nextConflictIndex], decl)) {
       return false;
     }
+    if (
+      decl.prop.toLowerCase() !== 'direction' &&
+      decl.prop.toLowerCase() !== 'unicode-bidi' &&
+      secondDecls.some(
+        (declaration) => declaration.prop.toLowerCase() === 'all'
+      )
+    ) {
+      return false;
+    }
     secondDecls.splice(nextConflictIndex, 1);
     return true;
   });
@@ -281,14 +290,7 @@ function partialMerge(first, second) {
   receivingBlock.selector = joinSelectors(first, second);
   receivingBlock.nodes = [];
 
-  // Rules with "all" declarations must be on top
-  if (
-    intersection.some((declaration) => declaration.prop.toLowerCase() === 'all')
-  ) {
-    second.parent.insertBefore(first, receivingBlock);
-  } else {
-    second.parent.insertBefore(second, receivingBlock);
-  }
+  second.parent.insertBefore(second, receivingBlock);
 
   const firstClone = first.clone();
   const secondClone = second.clone();


### PR DESCRIPTION
Fixes #824 

And remove some unsafe tests for `all`. Because, for example, in https://github.com/cssnano/cssnano/pull/872/files#diff-b9a0c329a170d3294df84c3c787c690dL624-L626 , the render result is different between input and output.

the input
```css
.a{margin: 10px 20px;display: flex;all: initial;font-size: 10px;border-radius: 2px;color: blue;}.b{margin: 10px 30px;display: flex;all: initial;font-size: 20px;border-radius: 2px;color: blue;}
```
render as
<img width="66" alt="スクリーンショット 2020-01-29 13 13 28" src="https://user-images.githubusercontent.com/14838850/73327379-28ca5680-4299-11ea-8cbe-74e933d24623.png">
(https://codepen.io/sosukesuzuki/pen/OJPYRoN).
But, the output
```css
.a,.b{display: flex;all: initial;border-radius: 2px;color: blue;}.a{margin: 10px 20px;font-size: 10px;}.b{margin: 10px 30px;font-size: 20px;}
```
render as
<img width="193" alt="スクリーンショット 2020-01-29 13 16 22" src="https://user-images.githubusercontent.com/14838850/73327493-8fe80b00-4299-11ea-998a-8c9a51bd6476.png">
(https://codepen.io/sosukesuzuki/pen/MWYdeBK).