### PR TITLE
Move postcss to dependencies

### DIFF
--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -51,7 +51,7 @@
         "autoprefixer": "^10.0.2",
         "postcss": "^8.2.1"
     },
-    "peerDependencies": {
+    "dependencies": {
         "postcss": "^8.2.1"
     }
 }

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -49,7 +49,6 @@
     },
     "devDependencies": {
         "autoprefixer": "^10.0.2",
-        "postcss": "^8.2.1"
     },
     "dependencies": {
         "postcss": "^8.2.1"


### PR DESCRIPTION
When postcss is not installed as a direct dependency in a project, yarn may print a bunch of warnings regarding the missing peer dependency. Move it to an actual dependency to avoid those warnings. The [docs](https://cssnano.co/docs/getting-started#installing-nodejs--npm) do not mention to install `postcss` so I thought it's the best course of action to ensure it's present.

Behaviour with npm v7 is to automatically install peerDependencies so it makes no practical difference whether a module is in dependencies vs. peerDependencies.

<details>
<summary>
Example of said yarn warnings
</summary>

````
warning " > cssnano@5.0.1" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > css-declaration-sorter@6.0.0" has unmet peer dependency "postcss@^8.0.9".
warning "cssnano > cssnano-preset-default > postcss-discard-empty@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-discard-overridden@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-discard-duplicates@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-calc@8.0.0" has unmet peer dependency "postcss@^8.2.2".
warning "cssnano > cssnano-preset-default > postcss-discard-comments@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-convert-values@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-colormin@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-merge-rules@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-merge-longhand@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-minify-font-values@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-minify-gradients@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-normalize-charset@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-minify-selectors@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-minify-params@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-normalize-display-values@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-normalize-repeat-style@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-normalize-positions@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-normalize-timing-functions@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-normalize-unicode@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-normalize-url@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-normalize-whitespace@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-ordered-values@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-reduce-transforms@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-reduce-initial@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-unique-selectors@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-svgo@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-normalize-string@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > postcss-merge-longhand > stylehacks@5.0.0" has unmet peer dependency "postcss@^8.2.1".
warning "cssnano > cssnano-preset-default > cssnano-utils@2.0.0" has unmet peer dependency "postcss@^8.2.1".
````
</details>