### PR TITLE
fix(postcss-svgo): fix processing declaration mixing svg and non svg

### DIFF
--- a/packages/postcss-svgo/src/__tests__/index.js
+++ b/packages/postcss-svgo/src/__tests__/index.js
@@ -198,6 +198,15 @@ test('should warn on SVG containing unclosed tags', async () => {
   expect(result.messages[0].type).toBe('warning');
 });
 
+test('should only warn with svg data uri', async () => {
+  const css = `@font-face {
+  src: url("https://example/dfds.woff2") format("woff2"),
+       url('data:image/svg+xml;charset=utf-8,<svg></svg>') format("svg");
+  }`;
+  const result = await postcss(plugin()).process(css, { from: undefined });
+  expect(result.messages.length).toBe(0);
+});
+
 test(
   'should pass through links to svg files',
   passthroughCSS('h1{background:url(unicorn.svg)}')

--- a/packages/postcss-svgo/src/index.js
+++ b/packages/postcss-svgo/src/index.js
@@ -28,6 +28,9 @@ function minify(decl, opts, postcssResult) {
       svg = Buffer.from(base64String, 'base64').toString('utf8');
       isBase64 = true;
     } else {
+      if (!dataURI.test(value)) {
+        return;
+      }
       let decodedUri;
 
       try {


### PR DESCRIPTION
Close #1040
Skip non-svg data urls even in the case the same declaration
also contains svg. Previously the code assumed declaration only
contained one uri.