### PR TITLE
feat(postcss-reduce-initial): added ignore options

### DIFF
--- a/packages/postcss-reduce-initial/README.md
+++ b/packages/postcss-reduce-initial/README.md
@@ -1,7 +1,6 @@
 # [postcss][postcss]-reduce-initial
 
-> Reduce `initial` definitions to the *actual* initial value, where possible.
-
+> Reduce `initial` definitions to the _actual_ initial value, where possible.
 
 ## Install
 
@@ -10,7 +9,6 @@ With [npm](https://npmjs.org/package/postcss-reduce-initial) do:
 ```
 npm install postcss-reduce-initial --save
 ```
-
 
 ## Examples
 
@@ -26,7 +24,7 @@ be converted:
 
 ```css
 h1 {
-    min-width: initial;
+  min-width: initial;
 }
 ```
 
@@ -34,10 +32,9 @@ h1 {
 
 ```css
 h1 {
-    min-width: 0;
+  min-width: 0;
 }
 ```
-
 
 ### Convert values back to `initial`
 
@@ -48,7 +45,7 @@ be converted:
 
 ```css
 h1 {
-    transform-box: border-box;
+  transform-box: border-box;
 }
 ```
 
@@ -56,31 +53,42 @@ h1 {
 
 ```css
 h1 {
-    transform-box: initial;
+  transform-box: initial;
 }
 ```
 
 This conversion is only applied when you supply a browsers list that all support
 the `initial` keyword; it's worth noting that Internet Explorer has no support.
 
+## API
+
+### reduceInitial([options])
+
+#### options
+
+##### ignore
+
+Type: `Array<String>`
+Default: `undefined`
+
+It contains the Array of properties that will be ignored while reducing its value to initial.
+Example : `{ ignore : ["min-height"] }`
 
 ## Usage
 
 See the [PostCSS documentation](https://github.com/postcss/postcss#usage) for
 examples for your environment.
 
-
 ## Contributors
 
 See [CONTRIBUTORS.md](https://github.com/cssnano/cssnano/blob/master/CONTRIBUTORS.md).
-
 
 ## License
 
 [Template:CSSData] by Mozilla Contributors is licensed under [CC-BY-SA 2.5].
 
-[Template:CSSData]: https://developer.mozilla.org/en-US/docs/Template:CSSData
-[CC-BY-SA 2.5]: http://creativecommons.org/licenses/by-sa/2.5/
+[template:cssdata]: https://developer.mozilla.org/en-US/docs/Template:CSSData
+[cc-by-sa 2.5]: http://creativecommons.org/licenses/by-sa/2.5/
 
 MIT © [Ben Briggs](http://beneb.info)
 

--- a/packages/postcss-reduce-initial/src/__tests__/index.js
+++ b/packages/postcss-reduce-initial/src/__tests__/index.js
@@ -96,3 +96,30 @@ test(
   'min-height auto tests',
   processCSS('h1{min-height:initial}', 'h1{min-height:auto}')
 );
+
+test(
+  'should ignore the data present in the ignore options',
+  passthroughCSS('h1{min-height:initial}', { ignore: ['min-height'] })
+);
+
+test(
+  'should ignore the data present in the ignore options #2',
+  processCSS(
+    'h1{  writing-mode: sideways-rl;}',
+    'h1{  writing-mode: sideways-rl;}',
+    { ignore: ['writing-mode'] }
+  )
+);
+
+test(
+  'should ignore the data present in the ignore options #3',
+  processCSS(
+    'h1{  writing-mode: vertical-lr;}',
+    'h1{  writing-mode: vertical-lr;}',
+    { ignore: [] }
+  )
+);
+test(
+  'should ignore the data present in the ignore options , toInitial #3',
+  passthroughCSS('WRITING-MODE:horizontal-tb', { ignore: ['writing-mode'] })
+);

--- a/packages/postcss-reduce-initial/src/index.js
+++ b/packages/postcss-reduce-initial/src/index.js
@@ -6,6 +6,8 @@ import fromInitial from '../data/fromInitial.json';
 import toInitial from '../data/toInitial.json';
 
 const initial = 'initial';
+
+// In most of the browser including chrome the initial for `writing-mode` is not `horizontal-tb`. Ref https://github.com/cssnano/cssnano/pull/905
 const defaultIgnoreProps = ['writing-mode'];
 
 export default plugin('postcss-reduce-initial', () => {

--- a/packages/postcss-reduce-initial/src/index.js
+++ b/packages/postcss-reduce-initial/src/index.js
@@ -20,6 +20,9 @@ export default plugin('postcss-reduce-initial', () => {
 
     css.walkDecls((decl) => {
       const lowerCasedProp = decl.prop.toLowerCase();
+      if (resultOpts.ignore && !!~resultOpts.ignore.indexOf(lowerCasedProp)) {
+        return;
+      }
 
       if (
         initialSupport &&

--- a/packages/postcss-reduce-initial/src/index.js
+++ b/packages/postcss-reduce-initial/src/index.js
@@ -6,6 +6,7 @@ import fromInitial from '../data/fromInitial.json';
 import toInitial from '../data/toInitial.json';
 
 const initial = 'initial';
+const defaultIgnoreProps = ['writing-mode'];
 
 export default plugin('postcss-reduce-initial', () => {
   return (css, result) => {
@@ -20,7 +21,9 @@ export default plugin('postcss-reduce-initial', () => {
 
     css.walkDecls((decl) => {
       const lowerCasedProp = decl.prop.toLowerCase();
-      if (resultOpts.ignore && !!~resultOpts.ignore.indexOf(lowerCasedProp)) {
+      const ignoreProp = defaultIgnoreProps.concat(resultOpts.ignore || []);
+
+      if (ignoreProp.includes(lowerCasedProp)) {
         return;
       }
 


### PR DESCRIPTION
fixes #905 

Added new option `ignore` to skip the property passed in it. 
