### PR TITLE
test(postss-normalize-url): test that it preserves paths in parameters

### DIFF
--- a/packages/postcss-normalize-url/src/__tests__/index.js
+++ b/packages/postcss-normalize-url/src/__tests__/index.js
@@ -276,6 +276,13 @@ test(
 );
 
 test(
+  'should preserve paths in parameters',
+  passthroughCSS(
+    'background: url("https://ss0.example.com/70cFuh_Q1Yn/it/u=5088,2842&fm=26&gp=0.jpg?imageView2/1/w/750/h/1334")'
+  )
+);
+
+test(
   "should pass through when it doesn't find a url function",
   passthroughCSS('h1{color:black;font-weight:bold}')
 );


### PR DESCRIPTION
Close #843
Close #812

Add a test to check for slashes in URL parameters.
No need for code changes as the normalize-url updates seem to have
fixed the issue.