### PR TITLE
chore: fix the code to generate the integration test fixtures

### DIFF
--- a/util/buildFrameworks.js
+++ b/util/buildFrameworks.js
@@ -2,7 +2,7 @@ import { join } from 'path';
 import glob from 'glob';
 import fs from 'fs-extra';
 import postcss from 'postcss';
-import cssnano from 'lerna:cssnano';
+import cssnano from '../packages/cssnano';
 import frameworks from './frameworks';
 
 function rebuild(pkg) {


### PR DESCRIPTION
Change the import prefix to a relative path (leftover from #1061).