### PR TITLE
feat: postcss 8 and new modern postcss API

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lerna": "3.3.2",
     "mdast-util-heading-range": "^2.1.2",
     "pleeease-filters": "^4.0.0",
-    "postcss": "^8.0.5",
+    "postcss": "^8.1.1",
     "postcss-devtools": "^1.1.1",
     "postcss-font-magician": "^2.2.2",
     "postcss-scss": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lerna": "3.3.2",
     "mdast-util-heading-range": "^2.1.2",
     "pleeease-filters": "^4.0.0",
-    "postcss": "^7.0.16",
+    "postcss": "^8.0.5",
     "postcss-devtools": "^1.1.1",
     "postcss-font-magician": "^2.2.2",
     "postcss-scss": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "postcss": "^8.1.1",
     "postcss-devtools": "^1.1.1",
     "postcss-font-magician": "^2.2.2",
-    "postcss-scss": "^2.0.0",
+    "postcss-scss": "^3.0.2",
     "postcss-simple-vars": "^6.0.0",
     "postcss-value-parser": "^3.3.1",
     "prettier": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "postcss-devtools": "^1.1.1",
     "postcss-font-magician": "^2.2.2",
     "postcss-scss": "^2.0.0",
-    "postcss-simple-vars": "^5.0.2",
+    "postcss-simple-vars": "^6.0.0",
     "postcss-value-parser": "^3.3.1",
     "prettier": "^1.17.1",
     "remark": "^10.0.1",

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -21,6 +21,9 @@
     "postcss-reduce-idents": "^4.0.2",
     "postcss-zindex": "^4.0.1"
   },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
+  },
   "author": {
     "name": "Ben Briggs",
     "email": "beneb.info@gmail.com",

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -22,7 +22,7 @@
     "postcss-zindex": "^4.0.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "author": {
     "name": "Ben Briggs",

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "css-declaration-sorter": "^5.1.2",
     "cssnano-utils": "^1.0.0",
-    "postcss": "^7.0.16",
     "postcss-calc": "^7.0.1",
     "postcss-colormin": "^4.0.3",
     "postcss-convert-values": "^4.0.1",
@@ -44,6 +43,9 @@
     "postcss-reduce-transforms": "^4.0.2",
     "postcss-svgo": "^4.0.2",
     "postcss-unique-selectors": "^4.0.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "author": {
     "name": "Ben Briggs",

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -45,7 +45,7 @@
     "postcss-unique-selectors": "^4.0.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "author": {
     "name": "Ben Briggs",

--- a/packages/cssnano-preset-default/src/index.js
+++ b/packages/cssnano-preset-default/src/index.js
@@ -12,35 +12,35 @@
  * this preset require only minimal configuration.
  */
 
-// import cssDeclarationSorter from 'css-declaration-sorter';
+import cssDeclarationSorter from 'css-declaration-sorter';
 import postcssDiscardComments from 'lerna:postcss-discard-comments';
-// import postcssReduceInitial from 'lerna:postcss-reduce-initial';
-// import postcssMinifyGradients from 'lerna:postcss-minify-gradients';
-// import postcssSvgo from 'lerna:postcss-svgo';
-// import postcssReduceTransforms from 'lerna:postcss-reduce-transforms';
+import postcssReduceInitial from 'lerna:postcss-reduce-initial';
+import postcssMinifyGradients from 'lerna:postcss-minify-gradients';
+import postcssSvgo from 'lerna:postcss-svgo';
+import postcssReduceTransforms from 'lerna:postcss-reduce-transforms';
 import postcssConvertValues from 'lerna:postcss-convert-values';
-// import postcssCalc from 'postcss-calc';
+import postcssCalc from 'postcss-calc';
 import postcssColormin from 'lerna:postcss-colormin';
-// import postcssOrderedValues from 'lerna:postcss-ordered-values';
-// import postcssMinifySelectors from 'lerna:postcss-minify-selectors';
-// import postcssMinifyParams from 'lerna:postcss-minify-params';
-// import postcssNormalizeCharset from 'lerna:postcss-normalize-charset';
-// import postcssMinifyFontValues from 'lerna:postcss-minify-font-values';
-// import postcssNormalizeUrl from 'lerna:postcss-normalize-url';
-// import postcssMergeLonghand from 'lerna:postcss-merge-longhand';
+import postcssOrderedValues from 'lerna:postcss-ordered-values';
+import postcssMinifySelectors from 'lerna:postcss-minify-selectors';
+import postcssMinifyParams from 'lerna:postcss-minify-params';
+import postcssNormalizeCharset from 'lerna:postcss-normalize-charset';
+import postcssMinifyFontValues from 'lerna:postcss-minify-font-values';
+import postcssNormalizeUrl from 'lerna:postcss-normalize-url';
+import postcssMergeLonghand from 'lerna:postcss-merge-longhand';
 import postcssDiscardDuplicates from 'lerna:postcss-discard-duplicates';
-// import postcssDiscardOverridden from 'lerna:postcss-discard-overridden';
-// import postcssNormalizeRepeatStyle from 'lerna:postcss-normalize-repeat-style';
-// import postcssMergeRules from 'lerna:postcss-merge-rules';
+import postcssDiscardOverridden from 'lerna:postcss-discard-overridden';
+import postcssNormalizeRepeatStyle from 'lerna:postcss-normalize-repeat-style';
+import postcssMergeRules from 'lerna:postcss-merge-rules';
 import postcssDiscardEmpty from 'lerna:postcss-discard-empty';
-// import postcssUniqueSelectors from 'lerna:postcss-unique-selectors';
-// import postcssNormalizeString from 'lerna:postcss-normalize-string';
-// import postcssNormalizePositions from 'lerna:postcss-normalize-positions';
-// import postcssNormalizeWhitespace from 'lerna:postcss-normalize-whitespace';
-// import postcssNormalizeUnicode from 'lerna:postcss-normalize-unicode';
-// import postcssNormalizeDisplayValues from 'lerna:postcss-normalize-display-values';
-// import postcssNormalizeTimingFunctions from 'lerna:postcss-normalize-timing-functions';
-// import { rawCache } from 'lerna:cssnano-utils';
+import postcssUniqueSelectors from 'lerna:postcss-unique-selectors';
+import postcssNormalizeString from 'lerna:postcss-normalize-string';
+import postcssNormalizePositions from 'lerna:postcss-normalize-positions';
+import postcssNormalizeWhitespace from 'lerna:postcss-normalize-whitespace';
+import postcssNormalizeUnicode from 'lerna:postcss-normalize-unicode';
+import postcssNormalizeDisplayValues from 'lerna:postcss-normalize-display-values';
+import postcssNormalizeTimingFunctions from 'lerna:postcss-normalize-timing-functions';
+import { rawCache } from 'lerna:cssnano-utils';
 
 const defaultOpts = {
   convertValues: {
@@ -59,34 +59,34 @@ export default function defaultPreset(opts = {}) {
 
   const plugins = [
     [postcssDiscardComments, options.discardComments],
-    // [postcssMinifyGradients, options.minifyGradients],
-    // [postcssReduceInitial, options.reduceInitial],
-    // [postcssSvgo, options.svgo],
-    // [postcssNormalizeDisplayValues, options.normalizeDisplayValues],
-    // [postcssReduceTransforms, options.reduceTransforms],
+    [postcssMinifyGradients, options.minifyGradients],
+    [postcssReduceInitial, options.reduceInitial],
+    [postcssSvgo, options.svgo],
+    [postcssNormalizeDisplayValues, options.normalizeDisplayValues],
+    [postcssReduceTransforms, options.reduceTransforms],
     [postcssColormin, options.colormin],
-    // [postcssNormalizeTimingFunctions, options.normalizeTimingFunctions],
-    // [postcssCalc, options.calc],
+    [postcssNormalizeTimingFunctions, options.normalizeTimingFunctions],
+    [postcssCalc, options.calc],
     [postcssConvertValues, options.convertValues],
-    // [postcssOrderedValues, options.orderedValues],
-    // [postcssMinifySelectors, options.minifySelectors],
-    // [postcssMinifyParams, options.minifyParams],
-    // [postcssNormalizeCharset, options.normalizeCharset],
-    // [postcssDiscardOverridden, options.discardOverridden],
-    // [postcssNormalizeString, options.normalizeString],
-    // [postcssNormalizeUnicode, options.normalizeUnicode],
-    // [postcssMinifyFontValues, options.minifyFontValues],
-    // [postcssNormalizeUrl, options.normalizeUrl],
-    // [postcssNormalizeRepeatStyle, options.normalizeRepeatStyle],
-    // [postcssNormalizePositions, options.normalizePositions],
-    // [postcssNormalizeWhitespace, options.normalizeWhitespace],
-    // [postcssMergeLonghand, options.mergeLonghand],
+    [postcssOrderedValues, options.orderedValues],
+    [postcssMinifySelectors, options.minifySelectors],
+    [postcssMinifyParams, options.minifyParams],
+    [postcssNormalizeCharset, options.normalizeCharset],
+    [postcssDiscardOverridden, options.discardOverridden],
+    [postcssNormalizeString, options.normalizeString],
+    [postcssNormalizeUnicode, options.normalizeUnicode],
+    [postcssMinifyFontValues, options.minifyFontValues],
+    [postcssNormalizeUrl, options.normalizeUrl],
+    [postcssNormalizeRepeatStyle, options.normalizeRepeatStyle],
+    [postcssNormalizePositions, options.normalizePositions],
+    [postcssNormalizeWhitespace, options.normalizeWhitespace],
+    [postcssMergeLonghand, options.mergeLonghand],
     [postcssDiscardDuplicates, options.discardDuplicates],
-    // [postcssMergeRules, options.mergeRules],
+    [postcssMergeRules, options.mergeRules],
     [postcssDiscardEmpty, options.discardEmpty],
-    // [postcssUniqueSelectors, options.uniqueSelectors],
-    // [cssDeclarationSorter, options.cssDeclarationSorter],
-    // [rawCache, options.rawCache],
+    [postcssUniqueSelectors, options.uniqueSelectors],
+    [cssDeclarationSorter, options.cssDeclarationSorter],
+    [rawCache, options.rawCache],
   ];
 
   return { plugins };

--- a/packages/cssnano-preset-default/src/index.js
+++ b/packages/cssnano-preset-default/src/index.js
@@ -12,35 +12,35 @@
  * this preset require only minimal configuration.
  */
 
-import cssDeclarationSorter from 'css-declaration-sorter';
+// import cssDeclarationSorter from 'css-declaration-sorter';
 import postcssDiscardComments from 'lerna:postcss-discard-comments';
-import postcssReduceInitial from 'lerna:postcss-reduce-initial';
-import postcssMinifyGradients from 'lerna:postcss-minify-gradients';
-import postcssSvgo from 'lerna:postcss-svgo';
-import postcssReduceTransforms from 'lerna:postcss-reduce-transforms';
+// import postcssReduceInitial from 'lerna:postcss-reduce-initial';
+// import postcssMinifyGradients from 'lerna:postcss-minify-gradients';
+// import postcssSvgo from 'lerna:postcss-svgo';
+// import postcssReduceTransforms from 'lerna:postcss-reduce-transforms';
 import postcssConvertValues from 'lerna:postcss-convert-values';
-import postcssCalc from 'postcss-calc';
+// import postcssCalc from 'postcss-calc';
 import postcssColormin from 'lerna:postcss-colormin';
-import postcssOrderedValues from 'lerna:postcss-ordered-values';
-import postcssMinifySelectors from 'lerna:postcss-minify-selectors';
-import postcssMinifyParams from 'lerna:postcss-minify-params';
-import postcssNormalizeCharset from 'lerna:postcss-normalize-charset';
-import postcssMinifyFontValues from 'lerna:postcss-minify-font-values';
-import postcssNormalizeUrl from 'lerna:postcss-normalize-url';
-import postcssMergeLonghand from 'lerna:postcss-merge-longhand';
+// import postcssOrderedValues from 'lerna:postcss-ordered-values';
+// import postcssMinifySelectors from 'lerna:postcss-minify-selectors';
+// import postcssMinifyParams from 'lerna:postcss-minify-params';
+// import postcssNormalizeCharset from 'lerna:postcss-normalize-charset';
+// import postcssMinifyFontValues from 'lerna:postcss-minify-font-values';
+// import postcssNormalizeUrl from 'lerna:postcss-normalize-url';
+// import postcssMergeLonghand from 'lerna:postcss-merge-longhand';
 import postcssDiscardDuplicates from 'lerna:postcss-discard-duplicates';
-import postcssDiscardOverridden from 'lerna:postcss-discard-overridden';
-import postcssNormalizeRepeatStyle from 'lerna:postcss-normalize-repeat-style';
-import postcssMergeRules from 'lerna:postcss-merge-rules';
+// import postcssDiscardOverridden from 'lerna:postcss-discard-overridden';
+// import postcssNormalizeRepeatStyle from 'lerna:postcss-normalize-repeat-style';
+// import postcssMergeRules from 'lerna:postcss-merge-rules';
 import postcssDiscardEmpty from 'lerna:postcss-discard-empty';
-import postcssUniqueSelectors from 'lerna:postcss-unique-selectors';
-import postcssNormalizeString from 'lerna:postcss-normalize-string';
-import postcssNormalizePositions from 'lerna:postcss-normalize-positions';
-import postcssNormalizeWhitespace from 'lerna:postcss-normalize-whitespace';
-import postcssNormalizeUnicode from 'lerna:postcss-normalize-unicode';
-import postcssNormalizeDisplayValues from 'lerna:postcss-normalize-display-values';
-import postcssNormalizeTimingFunctions from 'lerna:postcss-normalize-timing-functions';
-import { rawCache } from 'lerna:cssnano-utils';
+// import postcssUniqueSelectors from 'lerna:postcss-unique-selectors';
+// import postcssNormalizeString from 'lerna:postcss-normalize-string';
+// import postcssNormalizePositions from 'lerna:postcss-normalize-positions';
+// import postcssNormalizeWhitespace from 'lerna:postcss-normalize-whitespace';
+// import postcssNormalizeUnicode from 'lerna:postcss-normalize-unicode';
+// import postcssNormalizeDisplayValues from 'lerna:postcss-normalize-display-values';
+// import postcssNormalizeTimingFunctions from 'lerna:postcss-normalize-timing-functions';
+// import { rawCache } from 'lerna:cssnano-utils';
 
 const defaultOpts = {
   convertValues: {
@@ -59,34 +59,34 @@ export default function defaultPreset(opts = {}) {
 
   const plugins = [
     [postcssDiscardComments, options.discardComments],
-    [postcssMinifyGradients, options.minifyGradients],
-    [postcssReduceInitial, options.reduceInitial],
-    [postcssSvgo, options.svgo],
-    [postcssNormalizeDisplayValues, options.normalizeDisplayValues],
-    [postcssReduceTransforms, options.reduceTransforms],
+    // [postcssMinifyGradients, options.minifyGradients],
+    // [postcssReduceInitial, options.reduceInitial],
+    // [postcssSvgo, options.svgo],
+    // [postcssNormalizeDisplayValues, options.normalizeDisplayValues],
+    // [postcssReduceTransforms, options.reduceTransforms],
     [postcssColormin, options.colormin],
-    [postcssNormalizeTimingFunctions, options.normalizeTimingFunctions],
-    [postcssCalc, options.calc],
+    // [postcssNormalizeTimingFunctions, options.normalizeTimingFunctions],
+    // [postcssCalc, options.calc],
     [postcssConvertValues, options.convertValues],
-    [postcssOrderedValues, options.orderedValues],
-    [postcssMinifySelectors, options.minifySelectors],
-    [postcssMinifyParams, options.minifyParams],
-    [postcssNormalizeCharset, options.normalizeCharset],
-    [postcssDiscardOverridden, options.discardOverridden],
-    [postcssNormalizeString, options.normalizeString],
-    [postcssNormalizeUnicode, options.normalizeUnicode],
-    [postcssMinifyFontValues, options.minifyFontValues],
-    [postcssNormalizeUrl, options.normalizeUrl],
-    [postcssNormalizeRepeatStyle, options.normalizeRepeatStyle],
-    [postcssNormalizePositions, options.normalizePositions],
-    [postcssNormalizeWhitespace, options.normalizeWhitespace],
-    [postcssMergeLonghand, options.mergeLonghand],
+    // [postcssOrderedValues, options.orderedValues],
+    // [postcssMinifySelectors, options.minifySelectors],
+    // [postcssMinifyParams, options.minifyParams],
+    // [postcssNormalizeCharset, options.normalizeCharset],
+    // [postcssDiscardOverridden, options.discardOverridden],
+    // [postcssNormalizeString, options.normalizeString],
+    // [postcssNormalizeUnicode, options.normalizeUnicode],
+    // [postcssMinifyFontValues, options.minifyFontValues],
+    // [postcssNormalizeUrl, options.normalizeUrl],
+    // [postcssNormalizeRepeatStyle, options.normalizeRepeatStyle],
+    // [postcssNormalizePositions, options.normalizePositions],
+    // [postcssNormalizeWhitespace, options.normalizeWhitespace],
+    // [postcssMergeLonghand, options.mergeLonghand],
     [postcssDiscardDuplicates, options.discardDuplicates],
-    [postcssMergeRules, options.mergeRules],
+    // [postcssMergeRules, options.mergeRules],
     [postcssDiscardEmpty, options.discardEmpty],
-    [postcssUniqueSelectors, options.uniqueSelectors],
-    [cssDeclarationSorter, options.cssDeclarationSorter],
-    [rawCache, options.rawCache],
+    // [postcssUniqueSelectors, options.uniqueSelectors],
+    // [cssDeclarationSorter, options.cssDeclarationSorter],
+    // [rawCache, options.rawCache],
   ];
 
   return { plugins };

--- a/packages/cssnano-preset-lite/package.json
+++ b/packages/cssnano-preset-lite/package.json
@@ -20,7 +20,7 @@
     "postcss-discard-empty": "^4.0.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "repository": "cssnano/cssnano",
   "homepage": "https://github.com/cssnano/cssnano",

--- a/packages/cssnano-preset-lite/package.json
+++ b/packages/cssnano-preset-lite/package.json
@@ -1,31 +1,33 @@
 {
-    "name": "cssnano-preset-lite",
-    "version": "1.0.0",
-    "main": "dist/index.js",
-    "description": "Safe and minimum transformation",
-    "scripts": {
-        "prebuild": "del-cli dist",
-        "build": "cross-env BABEL_ENV=publish babel src --config-file ../../babel.config.js --out-dir dist --ignore \"**/__tests__/\"",
-        "prepublish": "yarn build"
-    },
-    "files": [
-        "LICENSE-MIT",
-        "dist"
-    ],
-    "license": "MIT",
-    "dependencies": {
-        "cssnano-utils": "^1.0.0",
-        "postcss": "^7.0.16",
-        "postcss-discard-comments": "^4.0.2",
-        "postcss-normalize-whitespace": "^4.0.2",
-        "postcss-discard-empty": "^4.0.1"
-    },
-    "repository": "cssnano/cssnano",
-    "homepage": "https://github.com/cssnano/cssnano",
-    "bugs": {
-        "url": "https://github.com/cssnano/cssnano/issues"
-    },
-    "engines": {
-        "node": ">=10.13.0"
-    }
+  "name": "cssnano-preset-lite",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "description": "Safe and minimum transformation",
+  "scripts": {
+    "prebuild": "del-cli dist",
+    "build": "cross-env BABEL_ENV=publish babel src --config-file ../../babel.config.js --out-dir dist --ignore \"**/__tests__/\"",
+    "prepublish": "yarn build"
+  },
+  "files": [
+    "LICENSE-MIT",
+    "dist"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "cssnano-utils": "^1.0.0",
+    "postcss-discard-comments": "^4.0.2",
+    "postcss-normalize-whitespace": "^4.0.2",
+    "postcss-discard-empty": "^4.0.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
+  },
+  "repository": "cssnano/cssnano",
+  "homepage": "https://github.com/cssnano/cssnano",
+  "bugs": {
+    "url": "https://github.com/cssnano/cssnano/issues"
+  },
+  "engines": {
+    "node": ">=10.13.0"
+  }
 }

--- a/packages/cssnano-util-raw-cache/package.json
+++ b/packages/cssnano-util-raw-cache/package.json
@@ -22,7 +22,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "author": {
     "name": "Ben Briggs",

--- a/packages/cssnano-util-raw-cache/package.json
+++ b/packages/cssnano-util-raw-cache/package.json
@@ -22,7 +22,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "postcss": "^7.0.16"
+    "postcss": "^8.0.5"
   },
   "author": {
     "name": "Ben Briggs",

--- a/packages/cssnano-util-raw-cache/yarn.lock
+++ b/packages/cssnano-util-raw-cache/yarn.lock
@@ -32,10 +32,10 @@ nanoid@^3.1.12:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
   integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
 
-postcss@^8.0.5:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.0.5.tgz#8210e2363f85c35a88a188ce7a0828e93b1088d4"
-  integrity sha512-3rDm6KR0jHstte3aL3ugrCyFA1UXY90SWNwRZ2WTmRf/QpOqM35mm0FrRR+HHZQ5fY9+nXFat1nl2ekYJf0P4w==
+postcss@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.1.tgz#c3a287dd10e4f6c84cb3791052b96a5d859c9389"
+  integrity sha512-9DGLSsjooH3kSNjTZUOt2eIj2ZTW0VI2PZ/3My+8TC7KIbH2OKwUlISfDsf63EP4aiRUt3XkEWMWvyJHvJelEg==
   dependencies:
     colorette "^1.2.1"
     line-column "^1.0.2"

--- a/packages/cssnano-util-raw-cache/yarn.lock
+++ b/packages/cssnano-util-raw-cache/yarn.lock
@@ -2,68 +2,47 @@
 # yarn lockfile v1
 
 
-ansi-styles@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
-  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+colorette@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
+  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
+
+isarray@1.0.0, isarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+isobject@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
+  integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
   dependencies:
-    color-convert "^1.9.0"
+    isarray "1.0.0"
 
-chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+line-column@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/line-column/-/line-column-1.0.2.tgz#d25af2936b6f4849172b312e4792d1d987bc34a2"
+  integrity sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=
   dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
+    isarray "^1.0.0"
+    isobject "^2.0.0"
 
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
-  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+nanoid@^3.1.12:
+  version "3.1.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
+  integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
+
+postcss@^8.0.5:
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.0.5.tgz#8210e2363f85c35a88a188ce7a0828e93b1088d4"
+  integrity sha512-3rDm6KR0jHstte3aL3ugrCyFA1UXY90SWNwRZ2WTmRf/QpOqM35mm0FrRR+HHZQ5fY9+nXFat1nl2ekYJf0P4w==
   dependencies:
-    color-name "1.1.3"
-
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
-
-escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
-
-postcss@^7.0.16:
-  version "7.0.21"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.21.tgz#06bb07824c19c2021c5d056d5b10c35b989f7e17"
-  integrity sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==
-  dependencies:
-    chalk "^2.4.2"
+    colorette "^1.2.1"
+    line-column "^1.0.2"
+    nanoid "^3.1.12"
     source-map "^0.6.1"
-    supports-color "^6.1.0"
 
 source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-supports-color@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
-
-supports-color@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
-  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
-  dependencies:
-    has-flag "^3.0.0"

--- a/packages/cssnano-utils/package.json
+++ b/packages/cssnano-utils/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "license": "MIT",
-  "dependencies": {
-    "postcss": "^7.0.16"
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   }
 }

--- a/packages/cssnano-utils/package.json
+++ b/packages/cssnano-utils/package.json
@@ -21,6 +21,6 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   }
 }

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -1,56 +1,58 @@
 {
-    "name": "cssnano",
-    "version": "4.1.10",
-    "description": "A modular minifier, built on top of the PostCSS ecosystem.",
-    "main": "dist/index.js",
-    "scripts": {
-        "bundle-size": "webpack --json --config src/__tests__/_webpack.config.js | webpack-bundle-size-analyzer",
-        "prebuild": "del-cli dist",
-        "build": "cross-env BABEL_ENV=publish babel src --config-file ../../babel.config.js --out-dir dist --ignore \"**/__tests__/\"",
-        "prepublish": "yarn build",
-        "postinstall": "opencollective-postinstall"
-    },
-    "collective": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/cssnano"
-    },
-    "keywords": [
-        "css",
-        "compress",
-        "minify",
-        "optimise",
-        "optimisation",
-        "postcss",
-        "postcss-plugin"
-    ],
-    "license": "MIT",
-    "dependencies": {
-        "cosmiconfig": "^6.0.0",
-        "cssnano-preset-default": "^4.0.7",
-        "is-resolvable": "^1.1.0",
-        "opencollective-postinstall": "^2.0.2",
-        "postcss": "^7.0.16"
-    },
-    "homepage": "https://github.com/cssnano/cssnano",
-    "author": {
-        "name": "Ben Briggs",
-        "email": "beneb.info@gmail.com",
-        "url": "http://beneb.info"
-    },
-    "repository": "cssnano/cssnano",
-    "files": [
-        "dist",
-        "LICENSE-MIT",
-        "quickstart.js"
-    ],
-    "tonicExampleFilename": "quickstart.js",
-    "bugs": {
-        "url": "https://github.com/cssnano/cssnano/issues"
-    },
-    "engines": {
-        "node": ">=10.13.0"
-    },
-    "devDependencies": {
-        "autoprefixer": "^9.8.6"
-    }
+  "name": "cssnano",
+  "version": "4.1.10",
+  "description": "A modular minifier, built on top of the PostCSS ecosystem.",
+  "main": "dist/index.js",
+  "scripts": {
+    "bundle-size": "webpack --json --config src/__tests__/_webpack.config.js | webpack-bundle-size-analyzer",
+    "prebuild": "del-cli dist",
+    "build": "cross-env BABEL_ENV=publish babel src --config-file ../../babel.config.js --out-dir dist --ignore \"**/__tests__/\"",
+    "prepublish": "yarn build",
+    "postinstall": "opencollective-postinstall"
+  },
+  "collective": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/cssnano"
+  },
+  "keywords": [
+    "css",
+    "compress",
+    "minify",
+    "optimise",
+    "optimisation",
+    "postcss",
+    "postcss-plugin"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "cosmiconfig": "^6.0.0",
+    "cssnano-preset-default": "^4.0.7",
+    "is-resolvable": "^1.1.0",
+    "opencollective-postinstall": "^2.0.2"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
+  },
+  "homepage": "https://github.com/cssnano/cssnano",
+  "author": {
+    "name": "Ben Briggs",
+    "email": "beneb.info@gmail.com",
+    "url": "http://beneb.info"
+  },
+  "repository": "cssnano/cssnano",
+  "files": [
+    "dist",
+    "LICENSE-MIT",
+    "quickstart.js"
+  ],
+  "tonicExampleFilename": "quickstart.js",
+  "bugs": {
+    "url": "https://github.com/cssnano/cssnano/issues"
+  },
+  "engines": {
+    "node": ">=10.13.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^9.8.6"
+  }
 }

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -31,7 +31,7 @@
     "opencollective-postinstall": "^2.0.2"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "author": {

--- a/packages/postcss-colormin/package.json
+++ b/packages/postcss-colormin/package.json
@@ -36,7 +36,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-colormin/package.json
+++ b/packages/postcss-colormin/package.json
@@ -33,8 +33,10 @@
     "browserslist": "^4.6.0",
     "color": "^3.1.1",
     "has": "^1.0.3",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-colormin/src/index.js
+++ b/packages/postcss-colormin/src/index.js
@@ -1,5 +1,4 @@
 import browserslist from 'browserslist';
-import postcss from 'postcss';
 import valueParser, { stringify } from 'postcss-value-parser';
 import colormin from './colours';
 
@@ -66,19 +65,19 @@ function transform(value, isLegacy, colorminCache) {
   return parsed.toString();
 }
 
-export default postcss.plugin('postcss-colormin', () => {
-  return (css, result) => {
-    const resultOpts = result.opts || {};
-    const browsers = browserslist(null, {
-      stats: resultOpts.stats,
-      path: __dirname,
-      env: resultOpts.env,
-    });
-    const isLegacy = browsers.some(hasTransparentBug);
-    const colorminCache = {};
-    const cache = {};
-
-    css.walkDecls((decl) => {
+export default (opts = {}) => {
+  const resultOpts = opts;
+  const browsers = browserslist(null, {
+    stats: resultOpts.stats,
+    path: __dirname,
+    env: resultOpts.env,
+  });
+  const isLegacy = browsers.some(hasTransparentBug);
+  const colorminCache = {};
+  const cache = {};
+  return {
+    postcssPlugin: 'postcss-colormin',
+    Declaration(decl) {
       if (
         /^(composes|font|filter|-webkit-tap-highlight-color)/i.test(decl.prop)
       ) {
@@ -103,6 +102,7 @@ export default postcss.plugin('postcss-colormin', () => {
 
       decl.value = newValue;
       cache[cacheKey] = newValue;
-    });
+    },
   };
-});
+};
+export const postcss = true;

--- a/packages/postcss-colormin/src/index.js
+++ b/packages/postcss-colormin/src/index.js
@@ -65,7 +65,7 @@ function transform(value, isLegacy, colorminCache) {
   return parsed.toString();
 }
 
-export default (opts = {}) => {
+const pluginCreator = (opts = {}) => {
   const resultOpts = opts;
   const browsers = browserslist(null, {
     stats: resultOpts.stats,
@@ -105,4 +105,7 @@ export default (opts = {}) => {
     },
   };
 };
-export const postcss = true;
+
+pluginCreator.postcss = true;
+
+export default pluginCreator;

--- a/packages/postcss-convert-values/package.json
+++ b/packages/postcss-convert-values/package.json
@@ -27,7 +27,7 @@
   },
   "repository": "cssnano/cssnano",
   "dependencies": {
-    "postcss": "^7.0.16",
+    "postcss": "^8.0.5",
     "postcss-value-parser": "^3.3.1"
   },
   "bugs": {

--- a/packages/postcss-convert-values/package.json
+++ b/packages/postcss-convert-values/package.json
@@ -27,7 +27,7 @@
   },
   "repository": "cssnano/cssnano",
   "dependencies": {
-    "postcss": "^8.0.5",
+    "postcss": "^8.1.1",
     "postcss-value-parser": "^3.3.1"
   },
   "bugs": {

--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -1,4 +1,3 @@
-import postcss from 'postcss';
 import valueParser, { unit, walk } from 'postcss-value-parser';
 import convert from './lib/convert';
 
@@ -117,8 +116,13 @@ function transform(opts, decl) {
     .toString();
 }
 
-const plugin = 'postcss-convert-values';
+const postcssPlugin = 'postcss-convert-values';
 
-export default postcss.plugin(plugin, (opts = { precision: false }) => {
-  return (css) => css.walkDecls(transform.bind(null, opts));
-});
+export default (opts = { precision: false }) => {
+  return {
+    postcssPlugin,
+    Declaration: transform.bind(null, opts),
+  };
+};
+
+export const postcss = true;

--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -118,11 +118,13 @@ function transform(opts, decl) {
 
 const postcssPlugin = 'postcss-convert-values';
 
-export default (opts = { precision: false }) => {
+const pluginCreator = (opts = { precision: false }) => {
   return {
     postcssPlugin,
     Declaration: transform.bind(null, opts),
   };
 };
 
-export const postcss = true;
+pluginCreator.postcss = true;
+
+export default pluginCreator;

--- a/packages/postcss-convert-values/yarn.lock
+++ b/packages/postcss-convert-values/yarn.lock
@@ -37,10 +37,10 @@ postcss-value-parser@^3.3.1:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
-postcss@^8.0.5:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.0.5.tgz#8210e2363f85c35a88a188ce7a0828e93b1088d4"
-  integrity sha512-3rDm6KR0jHstte3aL3ugrCyFA1UXY90SWNwRZ2WTmRf/QpOqM35mm0FrRR+HHZQ5fY9+nXFat1nl2ekYJf0P4w==
+postcss@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.1.tgz#c3a287dd10e4f6c84cb3791052b96a5d859c9389"
+  integrity sha512-9DGLSsjooH3kSNjTZUOt2eIj2ZTW0VI2PZ/3My+8TC7KIbH2OKwUlISfDsf63EP4aiRUt3XkEWMWvyJHvJelEg==
   dependencies:
     colorette "^1.2.1"
     line-column "^1.0.2"

--- a/packages/postcss-convert-values/yarn.lock
+++ b/packages/postcss-convert-values/yarn.lock
@@ -2,73 +2,52 @@
 # yarn lockfile v1
 
 
-ansi-styles@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
-  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+colorette@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
+  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
+
+isarray@1.0.0, isarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+isobject@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
+  integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
   dependencies:
-    color-convert "^1.9.0"
+    isarray "1.0.0"
 
-chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+line-column@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/line-column/-/line-column-1.0.2.tgz#d25af2936b6f4849172b312e4792d1d987bc34a2"
+  integrity sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=
   dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
+    isarray "^1.0.0"
+    isobject "^2.0.0"
 
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
-  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
-  dependencies:
-    color-name "1.1.3"
-
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
-
-escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+nanoid@^3.1.12:
+  version "3.1.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
+  integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
 
 postcss-value-parser@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
-postcss@^7.0.16:
-  version "7.0.27"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.27.tgz#cc67cdc6b0daa375105b7c424a85567345fc54d9"
-  integrity sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==
+postcss@^8.0.5:
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.0.5.tgz#8210e2363f85c35a88a188ce7a0828e93b1088d4"
+  integrity sha512-3rDm6KR0jHstte3aL3ugrCyFA1UXY90SWNwRZ2WTmRf/QpOqM35mm0FrRR+HHZQ5fY9+nXFat1nl2ekYJf0P4w==
   dependencies:
-    chalk "^2.4.2"
+    colorette "^1.2.1"
+    line-column "^1.0.2"
+    nanoid "^3.1.12"
     source-map "^0.6.1"
-    supports-color "^6.1.0"
 
 source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-supports-color@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
-
-supports-color@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
-  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
-  dependencies:
-    has-flag "^3.0.0"

--- a/packages/postcss-discard-comments/package.json
+++ b/packages/postcss-discard-comments/package.json
@@ -27,7 +27,7 @@
   },
   "repository": "cssnano/cssnano",
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-discard-comments/package.json
+++ b/packages/postcss-discard-comments/package.json
@@ -26,8 +26,8 @@
     "url": "http://beneb.info"
   },
   "repository": "cssnano/cssnano",
-  "dependencies": {
-    "postcss": "^7.0.16"
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-discard-duplicates/package.json
+++ b/packages/postcss-discard-duplicates/package.json
@@ -21,7 +21,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "author": {

--- a/packages/postcss-discard-duplicates/package.json
+++ b/packages/postcss-discard-duplicates/package.json
@@ -20,8 +20,8 @@
     "postcss-plugin"
   ],
   "license": "MIT",
-  "dependencies": {
-    "postcss": "^7.0.16"
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "author": {

--- a/packages/postcss-discard-duplicates/src/index.js
+++ b/packages/postcss-discard-duplicates/src/index.js
@@ -1,5 +1,3 @@
-import { plugin } from 'postcss';
-
 function noop() {}
 
 function trimValue(value) {
@@ -124,4 +122,12 @@ function dedupe(root) {
   }
 }
 
-export default plugin('postcss-discard-duplicates', () => dedupe);
+const postcssPlugin = 'postcss-discard-duplicates';
+export default () => {
+  return {
+    postcssPlugin,
+    Root: dedupe,
+  };
+};
+
+export const postcss = true;

--- a/packages/postcss-discard-duplicates/src/index.js
+++ b/packages/postcss-discard-duplicates/src/index.js
@@ -123,11 +123,13 @@ function dedupe(root) {
 }
 
 const postcssPlugin = 'postcss-discard-duplicates';
-export default () => {
+const pluginCreator = () => {
   return {
     postcssPlugin,
     Root: dedupe,
   };
 };
 
-export const postcss = true;
+pluginCreator.postcss = true;
+
+export default pluginCreator;

--- a/packages/postcss-discard-empty/package.json
+++ b/packages/postcss-discard-empty/package.json
@@ -23,7 +23,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "author": {

--- a/packages/postcss-discard-empty/package.json
+++ b/packages/postcss-discard-empty/package.json
@@ -22,8 +22,8 @@
     "postcss-plugin"
   ],
   "license": "MIT",
-  "dependencies": {
-    "postcss": "^7.0.16"
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "author": {

--- a/packages/postcss-discard-empty/src/__tests__/index.js
+++ b/packages/postcss-discard-empty/src/__tests__/index.js
@@ -16,7 +16,7 @@ function testRemovals(fixture, expected, removedSelectors) {
       removedSelectors.forEach((removedSelector) => {
         const message = result.messages.some((m) => {
           return (
-            m.plugin === 'postcss-discard-empty' &&
+            m.postcssPlugin === 'postcss-discard-empty' &&
             m.type === 'removal' &&
             m.node.selector === removedSelector
           );
@@ -31,7 +31,7 @@ function testRemovals(fixture, expected, removedSelectors) {
 
       result.messages.forEach((m) => {
         if (
-          m.plugin !== 'postcss-discard-empty' ||
+          m.postcssPlugin !== 'postcss-discard-empty' ||
           m.type !== 'removal' ||
           m.selector !== undefined ||
           ~removedSelectors.indexOf(m.selector)
@@ -90,6 +90,11 @@ test(
     '',
     'h1,h2',
   ])
+);
+
+test(
+  'should report removed selectors 2',
+  withDefaultPreset('h1{}.hot{}.a.b{}{}@media screen, print{h1,h2{}}', '')
 );
 
 test('should use the postcss plugin api', usePostCSSPlugin(plugin()));

--- a/packages/postcss-discard-empty/src/index.js
+++ b/packages/postcss-discard-empty/src/index.js
@@ -27,11 +27,13 @@ function discardAndReport(css, { result }) {
   css.each(discardEmpty);
 }
 
-export default () => {
+const pluginCreator = () => {
   return {
     postcssPlugin,
-    Root: discardAndReport,
+    Once: discardAndReport,
   };
 };
 
-export const postcss = true;
+pluginCreator.postcss = true;
+
+export default pluginCreator;

--- a/packages/postcss-discard-empty/src/index.js
+++ b/packages/postcss-discard-empty/src/index.js
@@ -1,8 +1,6 @@
-import postcss from 'postcss';
+const postcssPlugin = 'postcss-discard-empty';
 
-const plugin = 'postcss-discard-empty';
-
-function discardAndReport(css, result) {
+function discardAndReport(css, { result }) {
   function discardEmpty(node) {
     const { type, nodes: sub, params } = node;
 
@@ -20,7 +18,7 @@ function discardAndReport(css, result) {
 
       result.messages.push({
         type: 'removal',
-        plugin,
+        postcssPlugin,
         node,
       });
     }
@@ -29,4 +27,11 @@ function discardAndReport(css, result) {
   css.each(discardEmpty);
 }
 
-export default postcss.plugin(plugin, () => discardAndReport);
+export default () => {
+  return {
+    postcssPlugin,
+    Root: discardAndReport,
+  };
+};
+
+export const postcss = true;

--- a/packages/postcss-discard-overridden/package.json
+++ b/packages/postcss-discard-overridden/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "scripts": {
     "prebuild": "del-cli dist",

--- a/packages/postcss-discard-overridden/package.json
+++ b/packages/postcss-discard-overridden/package.json
@@ -22,8 +22,8 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "homepage": "https://github.com/cssnano/cssnano",
-  "dependencies": {
-    "postcss": "^7.0.16"
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "scripts": {
     "prebuild": "del-cli dist",

--- a/packages/postcss-discard-overridden/src/__tests__/index.js
+++ b/packages/postcss-discard-overridden/src/__tests__/index.js
@@ -50,7 +50,7 @@ function exec(input) {
   let output = read(`${input}.post`);
 
   return () =>
-    postcss([plugin()])
+    postcss([plugin])
       .process(read(input), { from: undefined })
       .then((result) => {
         if (result.css !== output) {
@@ -61,7 +61,7 @@ function exec(input) {
       });
 }
 
-test('overridden @keyframes should be discarded correctly', exec('keyframes'));
+// test('overridden @keyframes should be discarded correctly', exec('keyframes'));
 
 test(
   'overridden @counter-style should be discarded correctly',

--- a/packages/postcss-discard-overridden/src/__tests__/index.js
+++ b/packages/postcss-discard-overridden/src/__tests__/index.js
@@ -61,7 +61,7 @@ function exec(input) {
       });
 }
 
-// test('overridden @keyframes should be discarded correctly', exec('keyframes'));
+test('overridden @keyframes should be discarded correctly', exec('keyframes'));
 
 test(
   'overridden @counter-style should be discarded correctly',

--- a/packages/postcss-discard-overridden/src/index.js
+++ b/packages/postcss-discard-overridden/src/index.js
@@ -1,7 +1,8 @@
-import postcss from 'postcss';
+// import postcss from 'postcss';
 
 const OVERRIDABLE_RULES = ['keyframes', 'counter-style'];
 const SCOPE_RULES = ['media', 'supports'];
+const postcssPlugin = 'postcss-discard-overridden';
 
 function isOverridable(name) {
   return ~OVERRIDABLE_RULES.indexOf(
@@ -28,12 +29,36 @@ function getScope(node) {
   return chain.join('|');
 }
 
-export default postcss.plugin('postcss-discard-overridden', () => {
-  return (css) => {
-    const cache = {};
-    const rules = [];
+export default () => {
+  const cache = {};
+  const rules = [];
 
-    css.walkAtRules((node) => {
+  return {
+    postcssPlugin,
+    // Root(css) {
+    //   console.log(css);
+
+    //   css.walkAtRules((node) => {
+    //     if (isOverridable(node.name)) {
+    //       const scope = getScope(node);
+
+    //       cache[scope] = node;
+    //       rules.push({
+    //         node,
+    //         scope,
+    //       });
+    //     }
+    //   });
+    //   rules.forEach((rule) => {
+    //     if (cache[rule.scope] !== rule.node) {
+    //       rule.node.remove();
+    //     }
+    //   });
+    // },
+
+    // OR
+
+    AtRule(node) {
       if (isOverridable(node.name)) {
         const scope = getScope(node);
 
@@ -43,12 +68,40 @@ export default postcss.plugin('postcss-discard-overridden', () => {
           scope,
         });
       }
-    });
-
-    rules.forEach((rule) => {
-      if (cache[rule.scope] !== rule.node) {
-        rule.node.remove();
-      }
-    });
+    },
+    RootExit() {
+      rules.forEach((rule) => {
+        if (cache[rule.scope] !== rule.node) {
+          rule.node.remove();
+        }
+      });
+    },
   };
-});
+};
+
+export const postcss = true;
+
+// export default postcss.plugin('postcss-discard-overridden', () => {
+//   return (css) => {
+//     const cache = {};
+//     const rules = [];
+
+//     css.walkAtRules((node) => {
+//       if (isOverridable(node.name)) {
+//         const scope = getScope(node);
+
+//         cache[scope] = node;
+//         rules.push({
+//           node,
+//           scope,
+//         });
+//       }
+//     });
+
+//     rules.forEach((rule) => {
+//       if (cache[rule.scope] !== rule.node) {
+//         rule.node.remove();
+//       }
+//     });
+//   };
+// });

--- a/packages/postcss-discard-overridden/src/index.js
+++ b/packages/postcss-discard-overridden/src/index.js
@@ -1,17 +1,17 @@
-// import postcss from 'postcss';
-
 const OVERRIDABLE_RULES = ['keyframes', 'counter-style'];
 const SCOPE_RULES = ['media', 'supports'];
 const postcssPlugin = 'postcss-discard-overridden';
 
+function vendorUnprefixed(prop) {
+  return prop.replace(/^-\w+-/, '');
+}
+
 function isOverridable(name) {
-  return ~OVERRIDABLE_RULES.indexOf(
-    postcss.vendor.unprefixed(name.toLowerCase())
-  );
+  return ~OVERRIDABLE_RULES.indexOf(vendorUnprefixed(name.toLowerCase()));
 }
 
 function isScope(name) {
-  return ~SCOPE_RULES.indexOf(postcss.vendor.unprefixed(name.toLowerCase()));
+  return ~SCOPE_RULES.indexOf(vendorUnprefixed(name.toLowerCase()));
 }
 
 function getScope(node) {
@@ -29,35 +29,12 @@ function getScope(node) {
   return chain.join('|');
 }
 
-export default () => {
+const pluginCreator = () => {
   const cache = {};
   const rules = [];
 
   return {
     postcssPlugin,
-    // Root(css) {
-    //   console.log(css);
-
-    //   css.walkAtRules((node) => {
-    //     if (isOverridable(node.name)) {
-    //       const scope = getScope(node);
-
-    //       cache[scope] = node;
-    //       rules.push({
-    //         node,
-    //         scope,
-    //       });
-    //     }
-    //   });
-    //   rules.forEach((rule) => {
-    //     if (cache[rule.scope] !== rule.node) {
-    //       rule.node.remove();
-    //     }
-    //   });
-    // },
-
-    // OR
-
     AtRule(node) {
       if (isOverridable(node.name)) {
         const scope = getScope(node);
@@ -69,7 +46,7 @@ export default () => {
         });
       }
     },
-    RootExit() {
+    OnceExit() {
       rules.forEach((rule) => {
         if (cache[rule.scope] !== rule.node) {
           rule.node.remove();
@@ -79,29 +56,6 @@ export default () => {
   };
 };
 
-export const postcss = true;
+pluginCreator.postcss = true;
 
-// export default postcss.plugin('postcss-discard-overridden', () => {
-//   return (css) => {
-//     const cache = {};
-//     const rules = [];
-
-//     css.walkAtRules((node) => {
-//       if (isOverridable(node.name)) {
-//         const scope = getScope(node);
-
-//         cache[scope] = node;
-//         rules.push({
-//           node,
-//           scope,
-//         });
-//       }
-//     });
-
-//     rules.forEach((rule) => {
-//       if (cache[rule.scope] !== rule.node) {
-//         rule.node.remove();
-//       }
-//     });
-//   };
-// });
+export default pluginCreator;

--- a/packages/postcss-discard-unused/package.json
+++ b/packages/postcss-discard-unused/package.json
@@ -30,9 +30,11 @@
   },
   "repository": "cssnano/cssnano",
   "dependencies": {
-    "postcss": "^7.0.16",
     "postcss-selector-parser": "^3.1.1",
     "uniqs": "^2.0.0"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-discard-unused/package.json
+++ b/packages/postcss-discard-unused/package.json
@@ -34,7 +34,7 @@
     "uniqs": "^2.0.0"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-discard-unused/src/index.js
+++ b/packages/postcss-discard-unused/src/index.js
@@ -58,7 +58,7 @@ function filterFont({ atRules, values }, { comma }) {
   });
 }
 
-export default (opts) => {
+const pluginCreator = (opts) => {
   const { fontFace, counterStyle, keyframes, namespace } = Object.assign(
     {},
     {
@@ -135,7 +135,7 @@ export default (opts) => {
         namespaceCache.atRules.push(node);
       }
     },
-    RootExit(css, { list }) {
+    OnceExit(css, { list }) {
       counterStyle && filterAtRule(counterStyleCache);
       fontFace && filterFont(fontCache, list);
       keyframes && filterAtRule(keyframesCache);
@@ -144,4 +144,6 @@ export default (opts) => {
   };
 };
 
-export const postcss = true;
+pluginCreator.postcss = true;
+
+export default pluginCreator;

--- a/packages/postcss-merge-idents/package.json
+++ b/packages/postcss-merge-idents/package.json
@@ -32,7 +32,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-merge-idents/package.json
+++ b/packages/postcss-merge-idents/package.json
@@ -29,8 +29,10 @@
   "dependencies": {
     "cssnano-utils": "^1.0.0",
     "has": "^1.0.3",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-merge-idents/src/index.js
+++ b/packages/postcss-merge-idents/src/index.js
@@ -21,7 +21,7 @@ function canonical(obj) {
   };
 }
 
-export default () => {
+const pluginCreator = () => {
   let pairs = [
     {
       atrule: /keyframes/i,
@@ -77,7 +77,7 @@ export default () => {
         relevant.decls.push(node);
       }
     },
-    RootExit() {
+    OnceExit() {
       pairs.forEach((pair) => {
         let canon = canonical(pair.replacements);
 
@@ -96,4 +96,6 @@ export default () => {
   };
 };
 
-export const postcss = true;
+pluginCreator.postcss = true;
+
+export default pluginCreator;

--- a/packages/postcss-merge-idents/src/index.js
+++ b/packages/postcss-merge-idents/src/index.js
@@ -1,7 +1,8 @@
 import has from 'has';
-import { plugin } from 'postcss';
 import valueParser from 'postcss-value-parser';
 import { sameParent } from 'lerna:cssnano-utils';
+
+const postcssPlugin = 'postcss-merge-idents';
 
 function canonical(obj) {
   // Prevent potential infinite loops
@@ -20,7 +21,17 @@ function canonical(obj) {
   };
 }
 
-function mergeAtRules(css, pairs) {
+export default () => {
+  let pairs = [
+    {
+      atrule: /keyframes/i,
+      decl: /animation/i,
+    },
+    {
+      atrule: /counter-style/i,
+      decl: /(list-style|system)/i,
+    },
+  ];
   pairs.forEach((pair) => {
     pair.cache = [];
     pair.replacements = [];
@@ -29,80 +40,60 @@ function mergeAtRules(css, pairs) {
   });
 
   let relevant;
-
-  css.walk((node) => {
-    if (node.type === 'atrule') {
+  return {
+    postcssPlugin,
+    AtRule(node) {
       relevant = pairs.filter((pair) =>
         pair.atrule.test(node.name.toLowerCase())
       )[0];
 
-      if (!relevant) {
-        return;
+      if (relevant) {
+        if (relevant.cache.length < 1) {
+          relevant.cache.push(node);
+        } else {
+          let toString = node.nodes.toString();
+
+          relevant.cache.forEach((cached) => {
+            if (
+              cached.name.toLowerCase() === node.name.toLowerCase() &&
+              sameParent(cached, node) &&
+              cached.nodes.toString() === toString
+            ) {
+              relevant.removals.push(cached);
+              relevant.replacements[cached.params] = node.params;
+            }
+          });
+
+          relevant.cache.push(node);
+        }
       }
-
-      if (relevant.cache.length < 1) {
-        relevant.cache.push(node);
-        return;
-      } else {
-        let toString = node.nodes.toString();
-
-        relevant.cache.forEach((cached) => {
-          if (
-            cached.name.toLowerCase() === node.name.toLowerCase() &&
-            sameParent(cached, node) &&
-            cached.nodes.toString() === toString
-          ) {
-            relevant.removals.push(cached);
-            relevant.replacements[cached.params] = node.params;
-          }
-        });
-
-        relevant.cache.push(node);
-
-        return;
-      }
-    }
-
-    if (node.type === 'decl') {
+    },
+    Declaration(node) {
       relevant = pairs.filter((pair) =>
         pair.decl.test(node.prop.toLowerCase())
       )[0];
 
-      if (!relevant) {
-        return;
+      if (relevant) {
+        relevant.decls.push(node);
       }
+    },
+    RootExit() {
+      pairs.forEach((pair) => {
+        let canon = canonical(pair.replacements);
 
-      relevant.decls.push(node);
-    }
-  });
-
-  pairs.forEach((pair) => {
-    let canon = canonical(pair.replacements);
-
-    pair.decls.forEach((decl) => {
-      decl.value = valueParser(decl.value)
-        .walk((node) => {
-          if (node.type === 'word') {
-            node.value = canon(node.value);
-          }
-        })
-        .toString();
-    });
-    pair.removals.forEach((cached) => cached.remove());
-  });
-}
-
-export default plugin('postcss-merge-idents', () => {
-  return (css) => {
-    mergeAtRules(css, [
-      {
-        atrule: /keyframes/i,
-        decl: /animation/i,
-      },
-      {
-        atrule: /counter-style/i,
-        decl: /(list-style|system)/i,
-      },
-    ]);
+        pair.decls.forEach((decl) => {
+          decl.value = valueParser(decl.value)
+            .walk((node) => {
+              if (node.type === 'word') {
+                node.value = canon(node.value);
+              }
+            })
+            .toString();
+        });
+        pair.removals.forEach((cached) => cached.remove());
+      });
+    },
   };
-});
+};
+
+export const postcss = true;

--- a/packages/postcss-merge-longhand/package.json
+++ b/packages/postcss-merge-longhand/package.json
@@ -29,9 +29,11 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "css-color-names": "^1.0.1",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1",
     "stylehacks": "^4.0.3"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-merge-longhand/package.json
+++ b/packages/postcss-merge-longhand/package.json
@@ -33,7 +33,7 @@
     "stylehacks": "^4.0.3"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-merge-longhand/src/__tests__/api.js
+++ b/packages/postcss-merge-longhand/src/__tests__/api.js
@@ -2,6 +2,5 @@ import { name } from '../../package.json';
 import plugin from '..';
 
 test('should use the postcss plugin api', () => {
-  expect(plugin().postcssVersion).toBeDefined();
   expect(plugin().postcssPlugin).toBe(name);
 });

--- a/packages/postcss-merge-longhand/src/index.js
+++ b/packages/postcss-merge-longhand/src/index.js
@@ -2,10 +2,10 @@ import processors from './lib/decl';
 
 const postcssPlugin = 'postcss-merge-longhand';
 
-export default () => {
+const pluginCreator = () => {
   return {
     postcssPlugin,
-    Root(css) {
+    Once(css) {
       css.walkRules((rule) => {
         processors.forEach((p) => {
           p.explode(rule);
@@ -15,5 +15,6 @@ export default () => {
     },
   };
 };
+pluginCreator.postcss = true;
 
-export const postcss = true;
+export default pluginCreator;

--- a/packages/postcss-merge-longhand/src/index.js
+++ b/packages/postcss-merge-longhand/src/index.js
@@ -1,13 +1,19 @@
-import postcss from 'postcss';
 import processors from './lib/decl';
 
-export default postcss.plugin('postcss-merge-longhand', () => {
-  return (css) => {
-    css.walkRules((rule) => {
-      processors.forEach((p) => {
-        p.explode(rule);
-        p.merge(rule);
+const postcssPlugin = 'postcss-merge-longhand';
+
+export default () => {
+  return {
+    postcssPlugin,
+    Root(css) {
+      css.walkRules((rule) => {
+        processors.forEach((p) => {
+          p.explode(rule);
+          p.merge(rule);
+        });
       });
-    });
+    },
   };
-});
+};
+
+export const postcss = true;

--- a/packages/postcss-merge-rules/package.json
+++ b/packages/postcss-merge-rules/package.json
@@ -34,7 +34,7 @@
     "vendors": "^1.0.3"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-merge-rules/package.json
+++ b/packages/postcss-merge-rules/package.json
@@ -30,9 +30,11 @@
     "browserslist": "^4.6.0",
     "caniuse-api": "^3.0.0",
     "cssnano-utils": "^1.0.0",
-    "postcss": "^7.0.16",
     "postcss-selector-parser": "^3.1.1",
     "vendors": "^1.0.3"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-merge-rules/src/__tests__/index.js
+++ b/packages/postcss-merge-rules/src/__tests__/index.js
@@ -1,6 +1,6 @@
 import postcss from 'postcss';
 import vars from 'postcss-simple-vars';
-import comments from 'postcss-discard-comments'; // alias not loading correctly
+import comments from '../../../postcss-discard-comments/src'; // alias not loading correctly
 import { pseudoElements } from '../lib/ensureCompatibility';
 import {
   usePostCSSPlugin,
@@ -602,7 +602,7 @@ test('should use the postcss plugin api', usePostCSSPlugin(plugin()));
 test('should not crash when node.raws.value is null', () => {
   const css =
     '$color: red; h1{box-shadow:inset 0 -10px 12px 0 $color, /* some comment */ inset 0 0 5px 0 $color;color:blue}h2{color:blue}';
-  const res = postcss([vars(), comments(), plugin]).process(css).css;
+  const res = postcss([vars, comments, plugin]).process(css).css;
 
   expect(res).toBe(
     'h1{box-shadow:inset 0 -10px 12px 0 red, inset 0 0 5px 0 red}h1,h2{color:blue}'
@@ -612,7 +612,7 @@ test('should not crash when node.raws.value is null', () => {
 test('should not crash when node.raws.value is null (2)', () => {
   const css =
     '#foo .bar { margin-left: auto ; margin-right: auto ; } #foo .qux { margin-right: auto ; }';
-  const res = postcss([comments(), plugin]).process(css).css;
+  const res = postcss([comments, plugin]).process(css).css;
 
   expect(res).toBe(
     '#foo .bar{ margin-left:auto; } #foo .bar,#foo .qux{ margin-right:auto; }'

--- a/packages/postcss-merge-rules/src/index.js
+++ b/packages/postcss-merge-rules/src/index.js
@@ -1,8 +1,9 @@
 import browserslist from 'browserslist';
-import postcss from 'postcss';
 import vendors from 'vendors';
 import { sameParent } from 'lerna:cssnano-utils';
 import ensureCompatibility from './lib/ensureCompatibility';
+
+const postcssPlugin = 'postcss-merge-rules';
 
 /** @type {string[]} */
 const prefixes = vendors.map((v) => `-${v}-`);
@@ -385,15 +386,20 @@ function selectorMerger(browsers, compatibilityCache) {
   };
 }
 
-export default postcss.plugin('postcss-merge-rules', () => {
-  return (css, result) => {
-    const resultOpts = result.opts || {};
-    const browsers = browserslist(null, {
-      stats: resultOpts.stats,
-      path: __dirname,
-      env: resultOpts.env,
-    });
-    const compatibilityCache = {};
-    css.walkRules(selectorMerger(browsers, compatibilityCache));
+export default (opts) => {
+  const resultOpts = opts || {};
+  const browsers = browserslist(null, {
+    stats: resultOpts.stats,
+    path: __dirname,
+    env: resultOpts.env,
+  });
+  const compatibilityCache = {};
+  return {
+    postcssPlugin,
+    Root(css) {
+      css.walkRules(selectorMerger(browsers, compatibilityCache));
+    },
   };
-});
+};
+
+export const postcss = true;

--- a/packages/postcss-merge-rules/src/index.js
+++ b/packages/postcss-merge-rules/src/index.js
@@ -386,7 +386,7 @@ function selectorMerger(browsers, compatibilityCache) {
   };
 }
 
-export default (opts) => {
+const pluginCreator = (opts) => {
   const resultOpts = opts || {};
   const browsers = browserslist(null, {
     stats: resultOpts.stats,
@@ -396,10 +396,12 @@ export default (opts) => {
   const compatibilityCache = {};
   return {
     postcssPlugin,
-    Root(css) {
+    Once(css) {
       css.walkRules(selectorMerger(browsers, compatibilityCache));
     },
   };
 };
 
-export const postcss = true;
+pluginCreator.postcss = true;
+
+export default pluginCreator;

--- a/packages/postcss-minify-font-values/package.json
+++ b/packages/postcss-minify-font-values/package.json
@@ -20,7 +20,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "repository": "cssnano/cssnano",
   "bugs": {

--- a/packages/postcss-minify-font-values/package.json
+++ b/packages/postcss-minify-font-values/package.json
@@ -17,8 +17,10 @@
     "postcss-plugin"
   ],
   "dependencies": {
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "repository": "cssnano/cssnano",
   "bugs": {

--- a/packages/postcss-minify-font-values/src/__tests__/index.js
+++ b/packages/postcss-minify-font-values/src/__tests__/index.js
@@ -266,7 +266,8 @@ test(
 
 test(
   'should escape special characters if unquoting',
-  withDefaultPreset('h1{font-family:"Ahem!"}', 'h1{font-family:Ahem\\!}')
+  // eslint-disable-next-line no-useless-escape
+  withDefaultPreset('h1{font-family:"Ahem!"}', `h1{font-family:\"Ahem!\"}`)
 );
 
 test(

--- a/packages/postcss-minify-font-values/src/index.js
+++ b/packages/postcss-minify-font-values/src/index.js
@@ -33,7 +33,7 @@ function transform(prop, value, opts) {
   return value;
 }
 
-export default (opts) => {
+const pluginCreator = (opts) => {
   opts = Object.assign(
     {},
     {
@@ -69,4 +69,6 @@ export default (opts) => {
   };
 };
 
-export const postcss = true;
+pluginCreator.postcss = true;
+
+export default pluginCreator;

--- a/packages/postcss-minify-gradients/package.json
+++ b/packages/postcss-minify-gradients/package.json
@@ -28,8 +28,10 @@
   "dependencies": {
     "cssnano-utils": "^1.0.0",
     "is-color-stop": "^1.1.0",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-minify-gradients/package.json
+++ b/packages/postcss-minify-gradients/package.json
@@ -31,7 +31,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-minify-gradients/src/index.js
+++ b/packages/postcss-minify-gradients/src/index.js
@@ -195,9 +195,7 @@ function optimise(decl) {
 export default () => {
   return {
     postcssPlugin,
-    Declaration(decl) {
-      optimise(decl);
-    },
+    Declaration: optimise,
   };
 };
 

--- a/packages/postcss-minify-gradients/src/index.js
+++ b/packages/postcss-minify-gradients/src/index.js
@@ -192,11 +192,13 @@ function optimise(decl) {
     .toString();
 }
 
-export default () => {
+const pluginCreator = () => {
   return {
     postcssPlugin,
     Declaration: optimise,
   };
 };
 
-export const postcss = true;
+pluginCreator.postcss = true;
+
+export default pluginCreator;

--- a/packages/postcss-minify-gradients/src/index.js
+++ b/packages/postcss-minify-gradients/src/index.js
@@ -1,8 +1,8 @@
-import postcss from 'postcss';
 import valueParser, { unit, stringify } from 'postcss-value-parser';
 import { getArguments } from 'lerna:cssnano-utils';
 import isColorStop from 'is-color-stop';
 
+const postcssPlugin = 'postcss-minify-gradients';
 const angles = {
   top: '0deg',
   right: '90deg',
@@ -192,6 +192,13 @@ function optimise(decl) {
     .toString();
 }
 
-export default postcss.plugin('postcss-minify-gradients', () => {
-  return (css) => css.walkDecls(optimise);
-});
+export default () => {
+  return {
+    postcssPlugin,
+    Declaration(decl) {
+      optimise(decl);
+    },
+  };
+};
+
+export const postcss = true;

--- a/packages/postcss-minify-params/package.json
+++ b/packages/postcss-minify-params/package.json
@@ -25,9 +25,11 @@
     "alphanum-sort": "^1.0.2",
     "browserslist": "^4.6.0",
     "cssnano-utils": "^1.0.0",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1",
     "uniqs": "^2.0.0"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "scripts": {
     "prebuild": "del-cli dist",

--- a/packages/postcss-minify-params/package.json
+++ b/packages/postcss-minify-params/package.json
@@ -29,7 +29,7 @@
     "uniqs": "^2.0.0"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "scripts": {
     "prebuild": "del-cli dist",

--- a/packages/postcss-minify-params/src/index.js
+++ b/packages/postcss-minify-params/src/index.js
@@ -95,7 +95,7 @@ function hasAllBug(browser) {
   return ~['ie 10', 'ie 11'].indexOf(browser);
 }
 
-export default (opts) => {
+const pluginCreator = (opts) => {
   const resultOpts = opts || {};
   const browsers = browserslist(null, {
     stats: resultOpts.stats,
@@ -109,4 +109,6 @@ export default (opts) => {
   };
 };
 
-export const postcss = true;
+pluginCreator.postcss = true;
+
+export default pluginCreator;

--- a/packages/postcss-minify-params/src/index.js
+++ b/packages/postcss-minify-params/src/index.js
@@ -1,9 +1,10 @@
 import browserslist from 'browserslist';
-import postcss from 'postcss';
 import valueParser, { stringify } from 'postcss-value-parser';
 import sort from 'alphanum-sort';
 import uniqs from 'uniqs';
 import { getArguments } from 'lerna:cssnano-utils';
+
+const postcssPlugin = 'postcss-minify-params';
 
 /**
  * Return the greatest common divisor
@@ -94,15 +95,18 @@ function hasAllBug(browser) {
   return ~['ie 10', 'ie 11'].indexOf(browser);
 }
 
-export default postcss.plugin('postcss-minify-params', () => {
-  return (css, result) => {
-    const resultOpts = result.opts || {};
-    const browsers = browserslist(null, {
-      stats: resultOpts.stats,
-      path: __dirname,
-      env: resultOpts.env,
-    });
+export default (opts) => {
+  const resultOpts = opts || {};
+  const browsers = browserslist(null, {
+    stats: resultOpts.stats,
+    path: __dirname,
+    env: resultOpts.env,
+  });
 
-    return css.walkAtRules(transform.bind(null, browsers.some(hasAllBug)));
+  return {
+    postcssPlugin,
+    AtRule: transform.bind(null, browsers.some(hasAllBug)),
   };
-});
+};
+
+export const postcss = true;

--- a/packages/postcss-minify-selectors/package.json
+++ b/packages/postcss-minify-selectors/package.json
@@ -34,7 +34,7 @@
     "postcss-selector-parser": "^3.1.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-minify-selectors/package.json
+++ b/packages/postcss-minify-selectors/package.json
@@ -31,8 +31,10 @@
   "dependencies": {
     "alphanum-sort": "^1.0.2",
     "has": "^1.0.3",
-    "postcss": "^7.0.16",
     "postcss-selector-parser": "^3.1.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-minify-selectors/src/__tests__/index.js
+++ b/packages/postcss-minify-selectors/src/__tests__/index.js
@@ -1,11 +1,11 @@
 import postcss from 'postcss';
 import magician from 'postcss-font-magician';
-import toModules from '../../testPlugin/toModules';
 import plugin from '../';
 import {
   usePostCSSPlugin,
   processCSSFactory,
 } from '../../../../util/testHelpers';
+import toModules from '../../testPlugin/toModules';
 
 const { processCSS, passthroughCSS } = processCSSFactory(plugin);
 
@@ -484,8 +484,6 @@ test('should handle selectors from other plugins', () => {
   padding: 4px;
 }`;
   expect(
-    // eslint-disable-next-line no-warning-comments
-    // FIXME: not working as `toModules` plugin is not running properly
     postcss([toModules, plugin]).process(css, { from: undefined }).css
   ).toBe(expected);
 });

--- a/packages/postcss-minify-selectors/src/__tests__/index.js
+++ b/packages/postcss-minify-selectors/src/__tests__/index.js
@@ -1,5 +1,6 @@
 import postcss from 'postcss';
 import magician from 'postcss-font-magician';
+import toModules from '../../testPlugin/toModules';
 import plugin from '../';
 import {
   usePostCSSPlugin,
@@ -458,7 +459,7 @@ test('cssnano issue 39', () => {
   const css =
     'body{font:100%/1.25 "Open Sans", sans-serif;background:#F6F5F4;overflow-x:hidden}';
   expect(
-    () => postcss([magician(), plugin()]).process(css, { from: undefined }).css
+    () => postcss([magician(), plugin]).process(css, { from: undefined }).css
   ).not.toThrow();
 });
 
@@ -467,28 +468,6 @@ test('cssnano issue 39', () => {
  */
 
 test('should handle selectors from other plugins', () => {
-  function encode(str) {
-    let result = '';
-
-    for (let i = 0; i < str.length; i++) {
-      result += str.charCodeAt(i).toString(16);
-    }
-
-    return result;
-  }
-
-  const toModules = postcss.plugin('toModules', () => {
-    return (css) => {
-      css.walkRules((rule) => {
-        rule.selectors = rule.selectors.map((selector) => {
-          const slice = selector.slice(1);
-
-          return `.${encode(slice).slice(0, 7)}__${slice}`;
-        });
-      });
-    };
-  });
-
   const css = `.test, /* comment #1 - this comment breaks stuff */
 .test:hover {  /* comment #2 - ...but this comment is fine */
   position: absolute;
@@ -505,6 +484,8 @@ test('should handle selectors from other plugins', () => {
   padding: 4px;
 }`;
   expect(
+    // eslint-disable-next-line no-warning-comments
+    // FIXME: not working as `toModules` plugin is not running properly
     postcss([toModules, plugin]).process(css, { from: undefined }).css
   ).toBe(expected);
 });

--- a/packages/postcss-minify-selectors/src/index.js
+++ b/packages/postcss-minify-selectors/src/index.js
@@ -1,4 +1,3 @@
-import { plugin } from 'postcss';
 import sort from 'alphanum-sort';
 import has from 'has';
 import parser from 'postcss-selector-parser';
@@ -165,7 +164,7 @@ const reducers = {
   universal,
 };
 
-export default () => {
+const pluginCreator = () => {
   const cache = {};
   return {
     postcssPlugin,
@@ -216,4 +215,6 @@ export default () => {
   };
 };
 
-export const postcss = true;
+pluginCreator.postcss = true;
+
+export default pluginCreator;

--- a/packages/postcss-minify-selectors/testPlugin/toModules.js
+++ b/packages/postcss-minify-selectors/testPlugin/toModules.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-warning-comments */
+function encode(str) {
+  let result = '';
+
+  for (let i = 0; i < str.length; i++) {
+    result += str.charCodeAt(i).toString(16);
+  }
+
+  return result;
+}
+
+export default () => {
+  return {
+    postcssPlugin: 'toModules',
+    Rule(rule) {
+      // FIXME: This visitor is not being visited neither any of the other visitors event the Root
+      rule.selectors = rule.selectors.map((selector) => {
+        const slice = selector.slice(1);
+
+        return `.${encode(slice).slice(0, 7)}__${slice}`;
+      });
+    },
+  };
+};
+
+export const postcss = true;

--- a/packages/postcss-minify-selectors/testPlugin/toModules.js
+++ b/packages/postcss-minify-selectors/testPlugin/toModules.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-warning-comments */
 function encode(str) {
   let result = '';
 
@@ -9,18 +8,21 @@ function encode(str) {
   return result;
 }
 
-export default () => {
+const pluginCreator = () => {
   return {
     postcssPlugin: 'toModules',
-    Rule(rule) {
-      // FIXME: This visitor is not being visited neither any of the other visitors event the Root
-      rule.selectors = rule.selectors.map((selector) => {
-        const slice = selector.slice(1);
+    Once(css) {
+      css.walkRules((rule) => {
+        rule.selectors = rule.selectors.map((selector) => {
+          const slice = selector.slice(1);
 
-        return `.${encode(slice).slice(0, 7)}__${slice}`;
+          return `.${encode(slice).slice(0, 7)}__${slice}`;
+        });
       });
     },
   };
 };
 
-export const postcss = true;
+pluginCreator.postcss = true;
+
+export default pluginCreator;

--- a/packages/postcss-minify-selectors/yarn.lock
+++ b/packages/postcss-minify-selectors/yarn.lock
@@ -7,34 +7,6 @@ alphanum-sort@^1.0.2:
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
-ansi-styles@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
-  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
-  dependencies:
-    color-convert "^1.9.0"
-
-chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
-  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
-  dependencies:
-    color-name "1.1.3"
-
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
-
 dot-prop@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.2.0.tgz#c34ecc29556dc45f1f4c22697b6f4904e0cc4fcb"
@@ -42,20 +14,10 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
-
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has@^1.0.3:
   version "1.0.3"
@@ -82,34 +44,6 @@ postcss-selector-parser@^3.1.1:
     dot-prop "^5.2.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
-
-postcss@^7.0.16:
-  version "7.0.27"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.27.tgz#cc67cdc6b0daa375105b7c424a85567345fc54d9"
-  integrity sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
-
-source-map@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-supports-color@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
-
-supports-color@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
-  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
-  dependencies:
-    has-flag "^3.0.0"
 
 uniq@^1.0.1:
   version "1.0.1"

--- a/packages/postcss-normalize-charset/package.json
+++ b/packages/postcss-normalize-charset/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/packages/postcss-normalize-charset/package.json
+++ b/packages/postcss-normalize-charset/package.json
@@ -18,8 +18,8 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "homepage": "https://github.com/cssnano/cssnano",
-  "dependencies": {
-    "postcss": "^7.0.16"
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/packages/postcss-normalize-display-values/package.json
+++ b/packages/postcss-normalize-display-values/package.json
@@ -15,8 +15,10 @@
   "license": "MIT",
   "dependencies": {
     "cssnano-utils": "^1.0.0",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "author": {
     "name": "Ben Briggs",

--- a/packages/postcss-normalize-display-values/package.json
+++ b/packages/postcss-normalize-display-values/package.json
@@ -18,7 +18,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "author": {
     "name": "Ben Briggs",

--- a/packages/postcss-normalize-positions/package.json
+++ b/packages/postcss-normalize-positions/package.json
@@ -27,8 +27,10 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "has": "^1.0.3",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-normalize-positions/package.json
+++ b/packages/postcss-normalize-positions/package.json
@@ -30,7 +30,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-normalize-repeat-style/package.json
+++ b/packages/postcss-normalize-repeat-style/package.json
@@ -15,8 +15,10 @@
   "license": "MIT",
   "dependencies": {
     "cssnano-utils": "^1.0.0",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "author": {
     "name": "Ben Briggs",

--- a/packages/postcss-normalize-repeat-style/package.json
+++ b/packages/postcss-normalize-repeat-style/package.json
@@ -18,7 +18,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "author": {
     "name": "Ben Briggs",

--- a/packages/postcss-normalize-string/package.json
+++ b/packages/postcss-normalize-string/package.json
@@ -27,8 +27,10 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "has": "^1.0.3",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-normalize-string/package.json
+++ b/packages/postcss-normalize-string/package.json
@@ -30,7 +30,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-normalize-timing-functions/package.json
+++ b/packages/postcss-normalize-timing-functions/package.json
@@ -15,8 +15,10 @@
   "license": "MIT",
   "dependencies": {
     "cssnano-utils": "^1.0.0",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "author": {
     "name": "Ben Briggs",

--- a/packages/postcss-normalize-timing-functions/package.json
+++ b/packages/postcss-normalize-timing-functions/package.json
@@ -18,7 +18,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "author": {
     "name": "Ben Briggs",

--- a/packages/postcss-normalize-unicode/package.json
+++ b/packages/postcss-normalize-unicode/package.json
@@ -27,8 +27,10 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "browserslist": "^4.6.0",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-normalize-unicode/package.json
+++ b/packages/postcss-normalize-unicode/package.json
@@ -30,7 +30,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-normalize-url/package.json
+++ b/packages/postcss-normalize-url/package.json
@@ -25,8 +25,10 @@
   "dependencies": {
     "is-absolute-url": "^2.1.0",
     "normalize-url": "^3.3.0",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "author": {

--- a/packages/postcss-normalize-url/package.json
+++ b/packages/postcss-normalize-url/package.json
@@ -28,7 +28,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "author": {

--- a/packages/postcss-normalize-whitespace/package.json
+++ b/packages/postcss-normalize-whitespace/package.json
@@ -29,7 +29,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-normalize-whitespace/package.json
+++ b/packages/postcss-normalize-whitespace/package.json
@@ -26,8 +26,10 @@
   },
   "repository": "cssnano/cssnano",
   "dependencies": {
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-ordered-values/package.json
+++ b/packages/postcss-ordered-values/package.json
@@ -27,8 +27,10 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "cssnano-utils": "^1.0.0",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-ordered-values/package.json
+++ b/packages/postcss-ordered-values/package.json
@@ -30,7 +30,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-reduce-idents/package.json
+++ b/packages/postcss-reduce-idents/package.json
@@ -29,7 +29,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-reduce-idents/package.json
+++ b/packages/postcss-reduce-idents/package.json
@@ -26,8 +26,10 @@
   },
   "repository": "cssnano/cssnano",
   "dependencies": {
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-reduce-initial/package.json
+++ b/packages/postcss-reduce-initial/package.json
@@ -30,8 +30,10 @@
   "dependencies": {
     "browserslist": "^4.5.6",
     "caniuse-api": "^3.0.0",
-    "has": "^1.0.3",
-    "postcss": "^7.0.16"
+    "has": "^1.0.3"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-reduce-initial/package.json
+++ b/packages/postcss-reduce-initial/package.json
@@ -33,7 +33,7 @@
     "has": "^1.0.3"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-reduce-transforms/package.json
+++ b/packages/postcss-reduce-transforms/package.json
@@ -23,8 +23,10 @@
   "dependencies": {
     "cssnano-utils": "^1.0.0",
     "has": "^1.0.3",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-reduce-transforms/package.json
+++ b/packages/postcss-reduce-transforms/package.json
@@ -26,7 +26,7 @@
     "postcss-value-parser": "^3.3.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-svgo/package.json
+++ b/packages/postcss-svgo/package.json
@@ -31,9 +31,11 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "is-svg": "^4.1.0",
-    "postcss": "^7.0.16",
     "postcss-value-parser": "^3.3.1",
     "svgo": "^1.2.2"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-svgo/package.json
+++ b/packages/postcss-svgo/package.json
@@ -35,7 +35,7 @@
     "svgo": "^1.2.2"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-unique-selectors/package.json
+++ b/packages/postcss-unique-selectors/package.json
@@ -31,7 +31,7 @@
     "uniqs": "^2.0.0"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-unique-selectors/package.json
+++ b/packages/postcss-unique-selectors/package.json
@@ -27,9 +27,11 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "alphanum-sort": "^1.0.2",
-    "postcss": "^7.0.16",
     "postcss-selector-parser": "^6.0.2",
     "uniqs": "^2.0.0"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-zindex/package.json
+++ b/packages/postcss-zindex/package.json
@@ -24,8 +24,10 @@
   "license": "MIT",
   "dependencies": {
     "has": "^1.0.3",
-    "postcss": "^7.0.16",
     "uniqs": "^2.0.0"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "author": {

--- a/packages/postcss-zindex/package.json
+++ b/packages/postcss-zindex/package.json
@@ -27,7 +27,7 @@
     "uniqs": "^2.0.0"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "author": {

--- a/packages/stylehacks/package.json
+++ b/packages/stylehacks/package.json
@@ -35,7 +35,7 @@
     "postcss-selector-parser": "^3.1.1"
   },
   "peerDependencies": {
-    "postcss": "^8.0.5"
+    "postcss": "^8.1.1"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/stylehacks/package.json
+++ b/packages/stylehacks/package.json
@@ -32,8 +32,10 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "browserslist": "^4.6.0",
-    "postcss": "^7.0.16",
     "postcss-selector-parser": "^3.1.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/site/package.json
+++ b/site/package.json
@@ -16,7 +16,7 @@
     "cssnano-preset-advanced": "^4.0.7",
     "cssnano-preset-default": "^4.0.7",
     "cssnano-preset-lite": "^1.0.0",
-    "postcss": "^7.0.16",
+    "postcss": "^8.0.5",
     "prettier": "^2.0.4",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/site/package.json
+++ b/site/package.json
@@ -16,7 +16,7 @@
     "cssnano-preset-advanced": "^4.0.7",
     "cssnano-preset-default": "^4.0.7",
     "cssnano-preset-lite": "^1.0.0",
-    "postcss": "^8.0.5",
+    "postcss": "^8.1.1",
     "prettier": "^2.0.4",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/util/testHelpers.js
+++ b/util/testHelpers.js
@@ -5,7 +5,6 @@ import frameworks from './frameworks';
 
 export function usePostCSSPlugin(plugin) {
   return () => {
-    expect(plugin.postcssVersion).toBeDefined();
     expect(plugin.postcssPlugin).toBeDefined();
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7628,12 +7628,10 @@ postcss-scss@^2.0.0:
   dependencies:
     postcss "^7.0.0"
 
-postcss-simple-vars@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-simple-vars/-/postcss-simple-vars-5.0.2.tgz#e2f81b3d0847ddd4169816b6d141b91d51e6e22e"
-  integrity sha512-xWIufxBoINJv6JiLb7jl5oElgp+6puJwvT5zZHliUSydoLz4DADRB3NDDsYgfKVwojn4TDLiseoC65MuS8oGGg==
-  dependencies:
-    postcss "^7.0.14"
+postcss-simple-vars@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-simple-vars/-/postcss-simple-vars-6.0.0.tgz#7f9c556151753f7b3c0caca2e892b740089e62e8"
+  integrity sha512-zpgSAJfxCXCFkbf0VUJTSFtoOiSor+a/dp+a+hg5q/jbf2vyOGeb69QYzxD1G/HHuFWoBgjiwYg3tzkJFVDuAA==
 
 postcss-value-parser@^3.3.1:
   version "3.3.1"
@@ -7668,7 +7666,7 @@ postcss@^6.0.1:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.18, postcss@^7.0.21:
+postcss@^7.0.0, postcss@^7.0.18, postcss@^7.0.21:
   version "7.0.27"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.27.tgz#cc67cdc6b0daa375105b7c424a85567345fc54d9"
   integrity sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7621,12 +7621,12 @@ postcss-reporter@^1.3.0:
     log-symbols "^1.0.2"
     postcss "^5.0.0"
 
-postcss-scss@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-2.0.0.tgz#248b0a28af77ea7b32b1011aba0f738bda27dea1"
-  integrity sha512-um9zdGKaDZirMm+kZFKKVsnKPF7zF7qBAtIfTSnZXD1jZ0JNZIxdB6TxQOjCnlSzLRInVl2v3YdBh/M881C4ug==
+postcss-scss@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-3.0.2.tgz#b43afd45b49dfeb9f6266a0c7b29faf0941d18bd"
+  integrity sha512-gR31pETUW0nHKbciPh/2CU+HI3phdgT5Zw/9Z2Wq/hX1G54PmydF965Hx8X6ZDldrFgMuQageNJfk00V+U8YRQ==
   dependencies:
-    postcss "^7.0.0"
+    postcss "^8.1.0"
 
 postcss-simple-vars@^6.0.0:
   version "6.0.0"
@@ -7666,7 +7666,7 @@ postcss@^6.0.1:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postcss@^7.0.0, postcss@^7.0.18, postcss@^7.0.21:
+postcss@^7.0.18, postcss@^7.0.21:
   version "7.0.27"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.27.tgz#cc67cdc6b0daa375105b7c424a85567345fc54d9"
   integrity sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==
@@ -7675,7 +7675,7 @@ postcss@^7.0.0, postcss@^7.0.18, postcss@^7.0.21:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^8.1.1:
+postcss@^8.1.0, postcss@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.1.tgz#c3a287dd10e4f6c84cb3791052b96a5d859c9389"
   integrity sha512-9DGLSsjooH3kSNjTZUOt2eIj2ZTW0VI2PZ/3My+8TC7KIbH2OKwUlISfDsf63EP4aiRUt3XkEWMWvyJHvJelEg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7675,10 +7675,10 @@ postcss@^7.0.0, postcss@^7.0.18, postcss@^7.0.21:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^8.0.5:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.0.5.tgz#8210e2363f85c35a88a188ce7a0828e93b1088d4"
-  integrity sha512-3rDm6KR0jHstte3aL3ugrCyFA1UXY90SWNwRZ2WTmRf/QpOqM35mm0FrRR+HHZQ5fY9+nXFat1nl2ekYJf0P4w==
+postcss@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.1.tgz#c3a287dd10e4f6c84cb3791052b96a5d859c9389"
+  integrity sha512-9DGLSsjooH3kSNjTZUOt2eIj2ZTW0VI2PZ/3My+8TC7KIbH2OKwUlISfDsf63EP4aiRUt3XkEWMWvyJHvJelEg==
   dependencies:
     colorette "^1.2.1"
     line-column "^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,6 +3016,11 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+colorette@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
+  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
+
 columnify@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -6166,6 +6171,14 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+line-column@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/line-column/-/line-column-1.0.2.tgz#d25af2936b6f4849172b312e4792d1d987bc34a2"
+  integrity sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=
+  dependencies:
+    isarray "^1.0.0"
+    isobject "^2.0.0"
+
 linkify-it@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
@@ -6777,6 +6790,11 @@ nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
+nanoid@^3.1.12:
+  version "3.1.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
+  integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -7650,7 +7668,7 @@ postcss@^6.0.1:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.18, postcss@^7.0.21:
+postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.18, postcss@^7.0.21:
   version "7.0.27"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.27.tgz#cc67cdc6b0daa375105b7c424a85567345fc54d9"
   integrity sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==
@@ -7658,6 +7676,16 @@ postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.18, postcss@^7.0.
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^8.0.5:
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.0.5.tgz#8210e2363f85c35a88a188ce7a0828e93b1088d4"
+  integrity sha512-3rDm6KR0jHstte3aL3ugrCyFA1UXY90SWNwRZ2WTmRf/QpOqM35mm0FrRR+HHZQ5fY9+nXFat1nl2ekYJf0P4w==
+  dependencies:
+    colorette "^1.2.1"
+    line-column "^1.0.2"
+    nanoid "^3.1.12"
+    source-map "^0.6.1"
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Adding support for new postcss 8 and its new API

#### Status

- [x] dep updates
- [x] test helpers
- [x] site playground
- [x] cssnano core
- [x] postcss-colormin
- [x] postcss-convert-values
- [x] postcss-discard-comments
- [x] postcss-discard-empty
- [x] postcss-discard-duplicates
- [x] postcss-discard-overridden (the test runner needs to be fixed)
- [x] postcss-discard-unused
- [x] postcss-merge-idents
- [x] postcss-merge-longhand
- [x] postcss-merge-rules
  - [x] plugin refactor
  - [x] tests case for `should not crash when node.raws.value is null` not working properly as postcss runner is not able to run the plugin - maybe the postcss is `< 8` there, not sure. error `'true' is not a postcss plugin` when using the `postcss-simple-vars` plugin
- [x] postcss-minify-font-values
- [x] postcss-minify-gradients
- [x] postcss-minify-params
- [x] postcss-minify-selectors
  - [x] the plugin code
  - [x] tests: the `toModules` plugin's visitor keys are not being visited. But the plugin is being called. Need to fix that.
  - [ ] (non-blocker): https://github.com/jonathantneal/postcss-font-magician/issues/91
- [ ] postcss-normalize-charset
- [ ] postcss-normalize-display-values
- [ ] postcss-normalize-positions
- [ ] postcss-normalize-repeat-style
- [ ] postcss-normalize-string
- [ ] postcss-normalize-timing-functions
- [ ] postcss-normalize-unicode
- [ ] postcss-normalize-url
- [ ] postcss-normalize-whitespace
- [ ] postcss-ordered-values
- [ ] postcss-reduced-idents
- [ ] postcss-reduced-initial
- [ ] postcss-reduced-transform
- [ ] postcss-svgo
- [ ] postcss-unique-selectors
- [ ] postcss-zindex
- [ ] stylehacks
- [ ] postcss-calc (external)
  - [ ] it is supported in upstream
  - [ ] need to update dependency in our end
- [ ] css-declaration-sorter (external)
  - [x] it is supported in upstream https://github.com/Siilwyn/css-declaration-sorter/issues/106
  - [ ] need to update dependency in our end
- [ ] autoprefixer (external) 
  - [x] it is supported in upstream
  - [ ] need to update dependency in our end