### PR TITLE
chore(postcss-normalize-url): bump normalize-url dependency to 6.0.1

### DIFF
--- a/packages/postcss-normalize-url/package.json
+++ b/packages/postcss-normalize-url/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "is-absolute-url": "^3.0.3",
-    "normalize-url": "^4.5.0",
+    "normalize-url": "^6.0.1",
     "postcss-value-parser": "^4.1.0"
   },
   "homepage": "https://github.com/cssnano/cssnano",

--- a/packages/postcss-normalize-url/src/index.js
+++ b/packages/postcss-normalize-url/src/index.js
@@ -100,6 +100,7 @@ function pluginCreator(opts) {
       normalizeProtocol: false,
       stripHash: false,
       stripWWW: false,
+      stripTextFragment: false,
     },
     opts
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -7439,12 +7439,12 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
-normalize-url@^4.1.0, normalize-url@^4.5.0:
+normalize-url@^4.1.0:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
   integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
 
-normalize-url@^6.0.1:
+normalize-url@^6.0.0, normalize-url@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.0.1.tgz#a4f27f58cf8c7b287b440b8a8201f42d0b00d256"
   integrity sha512-VU4pzAuh7Kip71XEmO9aNREYAdMHFGTVj/i+CaTImS8x0i1d3jUZkXhqluy/PRgjPLMgsLQulYY3PJ/aSbSjpQ==


### PR DESCRIPTION
* turn off `stripTextFragment` to preserve current behavior

normalize-url changelog
https://github.com/sindresorhus/normalize-url/releases

* the major bump from 4 to 5 is for requiring Node.js 10
* the major bump from 5 to 6 is for adding the `stripTextFragmentOption`