### PR TITLE
fix(site-playground): add missing error handling to fix WSOD (#991)

### DIFF
--- a/site/src/components/editor/editor.module.css
+++ b/site/src/components/editor/editor.module.css
@@ -40,3 +40,13 @@
   left: 50%;
   z-index: 99;
 }
+
+.inputError {
+  color: #fff;
+  background-color: #bc1515;
+  padding: 0.3em 1em;
+}
+
+.inputError[data-theme='light'] {
+  background-color: #ff5959;
+}

--- a/site/src/components/editor/inputError.js
+++ b/site/src/components/editor/inputError.js
@@ -1,0 +1,14 @@
+import React, { Component } from 'react';
+import styles from './editor.module.css';
+
+class InputError extends Component {
+  render() {
+    return (
+      <div className={styles.inputError} data-theme={this.props.theme}>
+        {this.props.error}
+      </div>
+    );
+  }
+}
+
+export default InputError;


### PR DESCRIPTION
This pull request aims to fix the playground WSOD reported in #991

I found two related issues leading to this behaviour:

1. Uncaught errors thrown by `prettier.format()` when the "Format" button is used.
2. The error object from caught postcss errors when using "Run" were being passed to `setOutput()` in order to output it to the output pane of the playground. Here it was passed in raw as `EditorProps.value` - which expected a string, not an object.

The two cases throws slightly different types of errors. 

On most syntax errors, Prettier throws a `SyntaxError` wrapping some output from `CssSyntaxError` thrown by the css parser - which is quite verbose with numbered line output and such in the message. There are also some edge cases causing Prettier to throw different types of errors.  And the line numbering from the SyntaxError does not correspond to the input lines.

While postcss throws a clean `CssSyntaxError` with good/usable information.

I therefore introduced a simple error handling function which conforms the errors to a short and concise format (using common factors), and outputs it as a red bar right above the code panes. So now the error will for the most part be identical whether one clicks "Run" or "Format"

![Screenshot 2021-06-30 at 09 46 28](https://user-images.githubusercontent.com/6737410/123922221-179ee100-d988-11eb-8feb-a150533f9e5a.png)

This is also more friendly for devices with small screen resolutions, where outputting errors to the output pane would be out of view and could cause confusion (i.e. "nothing happening" when clicking the buttons)

I tried to follow the general style/conventions of the existing code.

Closes #991