### PR TITLE
chore: added support for list-style ordering

### DIFF
--- a/packages/postcss-ordered-values/src/__tests__/index.js
+++ b/packages/postcss-ordered-values/src/__tests__/index.js
@@ -669,3 +669,86 @@ test(
     'grid-column-end: 2 /  4; grid-column-end: span 2 /  7; grid-column-end: auto;grid-column-end: 3;grid-column-end: custom-indent-name /  3;'
   )
 );
+
+test(
+  'should order list-style 1',
+  processCSS('ul{list-style: unset}', 'ul{list-style: unset}')
+);
+
+test(
+  'should order list-style 2',
+  processCSS('ul{list-style: none}', 'ul{list-style: none}')
+);
+
+test(
+  'should order list-style 3',
+  processCSS('ul{list-style: square inside}', 'ul{list-style: square inside}')
+);
+
+test(
+  'should order list-style 4',
+  processCSS('ul{list-style: inside square}', 'ul{list-style: square inside}')
+);
+
+test(
+  'should order list-style 5',
+  processCSS('ul{list-style: square unset}', 'ul{list-style: square unset}')
+);
+
+test(
+  'should order list-style 6',
+  processCSS('ul{list-style: inside none}', 'ul{list-style: none inside}')
+  /**
+   *  This change is CORRECT as
+   *  list-style: inside none;
+          list-style-position: inside;
+          list-style-image: initial;
+          list-style-type: none;
+      list-style: none inside;
+          list-style-position: inside;
+          list-style-image: initial;
+          list-style-type: none;
+   *
+   */
+);
+test(
+  'should order list-style 7',
+  processCSS('ul{list-style: unset inside}', 'ul{list-style: unset inside}')
+);
+test(
+  'should order list-style 8',
+  processCSS(
+    'ul{list-style: circle unset none}',
+    'ul{list-style: circle unset none}'
+  )
+);
+
+test(
+  'should order list-style 9',
+  processCSS(
+    'ul{list-style: circle url("https://mdn.mozillademos.org/files/11981/starsolid.gif")}',
+    'ul{list-style: circle  url("https://mdn.mozillademos.org/files/11981/starsolid.gif")}'
+  )
+);
+
+test(
+  'should order list-style 10', // it is invalid CSS
+  processCSS('ul{list-style: circle none}', 'ul{list-style: circle none}')
+);
+
+test(
+  'should order list-style 11',
+  processCSS(
+    'ul{list-style: unset none circle}', // it is invalid CSS
+    'ul{list-style: unset none circle}' // its safe/better to leave as it is when global values and none comes
+    // cause both position and image accepts  none
+  )
+);
+
+test(
+  'should order list-style 12',
+  processCSS(
+    'ul{list-style: circle url("https://mdn.mozillademos.org/files/11981/starsolid.gif") none}',
+    'ul{list-style: circle none  url("https://mdn.mozillademos.org/files/11981/starsolid.gif")}'
+  )
+);

--- a/packages/postcss-ordered-values/src/index.js
+++ b/packages/postcss-ordered-values/src/index.js
@@ -12,6 +12,7 @@ import {
   normalizeGridColumnRowGap,
   normalizeGridColumnRow,
 } from './rules/grid';
+import listStyle from './rules/listStyle';
 import { columnsRule, column } from './rules/columns';
 
 const borderRules = {
@@ -50,6 +51,7 @@ const rules = {
   outline: border,
   'box-shadow': boxShadow,
   'flex-flow': flexFlow,
+  'list-style': listStyle,
   transition: transition,
   ...borderRules,
   ...grid,

--- a/packages/postcss-ordered-values/src/rules/listStyle.js
+++ b/packages/postcss-ordered-values/src/rules/listStyle.js
@@ -1,0 +1,45 @@
+import valueParser from 'postcss-value-parser';
+
+const definedTypes = [
+  'disc',
+  'circle',
+  'square',
+  'decimal',
+  'georgian',
+  'trad-chinese-informal',
+  'kannada',
+];
+
+const definedPosition = ['inside', 'outside'];
+export default function listStyleNormalizer(listStyle) {
+  const order = { type: '', position: '', image: '' };
+
+  listStyle.walk((decl) => {
+    if (decl.type === 'word') {
+      if (definedTypes.includes(decl.value)) {
+        // its a type field
+        order.type = `${order.type} ${decl.value}`;
+      } else if (definedPosition.includes(decl.value)) {
+        order.position = `${order.position} ${decl.value}`;
+      } else if (decl.value === 'none') {
+        if (
+          order.type
+            .split(' ')
+            .filter((e) => e !== '' || e !== '')
+            .includes('none')
+        ) {
+          order.image = `${order.image} ${decl.value}`;
+        } else {
+          order.type = `${order.type} ${decl.value}`;
+        }
+      } else {
+        order.type = `${order.type} ${decl.value}`;
+      }
+    }
+    if (decl.type === 'function') {
+      order.image = `${order.image} ${valueParser.stringify(decl)}`;
+    }
+  });
+
+  return `${order.type.trim()} ${order.position.trim()} ${order.image.trim()}`.trim();
+}


### PR DESCRIPTION
Added list-style ordering support

Ref : https://github.com/cssnano/cssnano/issues/756

Link to refer :
https://developer.mozilla.org/en-US/docs/Web/CSS/list-style
https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-image
https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-position
https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type

Input

```css
h1 {
  list-style: none inside;
  list-style: unset;
  list-style: none;
  list-style: square inside;
  list-style: inside square;
  list-style: square unset;
  list-style: inside none;
  list-style: unset inside;
  list-style: circle unset none;
  list-style: circle none none;
  list-style: unset none circle;
  list-style: none outside none;
  list-style: circle url("https://mdn.m");
  list-style: circle url("https://mdn.m") none;
}
```

Output

```css
h1 {
  list-style: none inside;
  list-style: unset;
  list-style: none;
  list-style: square inside;
  list-style: square inside;
  list-style: square unset;
  list-style: none inside;
  list-style: unset inside;
  list-style: circle unset none;
  list-style: circle none none;
  list-style: unset none circle;
  list-style: none outside none;
  list-style: circle url("https://mdn.m");
  list-style: circle none url("https://mdn.m");
}
```
