### PR TITLE
fix(postcss-merge-longhand): skip processing if diff not exactly 1

### DIFF
--- a/packages/postcss-merge-longhand/src/__tests__/borders.js
+++ b/packages/postcss-merge-longhand/src/__tests__/borders.js
@@ -1211,6 +1211,23 @@ test(
 );
 
 test(
+  'do not crash',
+  processCSS(
+    `.next-step-arrow[dir='rtl'] .next-step-item:before {
+  border: 16px solid transparent;
+  border-right: 16px solid transparent;
+  border: var(--step-arrow-item-border-width, 16px) solid transparent;
+  border-right-color: transparent;
+}`,
+    `.next-step-arrow[dir='rtl'] .next-step-item:before {
+  border: 16px solid transparent;
+  border-right: 16px solid transparent;
+  border: var(--step-arrow-item-border-width, 16px) solid transparent;
+}`
+  )
+);
+
+test(
   'should overwrite some border-width props and save fallbacks and preserve case #648 2',
   processCSS(
     'h1{border-top-width:10px;border-right-width:var(--fooBar);border-right-width:15px;border-bottom-width:var(--fooBar);border-bottom-width:20px;border-left-width:25px;border-top-width:var(--fooBar);border-left-width:var(--fooBar)}',

--- a/packages/postcss-merge-longhand/src/lib/decl/borders.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/borders.js
@@ -87,7 +87,7 @@ function mergeRedundant({ values, nextValues, decl, nextDecl, index }) {
 
   const diff = diffingProps(values, nextValues);
 
-  if (diff.length > 1) {
+  if (diff.length !== 1) {
     return;
   }
 


### PR DESCRIPTION
Fix #1217

Before we skipped if the diff was larger than 1, this excluded the case where the diff is 0.
Actually if the declarations are identical this part of the code should probably never execute in
the first place, but the issue only triggers with very specific CSS combinations so I could not
find a different fix.