### PR TITLE
Publish cssnano 5.0.6

### DIFF
--- a/packages/cssnano-preset-advanced/CHANGELOG.md
+++ b/packages/cssnano-preset-advanced/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+# [5.1.3] (2021-06-09)
+
+### Bug Fixes
+
+**postcss-normalize-url**: bump normalize-url dependency to 6.0.1 (#1142)
+([b60f54bed](https://github.com/cssnano/cssnano/commit/b60f54bedafe3781ff58f0888ab45ff5c56aee09))
+
+**postcss-ordered-values**: preserve columns count (#1144)
+([9acd6a2fe3e](https://github.com/cssnano/cssnano/commit/9acd6a2fe3e188a5f29fef91cf406495fa74a877))
+
+
 # [5.1.1] (2021-05-21)
 
 

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-advanced",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "main": "dist/index.js",
   "description": "Advanced optimisations for cssnano; may or may not break your CSS!",
   "scripts": {
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "autoprefixer": "^10.2.0",
-    "cssnano-preset-default": "^5.1.2",
+    "cssnano-preset-default": "^5.1.3",
     "postcss-discard-unused": "^5.0.1",
     "postcss-merge-idents": "^5.0.1",
     "postcss-reduce-idents": "^5.0.1",

--- a/packages/cssnano-preset-default/CHANGELOG.md
+++ b/packages/cssnano-preset-default/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+# [5.1.3] (2021-06-09)
+
+### Bug Fixes
+
+**postcss-normalize-url**: bump normalize-url dependency to 6.0.1 (#1142)
+([b60f54bed](https://github.com/cssnano/cssnano/commit/b60f54bedafe3781ff58f0888ab45ff5c56aee09))
+
+**postcss-ordered-values**: preserve columns count (#1144)
+([9acd6a2fe3e](https://github.com/cssnano/cssnano/commit/9acd6a2fe3e188a5f29fef91cf406495fa74a877))
+
+
 # [5.1.1] (2021-05-21)
 
 

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-default",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "main": "dist/index.js",
   "description": "Safe defaults for cssnano which require minimal configuration.",
   "scripts": {
@@ -36,9 +36,9 @@
     "postcss-normalize-string": "^5.0.1",
     "postcss-normalize-timing-functions": "^5.0.1",
     "postcss-normalize-unicode": "^5.0.1",
-    "postcss-normalize-url": "^5.0.1",
+    "postcss-normalize-url": "^5.0.2",
     "postcss-normalize-whitespace": "^5.0.1",
-    "postcss-ordered-values": "^5.0.1",
+    "postcss-ordered-values": "^5.0.2",
     "postcss-reduce-initial": "^5.0.1",
     "postcss-reduce-transforms": "^5.0.1",
     "postcss-svgo": "^5.0.2",

--- a/packages/cssnano/CHANGELOG.md
+++ b/packages/cssnano/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.6] (2021-06-09)
+
+### Bug Fixes
+
+**postcss-normalize-url**: bump normalize-url dependency to 6.0.1 (#1142)
+([b60f54bed](https://github.com/cssnano/cssnano/commit/b60f54bedafe3781ff58f0888ab45ff5c56aee09))
+
+**postcss-ordered-values**: preserve columns count (#1144)
+([9acd6a2fe3e](https://github.com/cssnano/cssnano/commit/9acd6a2fe3e188a5f29fef91cf406495fa74a877))
+
+
 # [5.0.5] (2021-05-28)
 
 ### Bug fixes

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cssnano",
-    "version": "5.0.5",
+    "version": "5.0.6",
     "description": "A modular minifier, built on top of the PostCSS ecosystem.",
     "main": "dist/index.js",
     "scripts": {
@@ -25,7 +25,7 @@
     "license": "MIT",
     "dependencies": {
         "cosmiconfig": "^7.0.0",
-        "cssnano-preset-default": "^5.1.2",
+        "cssnano-preset-default": "^5.1.3",
         "is-resolvable": "^1.1.0"
     },
     "homepage": "https://github.com/cssnano/cssnano",

--- a/packages/postcss-normalize-url/CHANGELOG.md
+++ b/packages/postcss-normalize-url/CHANGELOG.md
@@ -3,7 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-normalize-url@5.0.0...postcss-normalize-url@5.0.1) (2021-05-19)
+# [5.0.2] (2021-06-09)
+
+### Bug fixes
+
+**postcss-normalize-url**: bump normalize-url dependency to 6.0.1 (#1142)
+([b60f54bed](https://github.com/cssnano/cssnano/commit/b60f54bedafe3781ff58f0888ab45ff5c56aee09))
+
+
+
+# [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-normalize-url@5.0.0...postcss-normalize-url@5.0.1) (2021-05-19)
 
 **Note:** Version bump only for package postcss-normalize-url
 

--- a/packages/postcss-normalize-url/package.json
+++ b/packages/postcss-normalize-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-normalize-url",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Normalize URLs with PostCSS",
   "main": "dist/index.js",
   "files": [

--- a/packages/postcss-ordered-values/CHANGELOG.md
+++ b/packages/postcss-ordered-values/CHANGELOG.md
@@ -3,7 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-ordered-values@5.0.0...postcss-ordered-values@5.0.1) (2021-05-19)
+
+# [5.0.2] (2021-06-09)
+
+### Bug fixes
+
+**postcss-ordered-values**: preserve columns count (#1144)
+([9acd6a2fe3e](https://github.com/cssnano/cssnano/commit/9acd6a2fe3e188a5f29fef91cf406495fa74a877))
+
+
+
+
+# [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-ordered-values@5.0.0...postcss-ordered-values@5.0.1) (2021-05-19)
 
 **Note:** Version bump only for package postcss-ordered-values
 

--- a/packages/postcss-ordered-values/package.json
+++ b/packages/postcss-ordered-values/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-ordered-values",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Ensure values are ordered consistently in your CSS.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
I think we should make a release to fix https://github.com/cssnano/cssnano/issues/1123, especially since we might need to soon make another one to stop the [npm audit messages coming from a svgo dependency](https://github.com/svg/svgo/pull/1485).