### PR TITLE
chore(git): clean up .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,42 @@
-.nyc_output
-coverage
-dist
-lerna-debug.log
+# Package manager
 node_modules
-npm-debug.log
-yarn-error.log
+
+# Build
+dist
 _webpackOutput
 
 # Generated metadata (only the root one is generated!)
-
 /metadata.toml
 
-
-# Phenomic things
-
-*.bundle.js
-
 # Cache
-
+.cache
 .eslintcache
+
+# Testing
+.nyc_output
+coverage
+
+# Env
+.env.local
+.env.*.local
+
+# Logging
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
+# Editor
+.idea
+.vscode
+.history
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# OS generated
+.DS_Store

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,23 +1,6 @@
-# Dependencies
-/node_modules
-
-# Production
+# Build
 /build
 
 # Generated files
 .docusaurus
 .cache-loader
-
-# Misc
-.DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-
-
-.cache


### PR DESCRIPTION
## Description 

This pull request aims to re-organise the projects `.gitignore` to help keep it clean, and to add various common editor generated folders/files to the list. It also removes some redundant lines from the site/docusaurus `.gitignore`, which are covered by the root.

The pattern `*.bundle.js` is also deleted.
_(From what I could gather this was added ~5 years ago for a compiler that is now deprecated and no longer used)_

## Motivation / Context

I generated a `.vscode/launch.json` file for the vscode debugger while working on a PR, and thought it would be practical for developers to avoid having to stash or delete these types of files between commits. So I wanted to suggest adding common ignores for the most popular IDEs. Which seemed like a good opportunity for some housekeeping =)