### PR TITLE
refactor: drop one-liner dependencies

### DIFF
--- a/packages/postcss-merge-rules/package.json
+++ b/packages/postcss-merge-rules/package.json
@@ -30,8 +30,7 @@
     "browserslist": "^4.16.6",
     "caniuse-api": "^3.0.0",
     "cssnano-utils": "^2.0.1",
-    "postcss-selector-parser": "^6.0.5",
-    "vendors": "^1.0.3"
+    "postcss-selector-parser": "^6.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-merge-rules/src/lib/ensureCompatibility.js
+++ b/packages/postcss-merge-rules/src/lib/ensureCompatibility.js
@@ -11,31 +11,15 @@ const cssFirstLine = 'css-first-line';
 const cssInOutOfRange = 'css-in-out-of-range';
 const formValidation = 'form-validation';
 
-/** @type {string[]} */
-const prefixes = [
-  '-ah-',
-  '-apple-',
-  '-atsc-',
-  '-epub-',
-  '-hp-',
-  '-khtml-',
-  '-moz-',
-  '-ms-',
-  '-o-',
-  '-rim-',
-  '-ro-',
-  '-tc-',
-  '-wap-',
-  '-webkit-',
-  '-xv-',
-];
+const vendorPrefix =
+  /-(ah|apple|atsc|epub|hp|khtml|moz|ms|o|rim|ro|tc|wap|webkit|xv)-/;
 
 /**
  * @param {string} selector
  * @return {string[]}
  */
-export function filterPrefixes(selector) {
-  return prefixes.filter((prefix) => selector.indexOf(prefix) !== -1);
+function filterPrefixes(selector) {
+  return selector.match(vendorPrefix);
 }
 
 // Internet Explorer use :-ms-input-placeholder.
@@ -57,7 +41,7 @@ export function sameVendor(selectorsA, selectorsB) {
  * @return {boolean}
  */
 export function noVendor(selector) {
-  return !filterPrefixes(selector).length;
+  return !vendorPrefix.test(selector);
 }
 
 export const pseudoElements = {

--- a/packages/postcss-merge-rules/src/lib/ensureCompatibility.js
+++ b/packages/postcss-merge-rules/src/lib/ensureCompatibility.js
@@ -11,8 +11,7 @@ const cssFirstLine = 'css-first-line';
 const cssInOutOfRange = 'css-in-out-of-range';
 const formValidation = 'form-validation';
 
-const vendorPrefix =
-  /-(ah|apple|atsc|epub|hp|khtml|moz|ms|o|rim|ro|tc|wap|webkit|xv)-/;
+const vendorPrefix = /-([a-z]+)-/i;
 
 /**
  * @param {string} selector

--- a/packages/postcss-merge-rules/src/lib/ensureCompatibility.js
+++ b/packages/postcss-merge-rules/src/lib/ensureCompatibility.js
@@ -11,7 +11,8 @@ const cssFirstLine = 'css-first-line';
 const cssInOutOfRange = 'css-in-out-of-range';
 const formValidation = 'form-validation';
 
-const vendorPrefix = /-([a-z]+)-/i;
+const vendorPrefix =
+  /-(ah|apple|atsc|epub|hp|khtml|moz|ms|o|rim|ro|tc|wap|webkit|xv)-/;
 
 /**
  * @param {string} selector

--- a/packages/postcss-merge-rules/src/lib/ensureCompatibility.js
+++ b/packages/postcss-merge-rules/src/lib/ensureCompatibility.js
@@ -1,6 +1,5 @@
 import { isSupported } from 'caniuse-api';
 import selectorParser from 'postcss-selector-parser';
-import vendors from 'vendors';
 
 const simpleSelectorRe = /^#?[-._a-z0-9 ]+$/i;
 
@@ -13,7 +12,23 @@ const cssInOutOfRange = 'css-in-out-of-range';
 const formValidation = 'form-validation';
 
 /** @type {string[]} */
-const prefixes = vendors.map((v) => `-${v}-`);
+const prefixes = [
+  '-ah-',
+  '-apple-',
+  '-atsc-',
+  '-epub-',
+  '-hp-',
+  '-khtml-',
+  '-moz-',
+  '-ms-',
+  '-o-',
+  '-rim-',
+  '-ro-',
+  '-tc-',
+  '-wap-',
+  '-webkit-',
+  '-xv-',
+];
 
 /**
  * @param {string} selector

--- a/packages/postcss-minify-params/package.json
+++ b/packages/postcss-minify-params/package.json
@@ -25,8 +25,7 @@
     "alphanum-sort": "^1.0.2",
     "browserslist": "^4.16.6",
     "cssnano-utils": "^2.0.1",
-    "postcss-value-parser": "^4.1.0",
-    "uniqs": "^2.0.0"
+    "postcss-value-parser": "^4.1.0"
   },
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/postcss-minify-params/src/index.js
+++ b/packages/postcss-minify-params/src/index.js
@@ -1,7 +1,6 @@
 import browserslist from 'browserslist';
 import valueParser, { stringify } from 'postcss-value-parser';
 import sort from 'alphanum-sort';
-import uniqs from 'uniqs';
 import { getArguments } from 'cssnano-utils';
 
 /**
@@ -26,6 +25,12 @@ function split(args) {
 function removeNode(node) {
   node.value = '';
   node.type = 'word';
+}
+
+function sortAndDedupe(items) {
+  return sort([...new Set(items)], {
+    insensitive: true,
+  }).join();
 }
 
 function transform(legacy, rule) {
@@ -80,9 +85,7 @@ function transform(legacy, rule) {
     }
   }, true);
 
-  rule.params = sort(uniqs(getArguments(params).map(split)), {
-    insensitive: true,
-  }).join();
+  rule.params = sortAndDedupe(getArguments(params).map(split));
 
   if (!rule.params.length) {
     rule.raws.afterName = '';

--- a/packages/postcss-unique-selectors/package.json
+++ b/packages/postcss-unique-selectors/package.json
@@ -27,8 +27,7 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "alphanum-sort": "^1.0.2",
-    "postcss-selector-parser": "^6.0.5",
-    "uniqs": "^2.0.0"
+    "postcss-selector-parser": "^6.0.5"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/postcss-unique-selectors/src/index.js
+++ b/packages/postcss-unique-selectors/src/index.js
@@ -1,5 +1,4 @@
 import sort from 'alphanum-sort';
-import uniqs from 'uniqs';
 import selectorParser from 'postcss-selector-parser';
 
 function parseSelectors(selectors, callback) {
@@ -7,7 +6,9 @@ function parseSelectors(selectors, callback) {
 }
 
 function unique(rule) {
-  rule.selector = sort(uniqs(rule.selectors), { insensitive: true }).join();
+  rule.selector = sort([...new Set(rule.selectors)], {
+    insensitive: true,
+  }).join();
 }
 
 function pluginCreator() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8124,11 +8124,6 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
   integrity sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==
 
-uniqs@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02"
-  integrity sha1-/+3ks2slKQaW5uFl1KWe25mOawI=
-
 unique-filename@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8216,11 +8216,6 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-vendors@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.4.tgz#e2b800a53e7a29b93506c3cf41100d16c4c4ad8e"
-  integrity sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==
-
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"


### PR DESCRIPTION
After the recent vulnerability disclosures, I've looked at whether we could further reduce cssnano deps. 
1. we can remove uniqs as it's a one-liner.  The Set method should work on Nodejs 8+ and according to the measurements I have found online it is not slower than array filtering
2. we can remove vendors as it is [a single array](https://github.com/wooorm/vendors/blob/main/index.js) we only use once and it has not changed in the last 5 years, except that the latest release has become ESM-only