### PR TITLE
fix(postcss-merge-longhand): mergeLonghand should not apply to CSS variables

### DIFF
--- a/packages/postcss-merge-longhand/src/__tests__/borders.js
+++ b/packages/postcss-merge-longhand/src/__tests__/borders.js
@@ -1197,6 +1197,13 @@ test(
 );
 
 test(
+  'Should preserve border rule with only custom properties #1051',
+  passthroughCSS(
+    'h1{border-color: var(--a) var(--b) var(--c) var(--d);border-style:solid;border:var(--fooBar));}'
+  )
+);
+
+test(
   'should overwrite some border-width props and save fallbacks and preserve case #648 2',
   processCSS(
     'h1{border-top-width:10px;border-right-width:var(--fooBar);border-right-width:15px;border-bottom-width:var(--fooBar);border-bottom-width:20px;border-left-width:25px;border-top-width:var(--fooBar);border-left-width:var(--fooBar)}',

--- a/packages/postcss-merge-longhand/src/lib/decl/borders.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/borders.js
@@ -55,7 +55,7 @@ function getLevel(prop) {
 const isValueCustomProp = (value) => value && !!~value.search(/var\s*\(\s*--/i);
 
 function canMergeValues(values) {
-  return !values.some(isValueCustomProp) || values.every(isValueCustomProp);
+  return !values.some(isValueCustomProp);
 }
 
 function getColorValue(decl) {


### PR DESCRIPTION

Fixes #1051