### PR TITLE
postcss-minify-selectors: update selector parser

### DIFF
--- a/packages/cssnano/src/__tests__/postcss-minify-selectors.js
+++ b/packages/cssnano/src/__tests__/postcss-minify-selectors.js
@@ -79,7 +79,7 @@ test(
   'should handle deep combinators',
   processCss(
     'body /deep/ .theme-element{color:#00f}',
-    'body /deep/ .theme-element{color:#00f}'
+    'body/deep/.theme-element{color:#00f}'
   )
 );
 

--- a/packages/postcss-minify-selectors/package.json
+++ b/packages/postcss-minify-selectors/package.json
@@ -30,7 +30,7 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "alphanum-sort": "^1.0.2",
-    "postcss-selector-parser": "^3.1.2"
+    "postcss-selector-parser": "^6.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-minify-selectors/src/__tests__/index.js
+++ b/packages/postcss-minify-selectors/src/__tests__/index.js
@@ -87,7 +87,10 @@ test(
 
 test(
   'should handle deep combinators',
-  passthroughCSS('body /deep/ .theme-element{color:blue}')
+  processCSS(
+    'body /deep/ .theme-element{color:blue}',
+    'body/deep/.theme-element{color:blue}'
+  )
 );
 
 test(

--- a/packages/postcss-minify-selectors/src/index.js
+++ b/packages/postcss-minify-selectors/src/index.js
@@ -1,6 +1,5 @@
 import sort from 'alphanum-sort';
 import parser from 'postcss-selector-parser';
-import unquote from './lib/unquote.js';
 import canUnquote from './lib/canUnquote.js';
 
 const pseudoElements = [
@@ -12,11 +11,12 @@ const pseudoElements = [
 
 function attribute(selector) {
   if (selector.value) {
-    // Join selectors that are split over new lines
-    selector.value = selector.value.replace(/\\\n/g, '').trim();
-
+    if (selector.raws.value) {
+      // Join selectors that are split over new lines
+      selector.raws.value = selector.raws.value.replace(/\\\n/g, '').trim();
+    }
     if (canUnquote(selector.value)) {
-      selector.value = unquote(selector.value);
+      selector.quoteMark = null;
     }
 
     if (selector.operator) {
@@ -24,13 +24,14 @@ function attribute(selector) {
     }
   }
 
-  if (!selector.raws) {
-    selector.raws = {};
-  }
-
-  if (!selector.raws.spaces) {
-    selector.raws.spaces = {};
-  }
+  selector.rawSpaceBefore = '';
+  selector.rawSpaceAfter = '';
+  selector.spaces.attribute = { before: '', after: '' };
+  selector.spaces.operator = { before: '', after: '' };
+  selector.spaces.value = {
+    before: '',
+    after: selector.insensitive ? ' ' : '',
+  };
 
   selector.raws.spaces.attribute = {
     before: '',
@@ -59,7 +60,10 @@ function attribute(selector) {
 
 function combinator(selector) {
   const value = selector.value.trim();
-
+  selector.spaces.before = '';
+  selector.spaces.after = '';
+  selector.rawSpaceBefore = '';
+  selector.rawsSpaceAfter = '';
   selector.value = value.length ? value : ' ';
 }
 

--- a/packages/postcss-minify-selectors/src/lib/canUnquote.js
+++ b/packages/postcss-minify-selectors/src/lib/canUnquote.js
@@ -1,5 +1,3 @@
-import unquote from './unquote.js';
-
 /**
  * Can unquote attribute detection from mothereff.in
  * Copyright Mathias Bynens <https://mathiasbynens.be/>
@@ -10,8 +8,6 @@ const escapes = /\\([0-9A-Fa-f]{1,6})[ \t\n\f\r]?/g;
 const range = /[\u0000-\u002c\u002e\u002f\u003A-\u0040\u005B-\u005E\u0060\u007B-\u009f]/;
 
 export default function canUnquote(value) {
-  value = unquote(value);
-
   if (value === '-' || value === '') {
     return false;
   }

--- a/packages/postcss-minify-selectors/src/lib/unquote.js
+++ b/packages/postcss-minify-selectors/src/lib/unquote.js
@@ -1,1 +1,0 @@
-export default (string) => string.replace(/["']/g, '');

--- a/packages/postcss-minify-selectors/yarn.lock
+++ b/packages/postcss-minify-selectors/yarn.lock
@@ -12,36 +12,23 @@ colorette@^1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
-dot-prop@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
-  integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
-  dependencies:
-    is-obj "^2.0.0"
-
-indexes-of@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
-  integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
-
-is-obj@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
-  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
+cssesc@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 nanoid@^3.1.20:
   version "3.1.20"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
   integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
 
-postcss-selector-parser@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz#b310f5c4c0fdaf76f94902bbaa30db6aa84f5270"
-  integrity sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==
+postcss-selector-parser@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.5.tgz#042d74e137db83e6f294712096cb413f5aa612c4"
+  integrity sha512-aFYPoYmXbZ1V6HZaSvat08M97A8HqO6Pjz+PiNpw/DhuRrC72XWAdp3hL6wusDCN31sSmcZyMGa2hZEuX+Xfhg==
   dependencies:
-    dot-prop "^5.2.0"
-    indexes-of "^1.0.1"
-    uniq "^1.0.1"
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
 postcss@^8.2.1:
   version "8.2.1"
@@ -57,7 +44,7 @@ source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-uniq@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
-  integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=
+util-deprecate@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
Replace the old selector parser release used by `postcss-minify-selectors` so all packages use the new `postcss-selector-parser` 6.0.0 release.

I have tried to follow the postcss-selector parse [API docs](https://github.com/postcss/postcss-selector-parser/blob/master/API.md) but I was forced to operate on raw attribute values since the automatic quotes removal introduced in postcss-selector-parser 4.0 does not seem to work well in some cases (see https://github.com/postcss/postcss-selector-parser/pull/245).  