### PR TITLE
fix(postcss-ordered-values): columns transform returning string instead of the AST

### DIFF
--- a/packages/cssnano/src/__tests__/issue927.js
+++ b/packages/cssnano/src/__tests__/issue927.js
@@ -1,4 +1,4 @@
-	import postcss from 'postcss';
+import postcss from 'postcss';
 import nano from '..';
 
 const fixture = `

--- a/packages/cssnano/src/__tests__/issue927.js
+++ b/packages/cssnano/src/__tests__/issue927.js
@@ -1,0 +1,31 @@
+	import postcss from 'postcss';
+import nano from '..';
+
+const fixture = `
+div{
+  grid-column: span 2;
+}
+p{
+  columns: 2 auto;
+}
+`;
+
+const expected = `div{grid-column:span 2}p{column-count:2}`;
+
+test('it should compress the columns', () => {
+  const processor = postcss([
+    postcss.plugin('cloner', () => {
+      return (css) => {
+        css.walkAtRules((rule) => {
+          css.prepend(rule.clone());
+          rule.remove();
+        });
+      };
+    }),
+    nano(),
+  ]);
+
+  return processor
+    .process(fixture, { from: undefined })
+    .then((r) => expect(r.css).toBe(expected));
+});

--- a/packages/postcss-normalize-string/src/__tests__/index.js
+++ b/packages/postcss-normalize-string/src/__tests__/index.js
@@ -220,3 +220,20 @@ test(
 );
 
 test('should use the postcss plugin api', usePostCSSPlugin(plugin()));
+
+test(
+  'should work for grid-columsn',
+  passthroughCSS(`div{grid-column: span 2;}`)
+);
+
+test(
+  'should work for grid-columsn #2',
+  passthroughCSS(`div{grid-column: span 2 / 1;}`)
+);
+
+test(
+  'should work for grid-columsn #3',
+  passthroughCSS(`div{grid-column: "span 2";}`)
+);
+
+test('should work for columns', passthroughCSS(`div{columns: 2 auto;}`));

--- a/packages/postcss-ordered-values/src/index.js
+++ b/packages/postcss-ordered-values/src/index.js
@@ -125,8 +125,8 @@ export default postcss.plugin('postcss-ordered-values', () => {
 
       const result = processor(parsed);
 
-      decl.value = result;
-      cache[value] = result;
+      decl.value = result.toString();
+      cache[value] = result.toString();
     });
   };
 });


### PR DESCRIPTION
Fixes #927 

`postcss-order-values` when transforming the `columns` was returning ASTs instead of `string`