### PR TITLE
fix: units being removed in math functions

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -591,6 +591,15 @@
       "contributions": [
         "platform"
       ]
+    },
+    {
+      "login": "wongjn",
+      "name": "wongjn",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/11310624?v=4",
+      "profile": "https://github.com/wongjn",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "repoType": "github"

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,4 +10,5 @@ module.exports = {
     '_processCss.js',
     '_webpack.config.js',
   ],
+  testTimeout: 30000,
 };

--- a/packages/postcss-convert-values/src/__tests__/index.js
+++ b/packages/postcss-convert-values/src/__tests__/index.js
@@ -351,6 +351,12 @@ test(
   passthroughCSS('h1{line-height:0rem}')
 );
 
+test('should keep unit in max()', passthroughCSS('h1{margin:max(0px)}'));
+
+test('should keep unit in min()', passthroughCSS('h1{margin:min(0px)}'));
+
+test('should keep unit in clamp()', passthroughCSS('h1{margin:clamp(0px)}'));
+
 test(
   'should keep unknown units or hacks',
   passthroughCSS('h1{top:0\\9\\0;left:0lightyear}')

--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -106,7 +106,12 @@ function transform(opts, decl) {
           });
           return false;
         }
-        if (lowerCasedValue === 'url') {
+        if (
+          lowerCasedValue === 'url' ||
+          lowerCasedValue === 'min' ||
+          lowerCasedValue === 'max' ||
+          lowerCasedValue === 'clamp'
+        ) {
           return false;
         }
       }


### PR DESCRIPTION
When using `min()`, `max()` or `clamp()`, `0` values get their units stripped, making the value invalid. This pull request preserves any units within these CSS functions.