### PR TITLE
chore: update test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node-version: ['10', '12', '14', '16']
+        node-version: ['10', '12', '14', '16', '17']
 
     steps:
       - name: Setup Git


### PR DESCRIPTION
Test on Node.js without increasing the number of tests too much

* test on all supported Node.js versions on MacOS only
* test latest LTS on Linux and Windows
* update codecov action
* use built-in yarn cache functionality