### PR TITLE
fix(postcss-minify-selectors): added check for node.operator for namespace

### DIFF
--- a/packages/postcss-minify-selectors/src/__tests__/index.js
+++ b/packages/postcss-minify-selectors/src/__tests__/index.js
@@ -510,3 +510,22 @@ test('should handle selectors from other plugins', () => {
 });
 
 test('should use the postcss plugin api', usePostCSSPlugin(plugin()));
+
+test(
+  'should handle attribute selector and namespace',
+  passthroughCSS('::slotted([foo|bar])')
+);
+
+test(
+  'should handle attribute selector and namespace #2',
+  passthroughCSS('div[*|att] {  }')
+);
+
+test(
+  'should handle attribute selector and namespace #3',
+  passthroughCSS('div[|att] {  }')
+);
+test(
+  'should handle attribute selector and namespace #3',
+  passthroughCSS('div[att] {  }')
+);

--- a/packages/postcss-minify-selectors/src/index.js
+++ b/packages/postcss-minify-selectors/src/index.js
@@ -25,7 +25,9 @@ function attribute(selector) {
       selector.value = unquote(selector.value);
     }
 
-    selector.operator = selector.operator.trim();
+    if (selector.operator) {
+      selector.operator = selector.operator.trim();
+    }
   }
 
   if (!selector.raws) {


### PR DESCRIPTION
fixes https://github.com/cssnano/cssnano/pull/925

Explanation details : https://github.com/cssnano/cssnano/pull/925#issuecomment-663862095
Ref: [this](https://drafts.csswg.org/selectors-4/?expand=1#attrnmsp)