### PR TITLE
Publish cssnano 5.0.10

### DIFF
--- a/packages/cssnano-preset-advanced/CHANGELOG.md
+++ b/packages/cssnano-preset-advanced/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.1.6] (2021-11-05)
+
+### Bug fixes
+
+* **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
+
 # [5.1.5] (2021-11-01)
 
 ### Bug fixes

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-advanced",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "main": "dist/index.js",
   "description": "Advanced optimisations for cssnano; may or may not break your CSS!",
   "scripts": {
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "autoprefixer": "^10.3.7",
-    "cssnano-preset-default": "^5.1.5",
+    "cssnano-preset-default": "^5.1.6",
     "postcss-discard-unused": "^5.0.1",
     "postcss-merge-idents": "^5.0.1",
     "postcss-reduce-idents": "^5.0.1",

--- a/packages/cssnano-preset-default/CHANGELOG.md
+++ b/packages/cssnano-preset-default/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.1.6] (2021-11-05)
+
+### Bug fixes
+
+* **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
+
+
 # [5.1.5] (2021-11-01)
 
 ### Bug fixes

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-default",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "main": "dist/index.js",
   "description": "Safe defaults for cssnano which require minimal configuration.",
   "scripts": {
@@ -23,7 +23,7 @@
     "postcss-discard-duplicates": "^5.0.1",
     "postcss-discard-empty": "^5.0.1",
     "postcss-discard-overridden": "^5.0.1",
-    "postcss-merge-longhand": "^5.0.2",
+    "postcss-merge-longhand": "^5.0.3",
     "postcss-merge-rules": "^5.0.2",
     "postcss-minify-font-values": "^5.0.1",
     "postcss-minify-gradients": "^5.0.3",

--- a/packages/cssnano/CHANGELOG.md
+++ b/packages/cssnano/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 
+# [5.1.10] (2021-11-05)
+
+### Bug fixes
+
+* **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
+
 # [5.0.9] (2021-11-01)
 
 ### Bug fixes

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cssnano",
-    "version": "5.0.9",
+    "version": "5.0.10",
     "description": "A modular minifier, built on top of the PostCSS ecosystem.",
     "main": "dist/index.js",
     "scripts": {
@@ -26,7 +26,7 @@
     "dependencies": {
         "lilconfig": "^2.0.3",
         "yaml": "^1.10.2",
-        "cssnano-preset-default": "^5.1.5",
+        "cssnano-preset-default": "^5.1.6",
         "is-resolvable": "^1.1.0"
     },
     "homepage": "https://github.com/cssnano/cssnano",

--- a/packages/postcss-merge-longhand/CHANGELOG.md
+++ b/packages/postcss-merge-longhand/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.3]
+
+### Bug fixes
+
+* **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
+
 ## [5.0.2](https://github.com/cssnano/cssnano/compare/postcss-merge-longhand@5.0.0...postcss-merge-longhand@5.0.2) (2021-05-19)
 
 

--- a/packages/postcss-merge-longhand/package.json
+++ b/packages/postcss-merge-longhand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-merge-longhand",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Merge longhand properties into shorthand with PostCSS.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Bring out the fix for https://github.com/cssnano/cssnano/issues/1217 since it's a crash.