### PR TITLE
fix(postcss-colormin): Get rid of ERR_PACKAGE_PATH_NOT_EXPORTED error

### DIFF
--- a/packages/postcss-colormin/package.json
+++ b/packages/postcss-colormin/package.json
@@ -31,7 +31,7 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "browserslist": "^4.16.0",
-    "colord": "^1.7.0",
+    "colord": "^1.7.2",
     "postcss-value-parser": "^4.1.0"
   },
   "bugs": {

--- a/packages/postcss-colormin/yarn.lock
+++ b/packages/postcss-colormin/yarn.lock
@@ -18,10 +18,10 @@ caniuse-lite@^1.0.30001165:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz#0088bfecc6a14694969e391cc29d7eb6362ca6a7"
   integrity sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA==
 
-colord@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/colord/-/colord-1.7.0.tgz#2d2b3df19ebe81d72e626c5604e8e3e5867bb5d8"
-  integrity sha512-/9I83NehU/HvAKGTSEZrFFEubYHknzGMpSDOee2JBTqk42qbYd+EOKfN22gmh7kysTwdpNfbJGgfUiqGkLul0A==
+colord@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/colord/-/colord-1.7.2.tgz#474f0e46333cb5c7a191dbd571edeee19a5f97b6"
+  integrity sha512-/sQCxy6PEhZbrAn1+NVRRefy3k4jkWQGxk7mo2o0CoNA24jq4ujDc2jXzJ5uXphm/TwfdGOP0w8U+H+9ys4Peg==
 
 colorette@^1.2.1, colorette@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
Fixes #1110

See discussion https://github.com/omgovich/colord/issues/51