### PR TITLE
Publish cssnano 5.0.5

### DIFF
--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-advanced",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "main": "dist/index.js",
   "description": "Advanced optimisations for cssnano; may or may not break your CSS!",
   "scripts": {
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "autoprefixer": "^10.2.0",
-    "cssnano-preset-default": "^5.1.1",
+    "cssnano-preset-default": "^5.1.2",
     "postcss-discard-unused": "^5.0.1",
     "postcss-merge-idents": "^5.0.1",
     "postcss-reduce-idents": "^5.0.1",

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-default",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "main": "dist/index.js",
   "description": "Safe defaults for cssnano which require minimal configuration.",
   "scripts": {
@@ -17,14 +17,14 @@
     "css-declaration-sorter": "^6.0.3",
     "cssnano-utils": "^2.0.1",
     "postcss-calc": "^8.0.0",
-    "postcss-colormin": "^5.1.1",
+    "postcss-colormin": "^5.2.0",
     "postcss-convert-values": "^5.0.1",
     "postcss-discard-comments": "^5.0.1",
     "postcss-discard-duplicates": "^5.0.1",
     "postcss-discard-empty": "^5.0.1",
     "postcss-discard-overridden": "^5.0.1",
     "postcss-merge-longhand": "^5.0.2",
-    "postcss-merge-rules": "^5.0.1",
+    "postcss-merge-rules": "^5.0.2",
     "postcss-minify-font-values": "^5.0.1",
     "postcss-minify-gradients": "^5.0.1",
     "postcss-minify-params": "^5.0.1",
@@ -41,7 +41,7 @@
     "postcss-ordered-values": "^5.0.1",
     "postcss-reduce-initial": "^5.0.1",
     "postcss-reduce-transforms": "^5.0.1",
-    "postcss-svgo": "^5.0.1",
+    "postcss-svgo": "^5.0.2",
     "postcss-unique-selectors": "^5.0.1"
   },
   "author": {

--- a/packages/cssnano/CHANGELOG.md
+++ b/packages/cssnano/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.5] (2021-05-28)
+
+### Bug fixes
+
+* Preserve alpha channel in color minification
+* Check overlaps more exhaustively when merging rules
+* Do not crash when the input CSS contains relative URLs
+
 # [5.0.4] (2021-05-21)
 
 

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cssnano",
-    "version": "5.0.4",
+    "version": "5.0.5",
     "description": "A modular minifier, built on top of the PostCSS ecosystem.",
     "main": "dist/index.js",
     "scripts": {
@@ -25,7 +25,7 @@
     "license": "MIT",
     "dependencies": {
         "cosmiconfig": "^7.0.0",
-        "cssnano-preset-default": "^5.1.1",
+        "cssnano-preset-default": "^5.1.2",
         "is-resolvable": "^1.1.0"
     },
     "homepage": "https://github.com/cssnano/cssnano",

--- a/packages/postcss-colormin/CHANGELOG.md
+++ b/packages/postcss-colormin/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.2.0] (2021-05-28)
+
+### Features
+
+* Output 4 and 8 hex colors if it reduces the output size and the target browsers support it.
+
+### Bug Fixes
+
+* Preserve color alpha precision.
+
 # [5.1.1] (2021-05-21)
 
 

--- a/packages/postcss-colormin/package.json
+++ b/packages/postcss-colormin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-colormin",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "Minify colors in your CSS files with PostCSS.",
   "main": "dist/index.js",
   "files": [

--- a/packages/postcss-merge-rules/CHANGELOG.md
+++ b/packages/postcss-merge-rules/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.0.2](2021-05-28)
+
+### Bug fixes
+
+* Check all intersections when merging rules (https://github.com/cssnano/cssnano/commit/069c4249dc10a71e0fef455bf4ebea17776dbcf2)
+
 ## [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-merge-rules@5.0.0...postcss-merge-rules@5.0.1) (2021-05-19)
 
 

--- a/packages/postcss-merge-rules/package.json
+++ b/packages/postcss-merge-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-merge-rules",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Merge CSS rules with PostCSS.",
   "main": "dist/index.js",
   "files": [

--- a/packages/postcss-svgo/CHANGELOG.md
+++ b/packages/postcss-svgo/CHANGELOG.md
@@ -3,8 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-svgo@5.0.0...postcss-svgo@5.0.1) (2021-05-19)
+## [5.0.2] (2021-05-28)
 
+### Bug fixes
+
+* Prevent crash when input contains relative URL (https://github.com/cssnano/cssnano/commit/0ff1716e4cd69152ad1f98d512fdeb6f311e8ad5) 
+
+## [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-svgo@5.0.0...postcss-svgo@5.0.1) (2021-05-19)
 **Note:** Version bump only for package postcss-svgo
 
 

--- a/packages/postcss-svgo/package.json
+++ b/packages/postcss-svgo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-svgo",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Optimise inline SVG with PostCSS.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Again I've bumped every version and wrote the changelog manually. 

I've tried [changesets](https://github.com/atlassian/changesets/) but I was not happy. Either it did not want to bump cssnano when you bump the single plugins or it would bump everything to the highest version (see [this example in the emotion repo](https://github.com/emotion-js/emotion/commit/3a8eaac14c1d157d0b5bb96597444e05f4c33eb1), where some packages jump from `x.1` to `x.4`)