### PR TITLE
feat: disable css-declaration-sorter in default preset

### DIFF
--- a/packages/cssnano-preset-advanced/src/__tests__/css-declaration-sorter.js
+++ b/packages/cssnano-preset-advanced/src/__tests__/css-declaration-sorter.js
@@ -98,10 +98,7 @@ test(
 
 test(
   'sort properties inside at-rules, @font-face',
-  processCSS(
-    '@font-face{font-family:a;src:url()}',
-    '@font-face{font-family:a;src:url()}'
-  )
+  passthroughCSS('@font-face{font-family:a;src:url()}p{font-family:a}')
 );
 
 test(

--- a/packages/cssnano-preset-advanced/src/index.js
+++ b/packages/cssnano-preset-advanced/src/index.js
@@ -9,6 +9,10 @@ const defaultOpts = {
   autoprefixer: {
     add: false,
   },
+  cssDeclarationSorter: {
+    exclude: false,
+    keepOverrides: true,
+  },
 };
 
 export default function advancedPreset(opts = {}) {

--- a/packages/cssnano-preset-default/src/__tests__/declaration-order.js
+++ b/packages/cssnano-preset-default/src/__tests__/declaration-order.js
@@ -1,0 +1,14 @@
+import { processCSSWithPresetFactory } from '../../../../util/testHelpers';
+import preset from '..';
+
+const { passthroughCSS } = processCSSWithPresetFactory(preset);
+
+test(
+  'preserve order of border declarations',
+  passthroughCSS('a{border-top:1px solid;border-color:purple}')
+);
+
+test(
+  'preserve order of all declaration',
+  passthroughCSS('button{all:unset;align-items:center}')
+);

--- a/packages/cssnano-preset-default/src/index.js
+++ b/packages/cssnano-preset-default/src/index.js
@@ -50,7 +50,7 @@ const defaultOpts = {
     add: false,
   },
   cssDeclarationSorter: {
-    keepOverrides: true,
+    exclude: true,
   },
 };
 


### PR DESCRIPTION
Could not detect any size reduction with css-declaration-sorter on,
it introduces bugs in certain conditions and it is hard to upgrade
without breaking Node.js 10 compatibility.

Fix #1054

In the test below with `css-size`, it looks like `css-declaration-sorter`_increases_ the gzip size from 22.8kB to 22.9kB

master:
```
node dist/cli.js ../../frameworks/bootstrap-v4.2.1.css
┌────────────┬──────────────┬─────────┬─────────┐
│            │ Uncompressed │ Gzip    │ Brotli  │
├────────────┼──────────────┼─────────┼─────────┤
│ Original   │ 204 kB       │ 25.2 kB │ 18.5 kB │
├────────────┼──────────────┼─────────┼─────────┤
│ Processed  │ 152 kB       │ 22.9 kB │ 17 kB   │
├────────────┼──────────────┼─────────┼─────────┤
│ Difference │ 51.8 kB      │ 2.27 kB │ 1.41 kB │
├────────────┼──────────────┼─────────┼─────────┤
│ Percent    │ 74.57%       │ 90.98%  │ 92.37%  │
└────────────┴──────────────┴─────────┴─────────┘
```

in this PR:
```
node dist/cli.js ../../frameworks/bootstrap-v4.2.1.css
┌────────────┬──────────────┬─────────┬─────────┐
│            │ Uncompressed │ Gzip    │ Brotli  │
├────────────┼──────────────┼─────────┼─────────┤
│ Original   │ 204 kB       │ 25.2 kB │ 18.5 kB │
├────────────┼──────────────┼─────────┼─────────┤
│ Processed  │ 152 kB       │ 22.8 kB │ 17 kB   │
├────────────┼──────────────┼─────────┼─────────┤
│ Difference │ 51.8 kB      │ 2.33 kB │ 1.46 kB │
├────────────┼──────────────┼─────────┼─────────┤
│ Percent    │ 74.57%       │ 90.76%  │ 92.11%  │
└────────────┴──────────────┴─────────┴─────────┘

```