### PR TITLE
Update Browserslist to minimum 4.16.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "all-contributors-cli": "^6.20.0",
     "babel-jest": "^27.1.0",
     "babel-plugin-add-module-exports": "^1.0.2",
-    "browserslist": "^4.16.0",
+    "browserslist": "^4.16.5",
     "camelcase": "^6.2.0",
     "chalk": "^4.1.0",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
"browserslist" was updated to 4.16.5 to fix the "Regular Expression Denial of Service" vulnerability
Find more info @ https://www.npmjs.com/advisories/1747