### PR TITLE
chore(postcss-minify-gradients): replace is-color-stop with own code

### DIFF
--- a/packages/postcss-minify-gradients/package.json
+++ b/packages/postcss-minify-gradients/package.json
@@ -27,7 +27,7 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "cssnano-utils": "^2.0.1",
-    "is-color-stop": "^1.1.0",
+    "colord": "^2.6",
     "postcss-value-parser": "^4.1.0"
   },
   "bugs": {

--- a/packages/postcss-minify-gradients/src/__tests__/isColorStop.js
+++ b/packages/postcss-minify-gradients/src/__tests__/isColorStop.js
@@ -1,0 +1,9 @@
+import isColorStop from '../isColorStop.js';
+
+test('should recognise color stops', () => {
+  expect(isColorStop('yellow')).toBe(true);
+  expect(isColorStop('yellow', '12px')).toBe(true);
+  expect(isColorStop('yellow', 'px')).toBe(false);
+  expect(isColorStop('yellow', 'calc(100%)')).toBe(true);
+  expect(isColorStop(undefined)).toBe(false);
+});

--- a/packages/postcss-minify-gradients/src/index.js
+++ b/packages/postcss-minify-gradients/src/index.js
@@ -1,6 +1,6 @@
 import valueParser, { unit, stringify } from 'postcss-value-parser';
 import { getArguments } from 'cssnano-utils';
-import isColorStop from 'is-color-stop';
+import isColorStop from './isColorStop.js';
 
 const angles = {
   top: '0deg',

--- a/packages/postcss-minify-gradients/src/isColorStop.js
+++ b/packages/postcss-minify-gradients/src/isColorStop.js
@@ -1,0 +1,52 @@
+import { unit } from 'postcss-value-parser';
+import { colord, extend } from 'colord';
+import namesPlugin from 'colord/plugins/names';
+
+extend([namesPlugin]);
+
+/* Code derived from https://github.com/pigcan/is-color-stop */
+
+const lengthArray = [
+  'PX',
+  'IN',
+  'CM',
+  'MM',
+  'EM',
+  'REM',
+  'POINTS',
+  'PC',
+  'EX',
+  'CH',
+  'VW',
+  'VH',
+  'VMIN',
+  'VMAX',
+  '%',
+];
+
+function isCSSLengthUnit(input) {
+  return lengthArray.includes(input.toUpperCase());
+}
+
+function isStop(str) {
+  let stop = !str;
+
+  if (!stop) {
+    const node = unit(str);
+    if (node) {
+      if (
+        node.number === 0 ||
+        (!isNaN(node.number) && isCSSLengthUnit(node.unit))
+      ) {
+        stop = true;
+      }
+    } else {
+      stop = /^calc\(\S+\)$/g.test(str);
+    }
+  }
+  return stop;
+}
+
+export default function isColorStop(color, stop) {
+  return colord(color).isValid() && isStop(stop);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3130,7 +3130,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colord@^2.0.1:
+colord@^2.0.1, colord@^2.6:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/colord/-/colord-2.6.0.tgz#6cd716e1270cfff8d6f66e751768749650e209cd"
   integrity sha512-8yMrtE20ZxH1YWvvSoeJFtvqY+GIAOfU+mZ3jx7ZSiEMasnAmNqD1BKUP3CuCWcy/XHgcXkLW6YU8C35nhOYVg==
@@ -3370,11 +3370,6 @@ cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-css-color-names@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
-  integrity sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=
 
 css-color-names@^1.0.1:
   version "1.0.1"
@@ -4711,11 +4706,6 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hex-color-regex@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
-  integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
-
 homedir-polyfill@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
@@ -4734,16 +4724,6 @@ hosted-git-info@^4.0.0, hosted-git-info@^4.0.1:
   integrity sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==
   dependencies:
     lru-cache "^6.0.0"
-
-hsl-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/hsl-regex/-/hsl-regex-1.0.0.tgz#d49330c789ed819e276a4c0d272dffa30b18fe6e"
-  integrity sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=
-
-hsla-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
-  integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
@@ -5059,18 +5039,6 @@ is-ci@^3.0.0:
   integrity sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==
   dependencies:
     ci-info "^3.1.1"
-
-is-color-stop@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-color-stop/-/is-color-stop-1.1.0.tgz#cfff471aee4dd5c9e158598fbe12967b5cdad345"
-  integrity sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=
-  dependencies:
-    css-color-names "^0.0.4"
-    hex-color-regex "^1.1.0"
-    hsl-regex "^1.0.0"
-    hsla-regex "^1.0.0"
-    rgb-regex "^1.0.1"
-    rgba-regex "^1.0.0"
 
 is-core-module@^2.2.0, is-core-module@^2.4.0:
   version "2.5.0"
@@ -8314,16 +8282,6 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
-
-rgb-regex@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/rgb-regex/-/rgb-regex-1.0.1.tgz#c0e0d6882df0e23be254a475e8edd41915feaeb1"
-  integrity sha1-wODWiC3w4jviVKR16O3UGRX+rrE=
-
-rgba-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
-  integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
 rimraf@^2.6.3:
   version "2.7.1"


### PR DESCRIPTION
Get rid of 7 dependencies in a cssnano install.
is-color-stop duplicates functionality available from other dependencies. It copies
unit parsing code directly from postcss-value-parser.
cssnano has color detection logic is already available in colord.

Bringing the code inside might also help #650