### PR TITLE
Migrate cssnano-util-raw-cache to PostCSS 8

### DIFF
--- a/packages/cssnano-utils/src/rawCache.js
+++ b/packages/cssnano-utils/src/rawCache.js
@@ -1,19 +1,24 @@
-import { plugin } from 'postcss';
-
-export default plugin('cssnano-util-raw-cache', () => {
-  return (css, result) => {
-    result.root.rawCache = {
-      colon: ':',
-      indent: '',
-      beforeDecl: '',
-      beforeRule: '',
-      beforeOpen: '',
-      beforeClose: '',
-      beforeComment: '',
-      after: '',
-      emptyBody: '',
-      commentLeft: '',
-      commentRight: '',
-    };
+const pluginCreator = () => {
+  return {
+    postcssPlugin: 'cssnano-util-raw-cache',
+    OnceExit(css, { result }) {
+      result.root.rawCache = {
+        colon: ':',
+        indent: '',
+        beforeDecl: '',
+        beforeRule: '',
+        beforeOpen: '',
+        beforeClose: '',
+        beforeComment: '',
+        after: '',
+        emptyBody: '',
+        commentLeft: '',
+        commentRight: '',
+      };
+    },
   };
-});
+};
+
+pluginCreator.postcss = true;
+
+export default pluginCreator;


### PR DESCRIPTION
Currently I'm getting the following warning:

```
  cssnano-util-raw-cache: postcss.plugin was deprecated. Migration guide:
  https://evilmartians.com/chronicles/postcss-8-plugin-migration
```

cc @ludofischer 