### PR TITLE
chore(postcss-reduce-initial): fix build command

### DIFF
--- a/packages/postcss-reduce-initial/package.json
+++ b/packages/postcss-reduce-initial/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "acquire": "node ./src/script/acquire.mjs",
     "prebuild": "rimraf dist",
-    "build": "cross-env BABEL_ENV=publish babel src --config-file ../../babel.config.json --out-dir dist --ignore '**/__tests__/,src/acquire.mjs'",
+    "build": "cross-env BABEL_ENV=publish babel src --config-file ../../babel.config.json --out-dir dist --ignore '**/__tests__/,src/script'",
     "prepare": "yarn build"
   },
   "keywords": [


### PR DESCRIPTION
This pull request aims to fix an outdated babel `--ignore` for the `postcss-reduce-initial` acquire script

It was overlooked in #1169