### PR TITLE
Publish cssnano 5.0.7

### DIFF
--- a/packages/cssnano/CHANGELOG.md
+++ b/packages/cssnano/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+# [5.0.7] (2021-07-21)
+
+### Bug fixes
+
+* **cssnano**: reduce dependencies by moving from cosmiconfig to lilconfig (#1168)
+([506a8232](https://github.com/cssnano/cssnano/commit/506a823284191a41752939276f50dbdf75cc8e79))
+
 # [5.0.6] (2021-06-09)
 
 ### Bug Fixes

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cssnano",
-    "version": "5.0.6",
+    "version": "5.0.7",
     "description": "A modular minifier, built on top of the PostCSS ecosystem.",
     "main": "dist/index.js",
     "scripts": {

--- a/site/docs/changelog.md
+++ b/site/docs/changelog.md
@@ -12,6 +12,15 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 
+## \[5.0.7] (2021-07-21)
+
+#### Bug fixes
+
+- **cssnano**: reduce dependencies by moving from cosmiconfig to lilconfig ([#1168](https://github.com/cssnano/cssnano/issues/1168))
+
+([506a8232](https://github.com/cssnano/cssnano/commit/506a823284191a41752939276f50dbdf75cc8e79))
+
+
 ## \[5.0.6] (2021-06-09)
 
 #### Bug Fixes


### PR DESCRIPTION
I'd like to publish a new version of the `cssnano` package so people start using the config loading changes in https://github.com/cssnano/cssnano/pull/1168 , in the unlikely case it breaks something.
