### PR TITLE
Fix destructuring when undefined

### DIFF
--- a/packages/postcss-merge-rules/src/index.js
+++ b/packages/postcss-merge-rules/src/index.js
@@ -100,7 +100,7 @@ function canMerge(ruleA, ruleB, browsers, compatibilityCache) {
   }
 
   const parent = sameParent(ruleA, ruleB);
-  const { name } = ruleA.parent;
+  const name = ruleA.parent && ruleA.parent.name ? ruleA.parent.name : null;
   if (parent && name && ~name.indexOf('keyframes')) {
     return false;
   }


### PR DESCRIPTION
Keep getting the following error, not sure why, can't find anything in my CSS that causes it. Seems build properly with this change below.

```
Module build failed (from ./node_modules/postcss-loader/dist/cjs.js):
TypeError: Cannot destructure property 'name' of 'ruleA.parent' as it is undefined.
    at canMerge (.\node_modules\postcss-merge-rules\dist\index.js:119:5)
    at .\node_modules\postcss-merge-rules\dist\index.js:375:20
    at .\node_modules\postcss\lib\container.js:115:18
    at .\node_modules\postcss\lib\container.js:74:18
    at Root.each (.\node_modules\postcss\lib\container.js:60:16)
    at Root.walk (.\node_modules\postcss\lib\container.js:71:17)
    at Root.walkRules (.\node_modules\postcss\lib\container.js:113:19)
    at OnceExit (.\node_modules\postcss-merge-rules\dist\index.js:433:15)
    at LazyResult.runAsync (.\node_modules\postcss\lib\lazy-result.js:388:19)
    at async Object.loader (.\node_modules\postcss-loader\dist\index.js:87:14)
```