### PR TITLE
Fix syntax error in cssnanao.config.js example

### DIFF
--- a/site/docs/config-file.mdx
+++ b/site/docs/config-file.mdx
@@ -67,20 +67,20 @@ These plugins will run after once all presets operations are complete.
   ```js
   // cssnano.config.js
   module.exports = {
-    plugins: [require('autoprefixer')]
+    plugins: [ require('autoprefixer') ]
     
     // or
-    plugins: ['autoprefixer', 'postcss-preset-env']
+    plugins: [ 'autoprefixer', 'postcss-preset-env' ]
     
     // or
     plugins: [ 
-      ['autoprefixer', { remove: false },
+      [ 'autoprefixer', { remove: false } ],
     ]
 
     // or
     plugins: [
       [ require('autoprefixer'), {remove: false} ],
-      [ 'postcss-preset-env']
+      [ 'postcss-preset-env' ]
     ]
   }
   ```


### PR DESCRIPTION
Add a missing bracket. Update the bracket spacing style for clarity and to match the style used by the final, maximally complex example.