### PR TITLE
Release cssnano 5.0.11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ To create a changeset run
 
 ```
 yarn changeset
-``` 
+```
 
 It's best to select the affected packages by hand rather than rely on the tools automatically
 discovering dependencies. For example, if a change affects a plugin `cssnano-preset-default`,
@@ -75,9 +75,15 @@ yarn changeset version
 ```
 
 To publish release to npm, run:
+
 ```
-yarn changeset publish from-package
+yarn all-publish
 ```
+
+If you don't use the `package.json` script, do not forget to rebuild the packages first!
+
+1. `yarn prepare`
+2. `yarn changeset publish`
 
 ## Are there other ways of contributing?
 
@@ -91,7 +97,6 @@ help us by opening an issue detailing the problem.
 
 Use the [documentation label][documentation] to find relevant issues.
 
-
 ### Improve our issues
 
 Issues are like a secondary means of documenting the project, and in cases where
@@ -101,7 +106,6 @@ the original author to find out more details about their problem.
 Once the source of the error has been found, you can be of further help by
 submitting a failing test case as a pull request. Many of our tests follow a
 simple `fixture` & `expected` string comparison pattern.
-
 
 ### Send feedback on issues
 
@@ -113,7 +117,6 @@ Note that we don't find "+1" comments to be very helpful; instead, use GitHub
 reactions and subscribe to the thread to be notified of any progress. This helps
 to keep our discourse focused on the topic at hand.
 
-
 ### Review pull requests
 
 It's really important to get more eyes on upcoming features and fixes. Please
@@ -121,13 +124,11 @@ help by reviewing pull requests; even leaving a thumbs up reaction is better
 than nothing at all. Helping us to review means less time is wasted by all of
 us if a buggy release is cut.
 
-
 ### Talk with us!
 
 We have an [online chat][chat] where you can ask questions or discuss features;
 help us by joining the chat, and answer any questions that the community may
 have. Feel free to ask any questions of your own!
-
 
 ## How you can support us
 
@@ -136,7 +137,6 @@ help us out by starring the repository, or [follow us on Twitter][twitter].
 Word of mouth really does mean a lot to us!
 
 You can also [help support us financially](/docs/support-us/).
-
 
 [chat]: https://gitter.im/postcss/postcss
 [documentation]: https://github.com/cssnano/cssnano/labels/documentation

--- a/example-cli-usage/CHANGELOG.md
+++ b/example-cli-usage/CHANGELOG.md
@@ -66,7 +66,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
+* migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 
 ### BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:only": "cross-env BABEL_ENV=test jest",
     "test:coverage": "cross-env BABEL_ENV=test jest --coverage",
     "test": "yarn test:coverage",
-    "deploy": "cd site && GIT_USER=anikethsaha yarn deploy"
+    "all-publish": "yarn prepare && yarn changeset publish"
   },
   "workspaces": [
     "./packages/*"

--- a/packages/css-size/CHANGELOG.md
+++ b/packages/css-size/CHANGELOG.md
@@ -7,70 +7,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package css-size
 
-
-
-
-
 ## [5.0.2](https://github.com/cssnano/cssnano/compare/css-size@5.0.0...css-size@5.0.2) (2021-04-26)
 
 **Note:** Version bump only for package css-size
-
-
-
-
 
 ## [5.0.1](https://github.com/cssnano/cssnano/compare/css-size@5.0.0...css-size@5.0.1) (2021-04-13)
 
 **Note:** Version bump only for package css-size
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/css-size@5.0.0-rc.2...css-size@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package css-size
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/css-size@5.0.0-rc.1...css-size@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package css-size
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/css-size@5.0.0-rc.0...css-size@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package css-size
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* file was missing in css-size package.json. ([1d10335](https://github.com/cssnano/cssnano/commit/1d103352a5b7986afe820e374d426d965c7cdc51))
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
-
+- file was missing in css-size package.json. ([1d10335](https://github.com/cssnano/cssnano/commit/1d103352a5b7986afe820e374d426d965c7cdc51))
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13

--- a/packages/cssnano-preset-advanced/CHANGELOG.md
+++ b/packages/cssnano-preset-advanced/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+# 5.1.7 (2021-11-16)
+
+### Bug fixes
+
+- c38f14c3ce3d0b: **postcss-normalize-url**: avoid changing parameter encoding
+
+### Chore
+- 31d5c07dc07a4: refactor: drop one-liner dependencies
+- 07172825ffbb4f4: **postcss-merge-longhand**: drop css-color-names dependency
 
 # 5.1.6 (2021-11-05)
 

--- a/packages/cssnano-preset-advanced/CHANGELOG.md
+++ b/packages/cssnano-preset-advanced/CHANGELOG.md
@@ -3,36 +3,35 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.1.6] (2021-11-05)
+# 5.1.6 (2021-11-05)
 
 ### Bug fixes
 
-* **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
+- **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
 
-# [5.1.5] (2021-11-01)
+# 5.1.5 (2021-11-01)
 
 ### Bug fixes
 
-* **cssnano-preset-advanced:** update autoprefixer ([#1213](https://github.com/cssnano/cssnano/pull/1213)) ([f19932](https://github.com/cssnano/cssnano/commit/f199323a8368546d9632112d381419930106e384))
+- **cssnano-preset-advanced:** update autoprefixer ([#1213](https://github.com/cssnano/cssnano/pull/1213)) ([f19932](https://github.com/cssnano/cssnano/commit/f199323a8368546d9632112d381419930106e384))
 
-* **postcss-svgo:** normalize SVG with escaped quote characters ([#1200](https://github.com/cssnano/cssnano/pull/1200)) ([4ef5e41](https://github.com/cssnano/cssnano/commit/4ef5e41a6c61a23094001da82a76321ca746b22f))
+- **postcss-svgo:** normalize SVG with escaped quote characters ([#1200](https://github.com/cssnano/cssnano/pull/1200)) ([4ef5e41](https://github.com/cssnano/cssnano/commit/4ef5e41a6c61a23094001da82a76321ca746b22f))
 
-* **postcss-convert-values:** preserve percentage-only properties ([#1212](https://github.com/cssnano/cssnano/pull/1212)) ([8f3453](https://github.com/cssnano/cssnano/commit/8f345385b210cf85e9d591382d387f76ca4b0f64))
+- **postcss-convert-values:** preserve percentage-only properties ([#1212](https://github.com/cssnano/cssnano/pull/1212)) ([8f3453](https://github.com/cssnano/cssnano/commit/8f345385b210cf85e9d591382d387f76ca4b0f64))
 
-* **postcss-minify-gradients:** handle 2 color-stop-length in linear gradient ([#1215](https://github.com/cssnano/cssnano/pull/1215)) ([8bb7ba6c](https://github.com/cssnano/cssnano/commit/8bb7ba6c1733fd12122589169d847b1a1212a6b5))
+- **postcss-minify-gradients:** handle 2 color-stop-length in linear gradient ([#1215](https://github.com/cssnano/cssnano/pull/1215)) ([8bb7ba6c](https://github.com/cssnano/cssnano/commit/8bb7ba6c1733fd12122589169d847b1a1212a6b5))
 
 ### Chore
 
-* **postcss-colormin:** use colord plugin for color minification ([#1207](https://github.com/cssnano/cssnano/pull/1207)) ([3dbaa04](https://github.com/cssnano/cssnano/commit/3dbaa04addfa2f18375262377e172b03819dc2c0))
+- **postcss-colormin:** use colord plugin for color minification ([#1207](https://github.com/cssnano/cssnano/pull/1207)) ([3dbaa04](https://github.com/cssnano/cssnano/commit/3dbaa04addfa2f18375262377e172b03819dc2c0))
 
-
-# [5.1.4] (2021-08-18)
+# 5.1.4 (2021-08-18)
 
 ## Chore
 
-* **postcss-minify-gradients:** remove extra dependencies ([#1181](https://github.com/cssnano/cssnano/pull/1181)) ([50eb53](https://github.com/cssnano/cssnano/commit/50eb53e63b6eaae598ae4e51d02255ec8dcc9c8f))
+- **postcss-minify-gradients:** remove extra dependencies ([#1181](https://github.com/cssnano/cssnano/pull/1181)) ([50eb53](https://github.com/cssnano/cssnano/commit/50eb53e63b6eaae598ae4e51d02255ec8dcc9c8f))
 
-# [5.1.3] (2021-06-09)
+# 5.1.3 (2021-06-09)
 
 ### Bug Fixes
 
@@ -42,132 +41,85 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **postcss-ordered-values**: preserve columns count (#1144)
 ([9acd6a2fe3e](https://github.com/cssnano/cssnano/commit/9acd6a2fe3e188a5f29fef91cf406495fa74a877))
 
-
-# [5.1.1] (2021-05-21)
-
+# 5.1.1 (2021-05-21)
 
 ### Bug Fixes
 
-* **postcss-colormin:** Strict color parsing ([#1122](https://github.com/cssnano/cssnano/issues/1122)) ([32771da](https://github.com/cssnano/cssnano/commit/32771da46ee94f07a6907ec47701189f90ad2ec0))
-* **postcss-colormin:** fix ERR_PACKAGE_PATH_NOT_EXPORTED ([#1110](https://github.com/cssnano/cssnano/issues/1110)) ([8a31ca38796](https://github.com/cssnano/cssnano/commit/8a31ca38796e12e6fe52620cf8a545cb058fe295))
-
+- **postcss-colormin:** Strict color parsing ([#1122](https://github.com/cssnano/cssnano/issues/1122)) ([32771da](https://github.com/cssnano/cssnano/commit/32771da46ee94f07a6907ec47701189f90ad2ec0))
+- **postcss-colormin:** fix ERR_PACKAGE_PATH_NOT_EXPORTED ([#1110](https://github.com/cssnano/cssnano/issues/1110)) ([8a31ca38796](https://github.com/cssnano/cssnano/commit/8a31ca38796e12e6fe52620cf8a545cb058fe295))
 
 # [5.1.0](https://github.com/cssnano/cssnano/compare/cssnano-preset-advanced@5.0.0...cssnano-preset-advanced@5.1.0) (2021-05-19)
 
-
 ### Bug Fixes
 
-* **postcss-merge-rules:** add some missing known pseudo classes. ([#1099](https://github.com/cssnano/cssnano/issues/1099)) ([4d7fe36](https://github.com/cssnano/cssnano/commit/4d7fe367bebab86c7b5664ed4621ee7586ca7d86))
-* **postcss-merge-rules:** prevent breaking rule merges ([#1072](https://github.com/cssnano/cssnano/issues/1072)) ([c5e0a5e](https://github.com/cssnano/cssnano/commit/c5e0a5eac171089ae994fcba21d9c565fb462577)), closes [#999](https://github.com/cssnano/cssnano/issues/999)
-
+- **postcss-merge-rules:** add some missing known pseudo classes. ([#1099](https://github.com/cssnano/cssnano/issues/1099)) ([4d7fe36](https://github.com/cssnano/cssnano/commit/4d7fe367bebab86c7b5664ed4621ee7586ca7d86))
+- **postcss-merge-rules:** prevent breaking rule merges ([#1072](https://github.com/cssnano/cssnano/issues/1072)) ([c5e0a5e](https://github.com/cssnano/cssnano/commit/c5e0a5eac171089ae994fcba21d9c565fb462577)), closes [#999](https://github.com/cssnano/cssnano/issues/999)
 
 ### Features
 
-* **postcss-colormin:** switch to colord and solve multiple issues ([#1107](https://github.com/cssnano/cssnano/issues/1107)) ([a7f0be4](https://github.com/cssnano/cssnano/commit/a7f0be4acc640aab89cace53a720b3d59b6f7b4f)), closes [#819](https://github.com/cssnano/cssnano/issues/819) [#1042](https://github.com/cssnano/cssnano/issues/1042) [#819](https://github.com/cssnano/cssnano/issues/819) [#771](https://github.com/cssnano/cssnano/issues/771)
-
-
-
-
+- **postcss-colormin:** switch to colord and solve multiple issues ([#1107](https://github.com/cssnano/cssnano/issues/1107)) ([a7f0be4](https://github.com/cssnano/cssnano/commit/a7f0be4acc640aab89cace53a720b3d59b6f7b4f)), closes [#819](https://github.com/cssnano/cssnano/issues/819) [#1042](https://github.com/cssnano/cssnano/issues/1042) [#819](https://github.com/cssnano/cssnano/issues/819) [#771](https://github.com/cssnano/cssnano/issues/771)
 
 ## [5.0.1](https://github.com/cssnano/cssnano/compare/cssnano-preset-advanced@5.0.0...cssnano-preset-advanced@5.0.1) (2021-04-26)
 
 **Note:** Version bump only for package cssnano-preset-advanced
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/cssnano-preset-advanced@5.0.0-rc.2...cssnano-preset-advanced@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package cssnano-preset-advanced
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/cssnano-preset-advanced@5.0.0-rc.1...cssnano-preset-advanced@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package cssnano-preset-advanced
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/cssnano-preset-advanced@5.0.0-rc.0...cssnano-preset-advanced@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package cssnano-preset-advanced
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-convert-values:** prevent zero units from being dropped in line-height. ([#801](https://github.com/cssnano/cssnano/issues/801)) ([d781855](https://github.com/cssnano/cssnano/commit/d78185567ae5ebcde0469cf0e55145a7a3130d3e))
-* **postcss-merge-rules:** don't change specificity of prefixed properties ([#723](https://github.com/cssnano/cssnano/issues/723)) ([863cf2b](https://github.com/cssnano/cssnano/commit/863cf2b3470d3172523a3165dc368abcfa18809c))
-* **postcss-normalize-positions:** correct optimize math (`calc` and etc) and variable functions (`var` and `env`) ([#750](https://github.com/cssnano/cssnano/issues/750)) ([a81e8df](https://github.com/cssnano/cssnano/commit/a81e8dfc1ad26067d5a9efab8081072cd4b15c44))
-
+- **postcss-convert-values:** prevent zero units from being dropped in line-height. ([#801](https://github.com/cssnano/cssnano/issues/801)) ([d781855](https://github.com/cssnano/cssnano/commit/d78185567ae5ebcde0469cf0e55145a7a3130d3e))
+- **postcss-merge-rules:** don't change specificity of prefixed properties ([#723](https://github.com/cssnano/cssnano/issues/723)) ([863cf2b](https://github.com/cssnano/cssnano/commit/863cf2b3470d3172523a3165dc368abcfa18809c))
+- **postcss-normalize-positions:** correct optimize math (`calc` and etc) and variable functions (`var` and `env`) ([#750](https://github.com/cssnano/cssnano/issues/750)) ([a81e8df](https://github.com/cssnano/cssnano/commit/a81e8dfc1ad26067d5a9efab8081072cd4b15c44))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* css declaration sorter ([#855](https://github.com/cssnano/cssnano/issues/855)) ([613d562](https://github.com/cssnano/cssnano/commit/613d562ae79e7e169c80b523b7c2c9b0093bc1d8))
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-* **postcss-merge-rules:** merge at-rules ([#722](https://github.com/cssnano/cssnano/issues/722)) ([8d4610a](https://github.com/cssnano/cssnano/commit/8d4610a6391ddab29bcb08ef0522d0b7ce2d6582))
-
+- css declaration sorter ([#855](https://github.com/cssnano/cssnano/issues/855)) ([613d562](https://github.com/cssnano/cssnano/commit/613d562ae79e7e169c80b523b7c2c9b0093bc1d8))
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
+- **postcss-merge-rules:** merge at-rules ([#722](https://github.com/cssnano/cssnano/issues/722)) ([8d4610a](https://github.com/cssnano/cssnano/commit/8d4610a6391ddab29bcb08ef0522d0b7ce2d6582))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
-
 ## 4.1.7 (2018-10-22)
-
-
 
 ## 4.1.6 (2018-10-22)
 
-
-
 ## 4.1.5 (2018-10-17)
-
-
 
 ## 4.1.4 (2018-09-27)
 
-
-
 ## 4.1.3 (2018-09-25)
-
-
 
 ## 4.1.2 (2018-09-25)
 
-
-
 ## 4.1.1 (2018-09-24)
-
 
 ### Bug Fixes
 
-* parse error with iPhone X feature ([#614](https://github.com/cssnano/cssnano/issues/614)) ([a3704a7](https://github.com/cssnano/cssnano/commit/a3704a76a631b1cd907ab0c0a8637a622769676d))
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
-* **postcss-merge-longhand:** Should not mangle borders ([#579](https://github.com/cssnano/cssnano/issues/579)) ([#583](https://github.com/cssnano/cssnano/issues/583)) ([4d3b3f8](https://github.com/cssnano/cssnano/commit/4d3b3f8fa5a389329989b13f85f3523e56c81435))
-
+- parse error with iPhone X feature ([#614](https://github.com/cssnano/cssnano/issues/614)) ([a3704a7](https://github.com/cssnano/cssnano/commit/a3704a76a631b1cd907ab0c0a8637a622769676d))
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** Should not mangle borders ([#579](https://github.com/cssnano/cssnano/issues/579)) ([#583](https://github.com/cssnano/cssnano/issues/583)) ([4d3b3f8](https://github.com/cssnano/cssnano/commit/4d3b3f8fa5a389329989b13f85f3523e56c81435))
 
 ### Features
 
-* **postcss-ordered-values:** support ordering animation values ([#574](https://github.com/cssnano/cssnano/issues/574)) ([17ec039](https://github.com/cssnano/cssnano/commit/17ec039dfbe7f596df12f5d5889bf3e6cd32afd6))
+- **postcss-ordered-values:** support ordering animation values ([#574](https://github.com/cssnano/cssnano/issues/574)) ([17ec039](https://github.com/cssnano/cssnano/commit/17ec039dfbe7f596df12f5d5889bf3e6cd32afd6))

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-advanced",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "main": "dist/index.js",
   "description": "Advanced optimisations for cssnano; may or may not break your CSS!",
   "scripts": {
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "autoprefixer": "^10.3.7",
-    "cssnano-preset-default": "^5.1.6",
+    "cssnano-preset-default": "^5.1.7",
     "postcss-discard-unused": "^5.0.1",
     "postcss-merge-idents": "^5.0.1",
     "postcss-reduce-idents": "^5.0.1",

--- a/packages/cssnano-preset-default/CHANGELOG.md
+++ b/packages/cssnano-preset-default/CHANGELOG.md
@@ -3,36 +3,33 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.1.6] (2021-11-05)
+# 5.1.6 (2021-11-05)
 
 ### Bug fixes
 
-* **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
+- **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
 
-
-# [5.1.5] (2021-11-01)
+# 5.1.5 (2021-11-01)
 
 ### Bug fixes
 
-* **postcss-svgo:** normalize SVG with escaped quote characters ([#1200](https://github.com/cssnano/cssnano/pull/1200)) ([4ef5e41](https://github.com/cssnano/cssnano/commit/4ef5e41a6c61a23094001da82a76321ca746b22f))
+- **postcss-svgo:** normalize SVG with escaped quote characters ([#1200](https://github.com/cssnano/cssnano/pull/1200)) ([4ef5e41](https://github.com/cssnano/cssnano/commit/4ef5e41a6c61a23094001da82a76321ca746b22f))
 
-* **postcss-convert-values:** preserve percentage-only properties ([#1212](https://github.com/cssnano/cssnano/pull/1212)) ([8f3453](https://github.com/cssnano/cssnano/commit/8f345385b210cf85e9d591382d387f76ca4b0f64))
+- **postcss-convert-values:** preserve percentage-only properties ([#1212](https://github.com/cssnano/cssnano/pull/1212)) ([8f3453](https://github.com/cssnano/cssnano/commit/8f345385b210cf85e9d591382d387f76ca4b0f64))
 
-* **postcss-minify-gradients:** handle 2 color-stop-length in linear gradient ([#1215](https://github.com/cssnano/cssnano/pull/1215)) ([8bb7ba6c](https://github.com/cssnano/cssnano/commit/8bb7ba6c1733fd12122589169d847b1a1212a6b5))
+- **postcss-minify-gradients:** handle 2 color-stop-length in linear gradient ([#1215](https://github.com/cssnano/cssnano/pull/1215)) ([8bb7ba6c](https://github.com/cssnano/cssnano/commit/8bb7ba6c1733fd12122589169d847b1a1212a6b5))
 
 ### Chore
 
-* **postcss-colormin:** use colord plugin for color minification ([#1207](https://github.com/cssnano/cssnano/pull/1207)) ([3dbaa04](https://github.com/cssnano/cssnano/commit/3dbaa04addfa2f18375262377e172b03819dc2c0))
+- **postcss-colormin:** use colord plugin for color minification ([#1207](https://github.com/cssnano/cssnano/pull/1207)) ([3dbaa04](https://github.com/cssnano/cssnano/commit/3dbaa04addfa2f18375262377e172b03819dc2c0))
 
-
-# [5.1.4] (2021-08-18)
+# 5.1.4 (2021-08-18)
 
 ## Chore
 
-* **postcss-minify-gradients:** remove extra dependencies ([#1181](https://github.com/cssnano/cssnano/pull/1181)) ([50eb53](https://github.com/cssnano/cssnano/commit/50eb53e63b6eaae598ae4e51d02255ec8dcc9c8f))
+- **postcss-minify-gradients:** remove extra dependencies ([#1181](https://github.com/cssnano/cssnano/pull/1181)) ([50eb53](https://github.com/cssnano/cssnano/commit/50eb53e63b6eaae598ae4e51d02255ec8dcc9c8f))
 
-
-# [5.1.3] (2021-06-09)
+# 5.1.3 (2021-06-09)
 
 ### Bug Fixes
 
@@ -42,129 +39,84 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **postcss-ordered-values**: preserve columns count (#1144)
 ([9acd6a2fe3e](https://github.com/cssnano/cssnano/commit/9acd6a2fe3e188a5f29fef91cf406495fa74a877))
 
-
-# [5.1.1] (2021-05-21)
-
+# 5.1.1 (2021-05-21)
 
 ### Bug Fixes
 
-* **postcss-colormin:** Strict color parsing ([#1122](https://github.com/cssnano/cssnano/issues/1122)) ([32771da](https://github.com/cssnano/cssnano/commit/32771da46ee94f07a6907ec47701189f90ad2ec0))
-* **postcss-colormin:** fix ERR_PACKAGE_PATH_NOT_EXPORTED ([#1110](https://github.com/cssnano/cssnano/issues/1110)) ([8a31ca38796](https://github.com/cssnano/cssnano/commit/8a31ca38796e12e6fe52620cf8a545cb058fe295))
-
+- **postcss-colormin:** Strict color parsing ([#1122](https://github.com/cssnano/cssnano/issues/1122)) ([32771da](https://github.com/cssnano/cssnano/commit/32771da46ee94f07a6907ec47701189f90ad2ec0))
+- **postcss-colormin:** fix ERR_PACKAGE_PATH_NOT_EXPORTED ([#1110](https://github.com/cssnano/cssnano/issues/1110)) ([8a31ca38796](https://github.com/cssnano/cssnano/commit/8a31ca38796e12e6fe52620cf8a545cb058fe295))
 
 # [5.1.0](https://github.com/cssnano/cssnano/compare/cssnano-preset-default@5.0.0...cssnano-preset-default@5.1.0) (2021-05-19)
 
-
 ### Bug Fixes
 
-* **postcss-merge-rules:** add some missing known pseudo classes. ([#1099](https://github.com/cssnano/cssnano/issues/1099)) ([4d7fe36](https://github.com/cssnano/cssnano/commit/4d7fe367bebab86c7b5664ed4621ee7586ca7d86))
-* **postcss-merge-rules:** prevent breaking rule merges ([#1072](https://github.com/cssnano/cssnano/issues/1072)) ([c5e0a5e](https://github.com/cssnano/cssnano/commit/c5e0a5eac171089ae994fcba21d9c565fb462577)), closes [#999](https://github.com/cssnano/cssnano/issues/999)
-
+- **postcss-merge-rules:** add some missing known pseudo classes. ([#1099](https://github.com/cssnano/cssnano/issues/1099)) ([4d7fe36](https://github.com/cssnano/cssnano/commit/4d7fe367bebab86c7b5664ed4621ee7586ca7d86))
+- **postcss-merge-rules:** prevent breaking rule merges ([#1072](https://github.com/cssnano/cssnano/issues/1072)) ([c5e0a5e](https://github.com/cssnano/cssnano/commit/c5e0a5eac171089ae994fcba21d9c565fb462577)), closes [#999](https://github.com/cssnano/cssnano/issues/999)
 
 ### Features
 
-* **postcss-colormin:** switch to colord and solve multiple issues ([#1107](https://github.com/cssnano/cssnano/issues/1107)) ([a7f0be4](https://github.com/cssnano/cssnano/commit/a7f0be4acc640aab89cace53a720b3d59b6f7b4f)), closes [#819](https://github.com/cssnano/cssnano/issues/819) [#1042](https://github.com/cssnano/cssnano/issues/1042) [#819](https://github.com/cssnano/cssnano/issues/819) [#771](https://github.com/cssnano/cssnano/issues/771)
-
-
-
-
+- **postcss-colormin:** switch to colord and solve multiple issues ([#1107](https://github.com/cssnano/cssnano/issues/1107)) ([a7f0be4](https://github.com/cssnano/cssnano/commit/a7f0be4acc640aab89cace53a720b3d59b6f7b4f)), closes [#819](https://github.com/cssnano/cssnano/issues/819) [#1042](https://github.com/cssnano/cssnano/issues/1042) [#819](https://github.com/cssnano/cssnano/issues/819) [#771](https://github.com/cssnano/cssnano/issues/771)
 
 ## [5.0.1](https://github.com/cssnano/cssnano/compare/cssnano-preset-default@5.0.0...cssnano-preset-default@5.0.1) (2021-04-26)
 
 **Note:** Version bump only for package cssnano-preset-default
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/cssnano-preset-default@5.0.0-rc.2...cssnano-preset-default@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package cssnano-preset-default
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/cssnano-preset-default@5.0.0-rc.1...cssnano-preset-default@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package cssnano-preset-default
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/cssnano-preset-default@5.0.0-rc.0...cssnano-preset-default@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package cssnano-preset-default
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-convert-values:** prevent zero units from being dropped in line-height. ([#801](https://github.com/cssnano/cssnano/issues/801)) ([d781855](https://github.com/cssnano/cssnano/commit/d78185567ae5ebcde0469cf0e55145a7a3130d3e))
-* **postcss-merge-rules:** don't change specificity of prefixed properties ([#723](https://github.com/cssnano/cssnano/issues/723)) ([863cf2b](https://github.com/cssnano/cssnano/commit/863cf2b3470d3172523a3165dc368abcfa18809c))
-* **postcss-normalize-positions:** correct optimize math (`calc` and etc) and variable functions (`var` and `env`) ([#750](https://github.com/cssnano/cssnano/issues/750)) ([a81e8df](https://github.com/cssnano/cssnano/commit/a81e8dfc1ad26067d5a9efab8081072cd4b15c44))
-
+- **postcss-convert-values:** prevent zero units from being dropped in line-height. ([#801](https://github.com/cssnano/cssnano/issues/801)) ([d781855](https://github.com/cssnano/cssnano/commit/d78185567ae5ebcde0469cf0e55145a7a3130d3e))
+- **postcss-merge-rules:** don't change specificity of prefixed properties ([#723](https://github.com/cssnano/cssnano/issues/723)) ([863cf2b](https://github.com/cssnano/cssnano/commit/863cf2b3470d3172523a3165dc368abcfa18809c))
+- **postcss-normalize-positions:** correct optimize math (`calc` and etc) and variable functions (`var` and `env`) ([#750](https://github.com/cssnano/cssnano/issues/750)) ([a81e8df](https://github.com/cssnano/cssnano/commit/a81e8dfc1ad26067d5a9efab8081072cd4b15c44))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* css declaration sorter ([#855](https://github.com/cssnano/cssnano/issues/855)) ([613d562](https://github.com/cssnano/cssnano/commit/613d562ae79e7e169c80b523b7c2c9b0093bc1d8))
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-* **postcss-merge-rules:** merge at-rules ([#722](https://github.com/cssnano/cssnano/issues/722)) ([8d4610a](https://github.com/cssnano/cssnano/commit/8d4610a6391ddab29bcb08ef0522d0b7ce2d6582))
-* **postcss-ordered-values:** compress more vendor properties ([#746](https://github.com/cssnano/cssnano/issues/746)) ([b479440](https://github.com/cssnano/cssnano/commit/b4794404bffa54558654b215eb550e6adb98e144))
-
+- css declaration sorter ([#855](https://github.com/cssnano/cssnano/issues/855)) ([613d562](https://github.com/cssnano/cssnano/commit/613d562ae79e7e169c80b523b7c2c9b0093bc1d8))
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
+- **postcss-merge-rules:** merge at-rules ([#722](https://github.com/cssnano/cssnano/issues/722)) ([8d4610a](https://github.com/cssnano/cssnano/commit/8d4610a6391ddab29bcb08ef0522d0b7ce2d6582))
+- **postcss-ordered-values:** compress more vendor properties ([#746](https://github.com/cssnano/cssnano/issues/746)) ([b479440](https://github.com/cssnano/cssnano/commit/b4794404bffa54558654b215eb550e6adb98e144))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
-
 ## 4.1.7 (2018-10-22)
-
-
 
 ## 4.1.6 (2018-10-22)
 
-
-
 ## 4.1.5 (2018-10-17)
-
-
 
 ## 4.1.4 (2018-09-27)
 
-
-
 ## 4.1.2 (2018-09-25)
-
-
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* parse error with iPhone X feature ([#614](https://github.com/cssnano/cssnano/issues/614)) ([a3704a7](https://github.com/cssnano/cssnano/commit/a3704a76a631b1cd907ab0c0a8637a622769676d))
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
-* **postcss-merge-longhand:** Should not mangle borders ([#579](https://github.com/cssnano/cssnano/issues/579)) ([#583](https://github.com/cssnano/cssnano/issues/583)) ([4d3b3f8](https://github.com/cssnano/cssnano/commit/4d3b3f8fa5a389329989b13f85f3523e56c81435))
-
+- parse error with iPhone X feature ([#614](https://github.com/cssnano/cssnano/issues/614)) ([a3704a7](https://github.com/cssnano/cssnano/commit/a3704a76a631b1cd907ab0c0a8637a622769676d))
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** Should not mangle borders ([#579](https://github.com/cssnano/cssnano/issues/579)) ([#583](https://github.com/cssnano/cssnano/issues/583)) ([4d3b3f8](https://github.com/cssnano/cssnano/commit/4d3b3f8fa5a389329989b13f85f3523e56c81435))
 
 ### Features
 
-* **postcss-ordered-values:** support ordering animation values ([#574](https://github.com/cssnano/cssnano/issues/574)) ([17ec039](https://github.com/cssnano/cssnano/commit/17ec039dfbe7f596df12f5d5889bf3e6cd32afd6))
+- **postcss-ordered-values:** support ordering animation values ([#574](https://github.com/cssnano/cssnano/issues/574)) ([17ec039](https://github.com/cssnano/cssnano/commit/17ec039dfbe7f596df12f5d5889bf3e6cd32afd6))

--- a/packages/cssnano-preset-default/CHANGELOG.md
+++ b/packages/cssnano-preset-default/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+# 5.1.7 (2021-11-16)
+
+### Bug fixes
+
+- c38f14c3ce3d0b: **postcss-normalize-url**: avoid changing parameter encoding
+
+### Chore
+
+- 31d5c07dc07a4: refactor: drop one-liner dependencies
+- 07172825ffbb4f4: **postcss-merge-longhand**: drop css-color-names dependency
 
 # 5.1.6 (2021-11-05)
 

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-default",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "main": "dist/index.js",
   "description": "Safe defaults for cssnano which require minimal configuration.",
   "scripts": {
@@ -23,11 +23,11 @@
     "postcss-discard-duplicates": "^5.0.1",
     "postcss-discard-empty": "^5.0.1",
     "postcss-discard-overridden": "^5.0.1",
-    "postcss-merge-longhand": "^5.0.3",
-    "postcss-merge-rules": "^5.0.2",
+    "postcss-merge-longhand": "^5.0.4",
+    "postcss-merge-rules": "^5.0.3",
     "postcss-minify-font-values": "^5.0.1",
     "postcss-minify-gradients": "^5.0.3",
-    "postcss-minify-params": "^5.0.1",
+    "postcss-minify-params": "^5.0.2",
     "postcss-minify-selectors": "^5.1.0",
     "postcss-normalize-charset": "^5.0.1",
     "postcss-normalize-display-values": "^5.0.1",
@@ -36,13 +36,13 @@
     "postcss-normalize-string": "^5.0.1",
     "postcss-normalize-timing-functions": "^5.0.1",
     "postcss-normalize-unicode": "^5.0.1",
-    "postcss-normalize-url": "^5.0.2",
+    "postcss-normalize-url": "^5.0.3",
     "postcss-normalize-whitespace": "^5.0.1",
     "postcss-ordered-values": "^5.0.2",
     "postcss-reduce-initial": "^5.0.1",
     "postcss-reduce-transforms": "^5.0.1",
     "postcss-svgo": "^5.0.3",
-    "postcss-unique-selectors": "^5.0.1"
+    "postcss-unique-selectors": "^5.0.2"
   },
   "author": {
     "name": "Ben Briggs",

--- a/packages/cssnano-preset-lite/CHANGELOG.md
+++ b/packages/cssnano-preset-lite/CHANGELOG.md
@@ -7,42 +7,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package cssnano-preset-lite
 
-
-
-
-
 # [2.0.0](https://github.com/cssnano/cssnano/compare/cssnano-preset-lite@2.0.0-rc.2...cssnano-preset-lite@2.0.0) (2021-04-06)
 
 **Note:** Version bump only for package cssnano-preset-lite
-
-
-
-
 
 # [2.0.0-rc.2](https://github.com/cssnano/cssnano/compare/cssnano-preset-lite@2.0.0-rc.1...cssnano-preset-lite@2.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package cssnano-preset-lite
 
-
-
-
-
 # [2.0.0-rc.1](https://github.com/cssnano/cssnano/compare/cssnano-preset-lite@2.0.0-rc.0...cssnano-preset-lite@2.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package cssnano-preset-lite
 
-
-
-
-
 # 2.0.0-rc.0 (2021-02-19)
-
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
+- minimum supported `postcss` version is `8.2.1`

--- a/packages/cssnano-utils/CHANGELOG.md
+++ b/packages/cssnano-utils/CHANGELOG.md
@@ -7,45 +7,26 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package cssnano-utils
 
-
-
-
-
 # [2.0.0](https://github.com/cssnano/cssnano/compare/cssnano-utils@2.0.0-rc.2...cssnano-utils@2.0.0) (2021-04-06)
 
 **Note:** Version bump only for package cssnano-utils
-
-
-
-
 
 # [2.0.0-rc.2](https://github.com/cssnano/cssnano/compare/cssnano-utils@2.0.0-rc.1...cssnano-utils@2.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package cssnano-utils
 
-
-
-
-
 # [2.0.0-rc.1](https://github.com/cssnano/cssnano/compare/cssnano-utils@2.0.0-rc.0...cssnano-utils@2.0.0-rc.1) (2021-03-04)
-
 
 ### Bug Fixes
 
-* **cssnano-utils:** get rid of deprecation warning ([752a270](https://github.com/cssnano/cssnano/commit/752a2701085f45367a1e4a558fb9ec768ac760af))
-
-
-
-
+- **cssnano-utils:** get rid of deprecation warning ([752a270](https://github.com/cssnano/cssnano/commit/752a2701085f45367a1e4a558fb9ec768ac760af))
 
 # 2.0.0-rc.0 (2021-02-19)
 
-
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
+- minimum supported `postcss` version is `8.2.1`

--- a/packages/cssnano/CHANGELOG.md
+++ b/packages/cssnano/CHANGELOG.md
@@ -3,45 +3,42 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-
-# [5.1.10] (2021-11-05)
-
-### Bug fixes
-
-* **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
-
-# [5.0.9] (2021-11-01)
+# 5.1.10 (2021-11-05)
 
 ### Bug fixes
 
-* **postcss-svgo:** normalize SVG with escaped quote characters ([#1200](https://github.com/cssnano/cssnano/pull/1200)) ([4ef5e41](https://github.com/cssnano/cssnano/commit/4ef5e41a6c61a23094001da82a76321ca746b22f))
+- **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
 
-* **postcss-convert-values:** preserve percentage-only properties ([#1212](https://github.com/cssnano/cssnano/pull/1212)) ([8f3453](https://github.com/cssnano/cssnano/commit/8f345385b210cf85e9d591382d387f76ca4b0f64))
+# 5.0.9 (2021-11-01)
 
-* **postcss-minify-gradients:** handle 2 color-stop-length in linear gradient ([#1215](https://github.com/cssnano/cssnano/pull/1215)) ([8bb7ba6c](https://github.com/cssnano/cssnano/commit/8bb7ba6c1733fd12122589169d847b1a1212a6b5))
+### Bug fixes
 
-* **cssnano-preset-advanced:** update autoprefixer ([#1213](https://github.com/cssnano/cssnano/pull/1213)) ([f19932](https://github.com/cssnano/cssnano/commit/f199323a8368546d9632112d381419930106e384))
+- **postcss-svgo:** normalize SVG with escaped quote characters ([#1200](https://github.com/cssnano/cssnano/pull/1200)) ([4ef5e41](https://github.com/cssnano/cssnano/commit/4ef5e41a6c61a23094001da82a76321ca746b22f))
+
+- **postcss-convert-values:** preserve percentage-only properties ([#1212](https://github.com/cssnano/cssnano/pull/1212)) ([8f3453](https://github.com/cssnano/cssnano/commit/8f345385b210cf85e9d591382d387f76ca4b0f64))
+
+- **postcss-minify-gradients:** handle 2 color-stop-length in linear gradient ([#1215](https://github.com/cssnano/cssnano/pull/1215)) ([8bb7ba6c](https://github.com/cssnano/cssnano/commit/8bb7ba6c1733fd12122589169d847b1a1212a6b5))
+
+- **cssnano-preset-advanced:** update autoprefixer ([#1213](https://github.com/cssnano/cssnano/pull/1213)) ([f19932](https://github.com/cssnano/cssnano/commit/f199323a8368546d9632112d381419930106e384))
 
 ### Chore
 
-* **postcss-colormin:** use colord plugin for color minification ([#1207](https://github.com/cssnano/cssnano/pull/1207)) ([3dbaa04](https://github.com/cssnano/cssnano/commit/3dbaa04addfa2f18375262377e172b03819dc2c0))
+- **postcss-colormin:** use colord plugin for color minification ([#1207](https://github.com/cssnano/cssnano/pull/1207)) ([3dbaa04](https://github.com/cssnano/cssnano/commit/3dbaa04addfa2f18375262377e172b03819dc2c0))
 
-
-# [5.0.8] (2021-08-18)
+# 5.0.8 (2021-08-18)
 
 ## Chore
 
-* **postcss-minify-gradients:** remove extra dependencies ([#1181](https://github.com/cssnano/cssnano/pull/1181)) ([50eb53](https://github.com/cssnano/cssnano/commit/50eb53e63b6eaae598ae4e51d02255ec8dcc9c8f))
+- **postcss-minify-gradients:** remove extra dependencies ([#1181](https://github.com/cssnano/cssnano/pull/1181)) ([50eb53](https://github.com/cssnano/cssnano/commit/50eb53e63b6eaae598ae4e51d02255ec8dcc9c8f))
 
-
-# [5.0.7] (2021-07-21)
+# 5.0.7 (2021-07-21)
 
 ### Bug fixes
 
-* **cssnano**: reduce dependencies by moving from cosmiconfig to lilconfig (#1168)
-([506a8232](https://github.com/cssnano/cssnano/commit/506a823284191a41752939276f50dbdf75cc8e79))
+- **cssnano**: reduce dependencies by moving from cosmiconfig to lilconfig (#1168)
+  ([506a8232](https://github.com/cssnano/cssnano/commit/506a823284191a41752939276f50dbdf75cc8e79))
 
-# [5.0.6] (2021-06-09)
+# 5.0.6 (2021-06-09)
 
 ### Bug Fixes
 
@@ -51,397 +48,329 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **postcss-ordered-values**: preserve columns count (#1144)
 ([9acd6a2fe3e](https://github.com/cssnano/cssnano/commit/9acd6a2fe3e188a5f29fef91cf406495fa74a877))
 
-
-# [5.0.5] (2021-05-28)
+# 5.0.5 (2021-05-28)
 
 ### Bug fixes
 
-* Preserve alpha channel in color minification
-* Check overlaps more exhaustively when merging rules
-* Do not crash when the input CSS contains relative URLs
+- Preserve alpha channel in color minification
+- Check overlaps more exhaustively when merging rules
+- Do not crash when the input CSS contains relative URLs
 
-# [5.0.4] (2021-05-21)
-
+# 5.0.4 (2021-05-21)
 
 ### Bug Fixes
 
-* **postcss-colormin:** Strict color parsing ([#1122](https://github.com/cssnano/cssnano/issues/1122)) ([32771da](https://github.com/cssnano/cssnano/commit/32771da46ee94f07a6907ec47701189f90ad2ec0))
-* **postcss-colormin:** fix ERR_PACKAGE_PATH_NOT_EXPORTED ([#1110](https://github.com/cssnano/cssnano/issues/1110)) ([8a31ca38796](https://github.com/cssnano/cssnano/commit/8a31ca38796e12e6fe52620cf8a545cb058fe295))
+- **postcss-colormin:** Strict color parsing ([#1122](https://github.com/cssnano/cssnano/issues/1122)) ([32771da](https://github.com/cssnano/cssnano/commit/32771da46ee94f07a6907ec47701189f90ad2ec0))
+- **postcss-colormin:** fix ERR_PACKAGE_PATH_NOT_EXPORTED ([#1110](https://github.com/cssnano/cssnano/issues/1110)) ([8a31ca38796](https://github.com/cssnano/cssnano/commit/8a31ca38796e12e6fe52620cf8a545cb058fe295))
 
 ## [5.0.3](https://github.com/cssnano/cssnano/compare/cssnano@5.0.0...cssnano@5.0.3) (2021-05-19)
 
-
 ### Bug Fixes
 
-* **cssnano:** many bug fixes in dependent packages. Most notably fixed buggy reordering of border declarations and improved color value minification. See the changelogs for the single presets and plugins for details.
-
-
-
-
+- **cssnano:** many bug fixes in dependent packages. Most notably fixed buggy reordering of border declarations and improved color value minification. See the changelogs for the single presets and plugins for details.
 
 ## [5.0.2](https://github.com/cssnano/cssnano/compare/cssnano@5.0.0...cssnano@5.0.2) (2021-04-26)
 
-
 ### Bug Fixes
 
-* **cssnano:** replace opencollective with funding field. ([#1047](https://github.com/cssnano/cssnano/issues/1047)) ([3dee7c5](https://github.com/cssnano/cssnano/commit/3dee7c553350e43ad0750a9478a63cf897e5510f)), closes [#1046](https://github.com/cssnano/cssnano/issues/1046)
-
-
-
-
+- **cssnano:** replace opencollective with funding field. ([#1047](https://github.com/cssnano/cssnano/issues/1047)) ([3dee7c5](https://github.com/cssnano/cssnano/commit/3dee7c553350e43ad0750a9478a63cf897e5510f)), closes [#1046](https://github.com/cssnano/cssnano/issues/1046)
 
 ## [5.0.1](https://github.com/cssnano/cssnano/compare/cssnano@5.0.0...cssnano@5.0.1) (2021-04-13)
 
-
 ### Bug Fixes
 
-* **cssnano:** replace opencollective with funding field. ([#1047](https://github.com/cssnano/cssnano/issues/1047)) ([3dee7c5](https://github.com/cssnano/cssnano/commit/3dee7c553350e43ad0750a9478a63cf897e5510f)), closes [#1046](https://github.com/cssnano/cssnano/issues/1046)
-
-
-
-
+- **cssnano:** replace opencollective with funding field. ([#1047](https://github.com/cssnano/cssnano/issues/1047)) ([3dee7c5](https://github.com/cssnano/cssnano/commit/3dee7c553350e43ad0750a9478a63cf897e5510f)), closes [#1046](https://github.com/cssnano/cssnano/issues/1046)
 
 # [5.0.0](https://github.com/cssnano/cssnano/compare/cssnano@5.0.0-rc.2...cssnano@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package cssnano
 
-
-
-
-
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/cssnano@5.0.0-rc.1...cssnano@5.0.0-rc.2) (2021-03-15)
-
 
 ### Bug Fixes
 
-* update SVGO ([aa07cfd](https://github.com/cssnano/cssnano/commit/aa07cfd62c82ed4b1e87219eea8d0ed99635e4ca))
-
-
-
-
+- update SVGO ([aa07cfd](https://github.com/cssnano/cssnano/commit/aa07cfd62c82ed4b1e87219eea8d0ed99635e4ca))
 
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/cssnano@5.0.0-rc.0...cssnano@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package cssnano
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-ordered-values:** columns transform returning string instead of the AST ([#928](https://github.com/cssnano/cssnano/issues/928)) ([a5d6d36](https://github.com/cssnano/cssnano/commit/a5d6d364e0815ecb198a95de301f3554ccce4f78))
-* **unique-selector:** removed sorting and involving selector comments ([#857](https://github.com/cssnano/cssnano/issues/857)) ([3fa875d](https://github.com/cssnano/cssnano/commit/3fa875dade2138e1a531dce1f8b79814cb39dbc9))
-
+- **postcss-ordered-values:** columns transform returning string instead of the AST ([#928](https://github.com/cssnano/cssnano/issues/928)) ([a5d6d36](https://github.com/cssnano/cssnano/commit/a5d6d364e0815ecb198a95de301f3554ccce4f78))
+- **unique-selector:** removed sorting and involving selector comments ([#857](https://github.com/cssnano/cssnano/issues/857)) ([3fa875d](https://github.com/cssnano/cssnano/commit/3fa875dade2138e1a531dce1f8b79814cb39dbc9))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* css declaration sorter ([#855](https://github.com/cssnano/cssnano/issues/855)) ([613d562](https://github.com/cssnano/cssnano/commit/613d562ae79e7e169c80b523b7c2c9b0093bc1d8))
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-* **postcss-reduce-transforms:** improve optimizations ([#745](https://github.com/cssnano/cssnano/issues/745)) ([b0f0d89](https://github.com/cssnano/cssnano/commit/b0f0d892316d7b77e8033a6dc8d67745043a5072))
-
+- css declaration sorter ([#855](https://github.com/cssnano/cssnano/issues/855)) ([613d562](https://github.com/cssnano/cssnano/commit/613d562ae79e7e169c80b523b7c2c9b0093bc1d8))
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
+- **postcss-reduce-transforms:** improve optimizations ([#745](https://github.com/cssnano/cssnano/issues/745)) ([b0f0d89](https://github.com/cssnano/cssnano/commit/b0f0d892316d7b77e8033a6dc8d67745043a5072))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.10 (2019-02-14)
 
-
-
 ## 4.1.9 (2019-02-12)
-
 
 ### Bug Fixes
 
-* initial loading time ([#654](https://github.com/cssnano/cssnano/issues/654)) ([de2ef07](https://github.com/cssnano/cssnano/commit/de2ef074a0c7da94c22a5b0336e6c4ca2a94f1b5))
-
-
+- initial loading time ([#654](https://github.com/cssnano/cssnano/issues/654)) ([de2ef07](https://github.com/cssnano/cssnano/commit/de2ef074a0c7da94c22a5b0336e6c4ca2a94f1b5))
 
 ## 4.1.7 (2018-10-22)
 
-
-
 ## 4.1.6 (2018-10-22)
-
-
 
 ## 4.1.5 (2018-10-17)
 
-
 ### Bug Fixes
 
-* toggling of plugins in presets using boolean configuration option ([#622](https://github.com/cssnano/cssnano/issues/622)) ([15076f1](https://github.com/cssnano/cssnano/commit/15076f145118507e010722cc9ed548ffe1b91f8c))
-
-
+- toggling of plugins in presets using boolean configuration option ([#622](https://github.com/cssnano/cssnano/issues/622)) ([15076f1](https://github.com/cssnano/cssnano/commit/15076f145118507e010722cc9ed548ffe1b91f8c))
 
 ## 4.1.4 (2018-09-27)
 
-
-
 ## 4.1.3 (2018-09-25)
-
-
 
 ## 4.1.2 (2018-09-25)
 
-
-
 ## 4.1.1 (2018-09-24)
-
 
 ### Bug Fixes
 
-* parse error with iPhone X feature ([#614](https://github.com/cssnano/cssnano/issues/614)) ([a3704a7](https://github.com/cssnano/cssnano/commit/a3704a76a631b1cd907ab0c0a8637a622769676d))
-
-
+- parse error with iPhone X feature ([#614](https://github.com/cssnano/cssnano/issues/614)) ([a3704a7](https://github.com/cssnano/cssnano/commit/a3704a76a631b1cd907ab0c0a8637a622769676d))
 
 # 4.1.0 (2018-08-24)
 
-
-
 ## 4.0.5 (2018-07-30)
-
-
 
 ## 4.0.4 (2018-07-25)
 
-
-
 ## 4.0.3 (2018-07-18)
-
 
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
-
-
-
-
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
 
 # 4.1.10
 
 ## Bug Fixes
 
-* `stylehacks` does not throw error on `[attr]` selector
+- `stylehacks` does not throw error on `[attr]` selector
 
 # 4.1.9
 
 ## Performance Improvements
 
-* `postcss-colormin`: increase performance
-* `postcss-discard-comments`: increase performance
-* `postcss-merge-rules` increase performance
-* `postcss-minify-params` increase performance
-* `postcss-minify-selectors`: increase performance
-* `postcss-normalize-display-values`: increase performance 
-* `postcss-normalize-positions`: increase performance
-* `postcss-normalize-repeat-style`: increase performance
-* `postcss-normalize-string`: increase performance
-* `postcss-normalize-timing-functions`: increase performance
-* `postcss-normalize-whitespace`: increase performance
-* `postcss-ordered-values`: increase performance
-* `postcss-reduce-transforms`: increase performance
-* `postcss-svgo`: increase performance
+- `postcss-colormin`: increase performance
+- `postcss-discard-comments`: increase performance
+- `postcss-merge-rules` increase performance
+- `postcss-minify-params` increase performance
+- `postcss-minify-selectors`: increase performance
+- `postcss-normalize-display-values`: increase performance
+- `postcss-normalize-positions`: increase performance
+- `postcss-normalize-repeat-style`: increase performance
+- `postcss-normalize-string`: increase performance
+- `postcss-normalize-timing-functions`: increase performance
+- `postcss-normalize-whitespace`: increase performance
+- `postcss-ordered-values`: increase performance
+- `postcss-reduce-transforms`: increase performance
+- `postcss-svgo`: increase performance
 
 ## Bug Fixes
 
-* `postcss-merge-longhand` handle uppercase properties and values
-* `postcss-minify-gradients` handle uppercase properties and values
-* `postcss-minify-params` do break `@page` rules
-* `postcss-reduce-idents` handle uppercase at-rules
-* `postcss-reduce-initial` now uses `repeat` as initial value for `mask-repeat`
-* `postcss-reduce-initial` handle uppercase value when you convert to initial
-* `stylehacks` handle uppercase properties and values
+- `postcss-merge-longhand` handle uppercase properties and values
+- `postcss-minify-gradients` handle uppercase properties and values
+- `postcss-minify-params` do break `@page` rules
+- `postcss-reduce-idents` handle uppercase at-rules
+- `postcss-reduce-initial` now uses `repeat` as initial value for `mask-repeat`
+- `postcss-reduce-initial` handle uppercase value when you convert to initial
+- `stylehacks` handle uppercase properties and values
 
 # 4.1.8
 
 ## Performance Improvements
 
-* initial loading time (`require('cssnano')`).
+- initial loading time (`require('cssnano')`).
 
 ## Bug Fixes
 
-* `postcss-merge-longhand` correctly merging border properties with custom properties.
+- `postcss-merge-longhand` correctly merging border properties with custom properties.
 
 # 4.1.7
 
 ## Bug Fixes
 
-* republish `cssnano` due broken release.
+- republish `cssnano` due broken release.
 
 # 4.1.6
 
 ## Bug Fixes
 
-* `postcss-merge-longhand` doesn't throw error when merge a border property.
+- `postcss-merge-longhand` doesn't throw error when merge a border property.
 
 # 4.1.5
 
 ## Bug Fixes
 
-* `cssnano` now allow to toggling of plugins in presets using boolean configuration option.
-* `postcss-merge-longhand` doesn't merge properties with `unset`.
-* `postcss-merge-longhand` correctly merge borders with custom properties.
-* `postcss-merge-longhand` doesn't merge redundant values if declarations are of different importance.
+- `cssnano` now allow to toggling of plugins in presets using boolean configuration option.
+- `postcss-merge-longhand` doesn't merge properties with `unset`.
+- `postcss-merge-longhand` correctly merge borders with custom properties.
+- `postcss-merge-longhand` doesn't merge redundant values if declarations are of different importance.
 
 ## Other changes
 
-* `postcss-calc` updated to `7.0.0` version.
+- `postcss-calc` updated to `7.0.0` version.
 
 # 4.1.4
 
 ## Other changes
 
-* `css-declaration-sorter` now use PostCSS 7.
-* `postcss-calc` now use PostCSS 7.
+- `css-declaration-sorter` now use PostCSS 7.
+- `postcss-calc` now use PostCSS 7.
 
 # 4.1.3
 
 ## Other changes
 
-* `postcss-minify-font-values` now use PostCSS 7.
-* `postcss-discard-duplicates` now use PostCSS 7.
+- `postcss-minify-font-values` now use PostCSS 7.
+- `postcss-discard-duplicates` now use PostCSS 7.
 
 # 4.1.2
 
 ## Bug Fixes
 
-* `postcss-svgo` now handle DataURI with uppercase `data` value (`DATA:image/*;...`).
+- `postcss-svgo` now handle DataURI with uppercase `data` value (`DATA:image/*;...`).
 
 # 4.1.1
 
 ## Bug Fixes
 
-* `css-declaration-sorter` was removed from default prevent.
-* `postcss-normalize-timing-functions` doesn't lowercased property anymore.
-* `postcss-normalize-positons` now handles uppercase properties.
-* `postcss-normalize-url` now is case-insensitive.
-* `postcss-merge-idents` now is case-insensitive.
-* `postcss-merge-rules` now is case-insensitive.
-* `postcss-minify-selectors` now is case-insensitive.
-* `postcss-minify-font-values` now is case-insensitive.
-* `postcss-normalize-unicode` now has correct dependencies.
-* `postcss-minify-params` now has correct dependencies.
+- `css-declaration-sorter` was removed from default prevent.
+- `postcss-normalize-timing-functions` doesn't lowercased property anymore.
+- `postcss-normalize-positons` now handles uppercase properties.
+- `postcss-normalize-url` now is case-insensitive.
+- `postcss-merge-idents` now is case-insensitive.
+- `postcss-merge-rules` now is case-insensitive.
+- `postcss-minify-selectors` now is case-insensitive.
+- `postcss-minify-font-values` now is case-insensitive.
+- `postcss-normalize-unicode` now has correct dependencies.
+- `postcss-minify-params` now has correct dependencies.
 
 ## Other changes
 
-* `cssnano-preset-advanced` use Autoprefixer 9.
-* use PostCSS 7 in all plugins.
+- `cssnano-preset-advanced` use Autoprefixer 9.
+- use PostCSS 7 in all plugins.
 
 # 4.1.0
 
 ## Bug Fixes
 
-* `postcss-merge-longhand` doesn't mangle borders.
+- `postcss-merge-longhand` doesn't mangle borders.
 
 ## Features
 
-* `postcss-ordered-values` support ordering animation values.
+- `postcss-ordered-values` support ordering animation values.
 
 # 4.0.5
 
 ## Bug Fixes
 
-* `postcss-merge-longhand` now correctly merges borders with custom properties.
-* `postcss-merge-longhand` doesn't throw error in some `border` merge cases.
+- `postcss-merge-longhand` now correctly merges borders with custom properties.
+- `postcss-merge-longhand` doesn't throw error in some `border` merge cases.
 
 # 4.0.4
 
 ## Bug Fixes
 
-* `postcss-merge-longhand` doesn't drop border-width with custom property from border shorthand.
-* `postcss-merge-longhand` doesn't convert `currentColor`.
-* `postcss-merge-longhand` doesn't merge border properties if there is a shorthand property between them.
+- `postcss-merge-longhand` doesn't drop border-width with custom property from border shorthand.
+- `postcss-merge-longhand` doesn't convert `currentColor`.
+- `postcss-merge-longhand` doesn't merge border properties if there is a shorthand property between them.
 
 # 4.0.3
 
 ## Bug Fixes
 
-* `postcss-merge-longhand` incorrect minification of `border` (`border-*`) declarations.
+- `postcss-merge-longhand` incorrect minification of `border` (`border-*`) declarations.
 
 # 4.0.2
 
 ## Bug Fixes
 
-* `postcss-merge-longhand` don't explode declarations with custom properties.
-* `postcss-colormin` now better transform to `hsl`.
+- `postcss-merge-longhand` don't explode declarations with custom properties.
+- `postcss-colormin` now better transform to `hsl`.
 
 # 4.0.1
 
 ## Bug Fixes
 
-* `browserslist` version incompatibility with `caniuse-api`.
+- `browserslist` version incompatibility with `caniuse-api`.
 
 # 4.0.0
 
 ## Breaking changes
 
-* We dropped support for Node 4, now requiring at least Node 6.9.
+- We dropped support for Node 4, now requiring at least Node 6.9.
 
 ## Features
 
-* postcss-merge-longhand now optimises `border-spacing` property.
+- postcss-merge-longhand now optimises `border-spacing` property.
 
 ## Bug Fixes
 
-* postcss-normalize-unicode doesn't change `U` to lowercase for `IE` <= 11 and `Edge` <= 15.
-* postcss-merge-longhand works with custom properties (Example `a { border-style:dotted; border-style:var(--variable) }`) correctly.
-* postcss-ordered-values handle `border` property with invalid border width value correctly.
-* postcss-merge-rules handles `:-ms-input-placeholder` and `::-ms-input-placeholder` selectors correctly.
-* postcss-merge-rules works with `all` property correctly.
-* postcss-normalize-url don't handle empty `url` function.
-* postcss-normalize-url handles `data` and `*-extension://` URLs correctly.
-* postcss-colormin adds whitespace after minified value and before function.
-* postcss-minify-font-values better escapes font name.
-* postcss-minify-params doesn't remove `all` for IE.
+- postcss-normalize-unicode doesn't change `U` to lowercase for `IE` <= 11 and `Edge` <= 15.
+- postcss-merge-longhand works with custom properties (Example `a { border-style:dotted; border-style:var(--variable) }`) correctly.
+- postcss-ordered-values handle `border` property with invalid border width value correctly.
+- postcss-merge-rules handles `:-ms-input-placeholder` and `::-ms-input-placeholder` selectors correctly.
+- postcss-merge-rules works with `all` property correctly.
+- postcss-normalize-url don't handle empty `url` function.
+- postcss-normalize-url handles `data` and `*-extension://` URLs correctly.
+- postcss-colormin adds whitespace after minified value and before function.
+- postcss-minify-font-values better escapes font name.
+- postcss-minify-params doesn't remove `all` for IE.
 
 ## Other changes
 
-* update all dependencies to latest.
-* better handles uppercase selectors/properties/values/units.
+- update all dependencies to latest.
+- better handles uppercase selectors/properties/values/units.
 
 # 4.0.0-rc.2
 
 ## Features
 
-* Includes the new release candidate for postcss-selector-parser 3.
-* Refactors comments tokenizing in postcss-discard-comments to be more
+- Includes the new release candidate for postcss-selector-parser 3.
+- Refactors comments tokenizing in postcss-discard-comments to be more
   memory efficient.
-* Adds css-declaration-sorter for improved gzip compression efficiencies
+- Adds css-declaration-sorter for improved gzip compression efficiencies
   (thanks to @Siilwyn).
-* postcss-svgo now optimises base 64 encoded SVG where possible
+- postcss-svgo now optimises base 64 encoded SVG where possible
   (thanks to @evilebottnawi).
-* stylehacks now supports `@media \0screen\,screen\9 {}` hacks
+- stylehacks now supports `@media \0screen\,screen\9 {}` hacks
   (thanks to @evilebottnawi).
 
 ## Bug Fixes
 
-* Fixed handling of package.json configuration (thanks to @andyjansson).
-* Fixed `resolveConfig` for a `Root` node without a `source` property
+- Fixed handling of package.json configuration (thanks to @andyjansson).
+- Fixed `resolveConfig` for a `Root` node without a `source` property
   (thanks to @darthmaim).
-* Improved radial gradient handling (thanks to @pigcan).
-* stylehacks now properly accounts for vendor prefixes
+- Improved radial gradient handling (thanks to @pigcan).
+- stylehacks now properly accounts for vendor prefixes
   (thanks to @evilebottnawi).
 
 # 4.0.0-rc.1
 
 ## Bug Fixes
 
-* cssnano: Resolved an issue with external configuration which wasn't
+- cssnano: Resolved an issue with external configuration which wasn't
   being loaded correctly (thanks to @andyjansson).
-* postcss-minify-params: Resolved an issue with cssnano's handling of the
+- postcss-minify-params: Resolved an issue with cssnano's handling of the
   `@value` syntax from css-modules to better integrate with css-loader.
 
 # 4.0.0-rc.0
@@ -452,55 +381,57 @@ the actual release.
 
 ## Breaking changes
 
-* cssnano & its plugins have been upgraded to PostCSS 6.x. Please ensure that
+- cssnano & its plugins have been upgraded to PostCSS 6.x. Please ensure that
   for optimal results that you use cssnano with a PostCSS 6 compatible runner
   & that any other plugins are also using PostCSS 6.
-* cssnano is now essentially a preset loader and does not contain any built-in
+- cssnano is now essentially a preset loader and does not contain any built-in
   transforms (instead, it delegates to `cssnano-preset-default` by default).
   Due to the new architecture, it's not possible to exclude asynchronous
   transforms and run it synchronously, unlike in 3.x. Any transforms that
   were "core" modules have now been extracted out into separate packages.
-* Because of the new preset system, cssnano will not accept any transformation
+- Because of the new preset system, cssnano will not accept any transformation
   options; these must be set in the preset. The option names remain mostly the
   same, except some cases where "core" modules have been extracted out:
 
-  * `core` is now `normalizeWhitespace`.
-  * `reduceBackgroundRepeat` is now `normalizeRepeatStyle`.
-  * `reduceDisplayValues` is now `normalizeDisplayValues`.
-  * `reducePositions` is now `normalizePositions`.
-  * `reduceTimingFunctions` is now `normalizeTimingFunctions`.
-  * `styleCache` is now `rawCache`.
+  - `core` is now `normalizeWhitespace`.
+  - `reduceBackgroundRepeat` is now `normalizeRepeatStyle`.
+  - `reduceDisplayValues` is now `normalizeDisplayValues`.
+  - `reducePositions` is now `normalizePositions`.
+  - `reduceTimingFunctions` is now `normalizeTimingFunctions`.
+  - `styleCache` is now `rawCache`.
 
   When excluding transforms, we now have an `exclude` option (in 3.x this was
   named `disable`). Similarly, the `safe` option was removed; the defaults
   are now much less aggressive.
-* By default, the following transforms are no longer applied to any input CSS.
+
+- By default, the following transforms are no longer applied to any input CSS.
   You may see an increased output file size as a result:
 
-  * `autoprefixer`
-  * `postcss-discard-unused`
-  * `postcss-merge-idents`
-  * `postcss-reduce-idents`
-  * `postcss-zindex`
+  - `autoprefixer`
+  - `postcss-discard-unused`
+  - `postcss-merge-idents`
+  - `postcss-reduce-idents`
+  - `postcss-zindex`
 
-  Note that you can load `cssnano-preset-advanced` instead which *does* contain
+  Note that you can load `cssnano-preset-advanced` instead which _does_ contain
   these transforms.
-* We no longer detect previous plugins to silently exclude our own, and now
+
+- We no longer detect previous plugins to silently exclude our own, and now
   consider this to be an anti-pattern. So `postcss-filter-plugins` was removed.
-* We also changed some options to make the default transforms safer:
+- We also changed some options to make the default transforms safer:
 
-  * `postcss-minify-font-values`: `removeAfterKeyword` set to `false` from `true`.
-  * `postcss-normalize-url`: `stripWWW` set to `false` from `true`.
+  - `postcss-minify-font-values`: `removeAfterKeyword` set to `false` from `true`.
+  - `postcss-normalize-url`: `stripWWW` set to `false` from `true`.
 
-* cssnano now does not accept the `sourcemap` shortcut option; please refer
+- cssnano now does not accept the `sourcemap` shortcut option; please refer
   to the PostCSS documentation on sourcemaps. The `quickstart.js` file included
   with this module will give you a good starting point.
-* `cssnano.process` is no longer a custom method; we use the built-in `process`
+- `cssnano.process` is no longer a custom method; we use the built-in `process`
   method exposed on each PostCSS plugin. The new signature is
   `cssnano.process(css, postcssOpts, cssnanoOpts)`, in 3.x it was
   `cssnano.process(css, cssnanoOpts)`.
-* We dropped support for Node 0.12, now requiring at least Node 4.
-* Finally, cssnano is now developed as a monorepo, due to the fact that some
+- We dropped support for Node 0.12, now requiring at least Node 4.
+- Finally, cssnano is now developed as a monorepo, due to the fact that some
   transforms have a lot of grey area/overlap. Due to this, some modules have
   been refactored to delegate responsibility to others, such that duplication
   of functionality is minimized. For instance, `postcss-colormin` will no
@@ -509,11 +440,11 @@ the actual release.
 
 ## Other changes
 
-* Due to the PostCSS 6 upgrade, we have been able to reduce usage of custom
+- Due to the PostCSS 6 upgrade, we have been able to reduce usage of custom
   methods, such as node `clone` behaviour. In cases where some utility
   has been used by several plugins it is now a separate package, reducing
   cssnano's footprint.
-* cssnano now makes much better use of Browserslist. `postcss-colormin` &
+- cssnano now makes much better use of Browserslist. `postcss-colormin` &
   `postcss-reduce-initial` were enhanced with different behaviour depending
   on which browsers are passed. And now, the footprint for the `caniuse-db`
   dependency is much smaller thanks to `caniuse-lite` - 7 times smaller as
@@ -521,355 +452,355 @@ the actual release.
 
 # 3.10.0
 
-* cssnano will no longer `console.warn` any messages when using deprecated
+- cssnano will no longer `console.warn` any messages when using deprecated
   options; these are now sent to PostCSS. You will be able to see them if you
   use a PostCSS runner with built-in messages support, or alternately by
   loading `postcss-reporter` or `postcss-browser-reporter` in your plugins list.
-* Prepares support for `grid` identifier reduction by adding it to the list
+- Prepares support for `grid` identifier reduction by adding it to the list
   of optimisations turned off when `options.safe` is set to `true`.
-* Adds support for normalizing `unicode-range` descriptors. Values will
+- Adds support for normalizing `unicode-range` descriptors. Values will
   be converted when the code matches `0` & `f` in the same place on both sides
   of the range. So, `u+2000-2fff` can be converted to `u+2???`, but
   `u+2100-2fff` will be left as it is.
 
 # 3.9.1
 
-* Resolves an integration issue with `v3.9.0`, where `undefined` values
+- Resolves an integration issue with `v3.9.0`, where `undefined` values
   would attempt to be parsed.
 
 # 3.9.0
 
-* Adds a new option to normalize wrapping quotes for strings & joining
+- Adds a new option to normalize wrapping quotes for strings & joining
   multiple-line strings into a single line. This optimisation can potentially
   reduce the final gzipped size of your CSS file.
 
 # 3.8.2
 
-* Resolves an issue where `display: list-item inline flow` would be normalized
+- Resolves an issue where `display: list-item inline flow` would be normalized
   to `inline list-item` rather than `inline-list-item` (thanks to @mattbasta).
 
 # 3.8.1
 
-* Adds a quick start file for easy integration with Runkit. Try cssnano online
+- Adds a quick start file for easy integration with Runkit. Try cssnano online
   at https://runkit.com/npm/cssnano.
 
 # 3.8.0
 
-* Adds support for normalizing multiple values for the `display` property. For
+- Adds support for normalizing multiple values for the `display` property. For
   example `block flow` can be simplified to `block`.
 
 # 3.7.7
 
-* Further improves CSS mixin handling; semicolons will no longer be stripped
-  from *rules* as well as declarations.
+- Further improves CSS mixin handling; semicolons will no longer be stripped
+  from _rules_ as well as declarations.
 
 # 3.7.6
 
-* Resolves an issue where the semicolon was being incorrectly stripped
+- Resolves an issue where the semicolon was being incorrectly stripped
   from CSS mixins.
 
 # 3.7.5
 
-* Resolves an issue where the `safe` flag was not being persisted across
+- Resolves an issue where the `safe` flag was not being persisted across
   multiple files (thanks to @techmatt101).
 
 # 3.7.4
 
-* Improves performance of the reducePositions transform by testing
+- Improves performance of the reducePositions transform by testing
   against `hasOwnProperty` instead of using an array of object keys.
-* Removes the redundant `indexes-of` dependency.
+- Removes the redundant `indexes-of` dependency.
 
 # 3.7.3
 
-* Unpins postcss-filter-plugins from `2.0.0` as a fix has landed in the new
+- Unpins postcss-filter-plugins from `2.0.0` as a fix has landed in the new
   version of uniqid.
 
 # 3.7.2
 
-* Temporarily pins postcss-filter-plugins to version `2.0.0` in order to
+- Temporarily pins postcss-filter-plugins to version `2.0.0` in order to
   mitigate an issue with uniqid `3.0.0`.
 
 # 3.7.1
 
-* Enabling safe mode now turns off both postcss-merge-idents &
+- Enabling safe mode now turns off both postcss-merge-idents &
   postcss-normalize-url's `stripWWW` option.
 
 # 3.7.0
 
-* Added: Reduce `background-repeat` definitions; works with both this property
+- Added: Reduce `background-repeat` definitions; works with both this property
   & the `background` shorthand, and aims to compress the extended two value
   syntax into the single value syntax.
-* Added: Reduce `initial` values for properties when the *actual* initial value
+- Added: Reduce `initial` values for properties when the _actual_ initial value
   is shorter; for example, `min-width: initial` becomes `min-width: 0`.
 
 # 3.6.2
 
-* Fixed an issue where cssnano would crash on `steps(1)`.
+- Fixed an issue where cssnano would crash on `steps(1)`.
 
 # 3.6.1
 
-* Fixed an issue where cssnano would crash on `steps` functions with a
+- Fixed an issue where cssnano would crash on `steps` functions with a
   single argument.
 
 # 3.6.0
 
-* Added `postcss-discard-overridden` to safely discard overridden rules with
+- Added `postcss-discard-overridden` to safely discard overridden rules with
   the same identifier (thanks to @Justineo).
-* Added: Reduce animation/transition timing functions. Detects `cubic-bezier`
+- Added: Reduce animation/transition timing functions. Detects `cubic-bezier`
   functions that are equivalent to the timing keywords and compresses, as well
   as normalizing the `steps` timing function.
-* Added the `perspective-origin` property to the list of supported properties
+- Added the `perspective-origin` property to the list of supported properties
   transformed by the `reduce-positions` transform.
 
 # 3.5.2
 
-* Resolves an issue where the 3 or 4 value syntax for `background-position`
+- Resolves an issue where the 3 or 4 value syntax for `background-position`
   were being incorrectly converted.
 
 # 3.5.1
 
-* Improves checking for `background-position` values in the `background`
+- Improves checking for `background-position` values in the `background`
   shorthand property.
 
 # 3.5.0
 
-* Adds a new optimisation path which can minimise keyword values for
+- Adds a new optimisation path which can minimise keyword values for
   `background-position` and the `background` shorthand.
-* Tweaks to performance in the `core` module, now performs less AST passes.
-* Now compiled with Babel 6.
+- Tweaks to performance in the `core` module, now performs less AST passes.
+- Now compiled with Babel 6.
 
 # 3.4.0
 
-* Adds a new optimisation path which can minimise gradient parameters
+- Adds a new optimisation path which can minimise gradient parameters
   automatically.
 
 # 3.3.2
 
-* Fixes an issue where using `options.safe` threw an error when cssnano was
+- Fixes an issue where using `options.safe` threw an error when cssnano was
   not used as part of a PostCSS instance, but standalone (such as in modules
   like gulp-cssnano). cssnano now renames `safe` internally to `isSafe`.
 
 # 3.3.1
 
-* Unpins postcss-colormin from `2.1.2`, as the `2.1.3` & `2.1.4` patches had
+- Unpins postcss-colormin from `2.1.2`, as the `2.1.3` & `2.1.4` patches had
   optimization regressions that are now resolved in `2.1.5`.
 
 # 3.3.0
 
-* Updated modules to use postcss-value-parser version 3 (thanks to @TrySound).
-* Now converts between transform functions with postcss-reduce-transforms.
+- Updated modules to use postcss-value-parser version 3 (thanks to @TrySound).
+- Now converts between transform functions with postcss-reduce-transforms.
   e.g. `translate3d(0, 0, 0)` becomes `translateZ(0)`.
 
 # 3.2.0
 
-* cssnano no longer converts `outline: none` to `outline: 0`, as there are
+- cssnano no longer converts `outline: none` to `outline: 0`, as there are
   some cases where the values are not equivalent (thanks to @TrySound).
-* cssnano no longer converts for example `16px` to `1pc` *by default*. Length
+- cssnano no longer converts for example `16px` to `1pc` _by default_. Length
   optimisations can be turned on via `{convertValues: {length: true}}`.
-* Improved minimization of css functions (thanks to @TrySound).
+- Improved minimization of css functions (thanks to @TrySound).
 
 # 3.1.0
 
-* This release swaps postcss-single-charset for postcss-normalize-charset,
+- This release swaps postcss-single-charset for postcss-normalize-charset,
   which can detect encoding to determine whether a charset is necessary.
   Optionally, you can set the `add` option to `true` to prepend a UTF-8
   charset to the output automatically (thanks to @TrySound).
-* A `safe` option was added, which disables more aggressive optimisations, as
+- A `safe` option was added, which disables more aggressive optimisations, as
   a convenient preset configuration (thanks to @TrySound).
-* Added an option to convert from `deg` to `turn` & vice versa, & improved
+- Added an option to convert from `deg` to `turn` & vice versa, & improved
   minification performance in functions (thanks to @TrySound).
 
 # 3.0.3
 
-* Fixes an issue where cssnano was removing spaces around forward slashes in
+- Fixes an issue where cssnano was removing spaces around forward slashes in
   string literals (thanks to @TrySound).
 
 # 3.0.2
 
-* Fixes an issue where cssnano was removing spaces around forward slashes in
+- Fixes an issue where cssnano was removing spaces around forward slashes in
   calc functions.
 
 # 3.0.1
 
-* Replaced css-list & balanced-match with postcss-value-parser, reducing the
+- Replaced css-list & balanced-match with postcss-value-parser, reducing the
   module's overall size (thanks to @TrySound).
 
 # 3.0.0
 
-* All cssnano plugins and cssnano itself have migrated to PostCSS 5.x. Please
+- All cssnano plugins and cssnano itself have migrated to PostCSS 5.x. Please
   make sure that when using the 3.x releases that you use a 5.x compatible
   PostCSS runner.
-* cssnano will now compress inline SVG through SVGO. Because of this change,
+- cssnano will now compress inline SVG through SVGO. Because of this change,
   interfacing with cssnano must now be done through an asynchronous API. The
   main `process` method has the same signature as a PostCSS processor instance.
-* The old options such as `merge` & `fonts` that were deprecated in
+- The old options such as `merge` & `fonts` that were deprecated in
   release `2.5.0` were removed. The new architecture allows you to specify any
   module name to disable it.
-* postcss-minify-selectors' at-rule compression was extracted out into
+- postcss-minify-selectors' at-rule compression was extracted out into
   postcss-minify-params (thanks to @TrySound).
-* Overall performance of the module has improved dramatically, thanks to work
+- Overall performance of the module has improved dramatically, thanks to work
   by @TrySound and input from the community.
-* Improved selector merging/deduplication in certain use cases.
-* cssnano no longer compresses hex colours in filter properties, to better
+- Improved selector merging/deduplication in certain use cases.
+- cssnano no longer compresses hex colours in filter properties, to better
   support old versions of Internet Explorer (thanks to @faddee).
-* cssnano will not merge properties together that have an `inherit` keyword.
-* postcss-minify-font-weight & postcss-font-family were consolidated into
+- cssnano will not merge properties together that have an `inherit` keyword.
+- postcss-minify-font-weight & postcss-font-family were consolidated into
   postcss-minify-font-values. Using the old options will print deprecation
   warnings (thanks to @TrySound).
-* The cssnano CLI was extracted into a separate module, so that dependent
+- The cssnano CLI was extracted into a separate module, so that dependent
   modules such as gulp-cssnano don't download unnecessary extras.
 
 # 2.6.1
 
-* Improved performance of the core module `functionOptimiser`.
+- Improved performance of the core module `functionOptimiser`.
 
 # 2.6.0
 
-* Adds a new optimisation which re-orders properties that accept values in
+- Adds a new optimisation which re-orders properties that accept values in
   an arbitrary order. This can lead to improved merging behaviour in certain
   cases.
 
 # 2.5.0
 
-* Adds support for disabling modules of the user's choosing, with new option
+- Adds support for disabling modules of the user's choosing, with new option
   names. The old options (such as `merge` & `fonts`) will be removed in `3.0`.
 
 # 2.4.0
 
-* postcss-minify-selectors was extended to add support for conversion of
+- postcss-minify-selectors was extended to add support for conversion of
   `::before` to `:before`; this release removes the dedicated
   postcss-pseudoelements module.
 
 # 2.3.0
 
-* Consolidated postcss-minify-trbl & two integrated modules into
+- Consolidated postcss-minify-trbl & two integrated modules into
   postcss-merge-longhand.
 
 # 2.2.0
 
-* Replaced integrated plugin filter with postcss-filter-plugins.
-* Improved rule merging logic.
-* Improved performance across the board by reducing AST iterations where it
+- Replaced integrated plugin filter with postcss-filter-plugins.
+- Improved rule merging logic.
+- Improved performance across the board by reducing AST iterations where it
   was possible to do so.
-* cssnano will now perform better whitespace compression when used with other
+- cssnano will now perform better whitespace compression when used with other
   PostCSS plugins.
 
 # 2.1.1
 
-* Fixes an issue where options were not passed to normalize-url.
+- Fixes an issue where options were not passed to normalize-url.
 
 # 2.1.0
 
-* Allow `postcss-font-family` to be disabled.
+- Allow `postcss-font-family` to be disabled.
 
 # 2.0.3
 
-* cssnano can now be consumed with the parentheses-less method in PostCSS; e.g.
+- cssnano can now be consumed with the parentheses-less method in PostCSS; e.g.
   `postcss([ cssnano ])`.
-* Fixes an issue where 'Din' was being picked up by the logic as a numeric
+- Fixes an issue where 'Din' was being picked up by the logic as a numeric
   value, causing the full font name to be incorrectly rearranged.
 
 # 2.0.2
 
-* Extract trbl value reducing into a separate module.
-* Refactor core longhand optimiser to not rely on trbl cache.
-* Adds support for `ch` units; previously they were removed.
-* Fixes parsing of some selector hacks.
-* Fixes an issue where embedded base 64 data was being converted as if it were
+- Extract trbl value reducing into a separate module.
+- Refactor core longhand optimiser to not rely on trbl cache.
+- Adds support for `ch` units; previously they were removed.
+- Fixes parsing of some selector hacks.
+- Fixes an issue where embedded base 64 data was being converted as if it were
   a URL.
 
 # 2.0.1
 
-* Add `postcss-plugin` keyword to package.json.
-* Wraps all core processors with the PostCSS 4.1 plugin API.
+- Add `postcss-plugin` keyword to package.json.
+- Wraps all core processors with the PostCSS 4.1 plugin API.
 
 # 2.0.0
 
-* Adds removal of outdated vendor prefixes based on browser support.
-* Addresses an issue where relative path separators were converted to
+- Adds removal of outdated vendor prefixes based on browser support.
+- Addresses an issue where relative path separators were converted to
   backslashes on Windows.
-* cssnano will now detect previous plugins and silently disable them when the
+- cssnano will now detect previous plugins and silently disable them when the
   functionality overlaps. This is to enable faster interoperation with cssnext.
-* cssnano now exports as a PostCSS plugin. The simple interface is exposed
+- cssnano now exports as a PostCSS plugin. The simple interface is exposed
   at `cssnano.process(css, opts)` instead of `cssnano(css, opts)`.
-* Improved URL detection when using two or more in the same declaration.
-* node 0.10 is no longer officially supported.
+- Improved URL detection when using two or more in the same declaration.
+- node 0.10 is no longer officially supported.
 
 # 1.4.3
 
-* Fixes incorrect minification of `background:none` to `background:0 0`.
+- Fixes incorrect minification of `background:none` to `background:0 0`.
 
 # 1.4.2
 
-* Fixes an issue with nested URLs inside `url()` functions.
+- Fixes an issue with nested URLs inside `url()` functions.
 
 # 1.4.1
 
-* Addresses an issue where whitespace removal after a CSS function would cause
+- Addresses an issue where whitespace removal after a CSS function would cause
   rendering issues in Internet Explorer.
 
 # 1.4.0
 
-* Adds support for removal of unused `@keyframes` and `@counter-style` at-rules.
-* comments: adds support for user-directed removal of comments, with the
+- Adds support for removal of unused `@keyframes` and `@counter-style` at-rules.
+- comments: adds support for user-directed removal of comments, with the
   `remove` option (thanks to @dmitrykiselyov).
-* comments: `removeAllButFirst` now operates on each CSS tree, rather than the
+- comments: `removeAllButFirst` now operates on each CSS tree, rather than the
   first one passed to cssnano.
 
 # 1.3.3
 
-* Fixes incorrect minification of `border:none` to `border:0 0`.
+- Fixes incorrect minification of `border:none` to `border:0 0`.
 
 # 1.3.2
 
-* Improved selector minifying logic, leading to better compression of attribute
+- Improved selector minifying logic, leading to better compression of attribute
   selectors.
-* Improved comment discarding logic.
+- Improved comment discarding logic.
 
 # 1.3.1
 
-* Fixes crash on undefined `decl.before` from prior AST.
+- Fixes crash on undefined `decl.before` from prior AST.
 
 # 1.3.0
 
-* Added support for bundling cssnano using webpack (thanks to @MoOx).
+- Added support for bundling cssnano using webpack (thanks to @MoOx).
 
 # 1.2.1
 
-* Fixed a bug where a CSS function keyword inside its value would throw
+- Fixed a bug where a CSS function keyword inside its value would throw
   an error.
 
 # 1.2.0
 
-* Better support for merging properties without the existance of a shorthand
+- Better support for merging properties without the existance of a shorthand
   override.
-* Can now 'merge forward' adjacent rules as well as the previous 'merge behind'
+- Can now 'merge forward' adjacent rules as well as the previous 'merge behind'
   behaviour, leading to better compression.
-* Selector re-ordering now happens last in the chain of plugins, to help clean
+- Selector re-ordering now happens last in the chain of plugins, to help clean
   up merged selectors.
 
 # 1.1.0
 
-* Now can merge identifiers such as `@keyframes` and `@counter-style` if they
+- Now can merge identifiers such as `@keyframes` and `@counter-style` if they
   have duplicated properties but are named differently.
-* Fixes an issue where duplicated keyframes with the same name would cause
+- Fixes an issue where duplicated keyframes with the same name would cause
   an infinite loop.
 
 # 1.0.2
 
-* Improve module loading logic (thanks to @tunnckoCore).
-* Improve minification of numeric values, with better support for `rem`,
+- Improve module loading logic (thanks to @tunnckoCore).
+- Improve minification of numeric values, with better support for `rem`,
   trailing zeroes and slash/comma separated values
   (thanks to @TrySound & @tunnckoCore).
-* Fixed an issue where `-webkit-tap-highlight-color` values were being
+- Fixed an issue where `-webkit-tap-highlight-color` values were being
   incorrectly transformed to `transparent`. This is not supported in Safari.
-* Added support for viewport units (thanks to @TrySound).
-* Add MIT license file.
+- Added support for viewport units (thanks to @TrySound).
+- Add MIT license file.
 
 # 1.0.1
 
-* Add repository/author links to package.json.
+- Add repository/author links to package.json.
 
 # 1.0.0
 
-* Initial release.
+- Initial release.

--- a/packages/cssnano/CHANGELOG.md
+++ b/packages/cssnano/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+# 5.0.11 (2021-11-16)
+
+### Bug fixes
+
+- c38f14c3ce3d0: **postcss-normalize-url**: avoid changing parameter encoding
+
+### Chore
+
+- 31d5c07dc07a4: refactor: drop one-liner dependencies
+- 07172825ffbb4f4: **postcss-merge-longhand**: drop css-color-names dependency
 
 # 5.1.10 (2021-11-05)
 

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cssnano",
-    "version": "5.0.10",
+    "version": "5.0.11",
     "description": "A modular minifier, built on top of the PostCSS ecosystem.",
     "main": "dist/index.js",
     "scripts": {
@@ -26,7 +26,7 @@
     "dependencies": {
         "lilconfig": "^2.0.3",
         "yaml": "^1.10.2",
-        "cssnano-preset-default": "^5.1.6",
+        "cssnano-preset-default": "^5.1.7",
         "is-resolvable": "^1.1.0"
     },
     "homepage": "https://github.com/cssnano/cssnano",

--- a/packages/postcss-colormin/CHANGELOG.md
+++ b/packages/postcss-colormin/CHANGELOG.md
@@ -3,104 +3,75 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.2.1] (2021-11-01)
+# 5.2.1 (2021-11-01)
 
 ### Chore
 
-* **postcss-colormin:** use colord plugin for color minification ([#1207](https://github.com/cssnano/cssnano/pull/1207)) ([3dbaa04](https://github.com/cssnano/cssnano/commit/3dbaa04addfa2f18375262377e172b03819dc2c0))
+- **postcss-colormin:** use colord plugin for color minification ([#1207](https://github.com/cssnano/cssnano/pull/1207)) ([3dbaa04](https://github.com/cssnano/cssnano/commit/3dbaa04addfa2f18375262377e172b03819dc2c0))
 
-
-# [5.2.0] (2021-05-28)
+# 5.2.0 (2021-05-28)
 
 ### Features
 
-* Output 4 and 8 hex colors if it reduces the output size and the target browsers support it.
+- Output 4 and 8 hex colors if it reduces the output size and the target browsers support it.
 
 ### Bug Fixes
 
-* Preserve color alpha precision.
+- Preserve color alpha precision.
 
-# [5.1.1] (2021-05-21)
-
+# 5.1.1 (2021-05-21)
 
 ### Bug Fixes
 
-* **postcss-colormin:** Strict color parsing ([#1122](https://github.com/cssnano/cssnano/issues/1122)) ([32771da](https://github.com/cssnano/cssnano/commit/32771da46ee94f07a6907ec47701189f90ad2ec0))
-* **postcss-colormin:** fix ERR_PACKAGE_PATH_NOT_EXPORTED ([#1110](https://github.com/cssnano/cssnano/issues/1110)) ([8a31ca38796](https://github.com/cssnano/cssnano/commit/8a31ca38796e12e6fe52620cf8a545cb058fe295))
+- **postcss-colormin:** Strict color parsing ([#1122](https://github.com/cssnano/cssnano/issues/1122)) ([32771da](https://github.com/cssnano/cssnano/commit/32771da46ee94f07a6907ec47701189f90ad2ec0))
+- **postcss-colormin:** fix ERR_PACKAGE_PATH_NOT_EXPORTED ([#1110](https://github.com/cssnano/cssnano/issues/1110)) ([8a31ca38796](https://github.com/cssnano/cssnano/commit/8a31ca38796e12e6fe52620cf8a545cb058fe295))
 
 # [5.1.0](https://github.com/cssnano/cssnano/compare/postcss-colormin@5.0.0...postcss-colormin@5.1.0) (2021-05-19)
 
-
 ### Features
 
-* **postcss-colormin:** switch to colord and solve multiple issues ([#1107](https://github.com/cssnano/cssnano/issues/1107)) ([a7f0be4](https://github.com/cssnano/cssnano/commit/a7f0be4acc640aab89cace53a720b3d59b6f7b4f)), closes [#819](https://github.com/cssnano/cssnano/issues/819) [#1042](https://github.com/cssnano/cssnano/issues/1042) [#819](https://github.com/cssnano/cssnano/issues/819) [#771](https://github.com/cssnano/cssnano/issues/771)
-
-
-
-
+- **postcss-colormin:** switch to colord and solve multiple issues ([#1107](https://github.com/cssnano/cssnano/issues/1107)) ([a7f0be4](https://github.com/cssnano/cssnano/commit/a7f0be4acc640aab89cace53a720b3d59b6f7b4f)), closes [#819](https://github.com/cssnano/cssnano/issues/819) [#1042](https://github.com/cssnano/cssnano/issues/1042) [#819](https://github.com/cssnano/cssnano/issues/819) [#771](https://github.com/cssnano/cssnano/issues/771)
 
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-colormin@5.0.0-rc.2...postcss-colormin@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-colormin
 
-
-
-
-
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-colormin@5.0.0-rc.1...postcss-colormin@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-colormin
-
-
-
-
 
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-colormin@5.0.0-rc.0...postcss-colormin@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-colormin
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-colormin:** fixed plugin running error ([#856](https://github.com/cssnano/cssnano/issues/856)) ([eb37dd5](https://github.com/cssnano/cssnano/commit/eb37dd570a916ce7d6080a782a24d951082c5497))
-
+- **postcss-colormin:** fixed plugin running error ([#856](https://github.com/cssnano/cssnano/issues/856)) ([eb37dd5](https://github.com/cssnano/cssnano/commit/eb37dd570a916ce7d6080a782a24d951082c5497))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Performance Improvements
 
-* **postcss-colormin:** increase ([#682](https://github.com/cssnano/cssnano/issues/682)) ([73e021e](https://github.com/cssnano/cssnano/commit/73e021e0fd02ab44c8726ae0719c5669a29bc8dc))
-* **postcss-colormin:** increase perf ([#696](https://github.com/cssnano/cssnano/issues/696)) ([88c2f2e](https://github.com/cssnano/cssnano/commit/88c2f2e0c20fcd3f3be20b10501e0cec9e453aeb))
-
-
+- **postcss-colormin:** increase ([#682](https://github.com/cssnano/cssnano/issues/682)) ([73e021e](https://github.com/cssnano/cssnano/commit/73e021e0fd02ab44c8726ae0719c5669a29bc8dc))
+- **postcss-colormin:** increase perf ([#696](https://github.com/cssnano/cssnano/issues/696)) ([88c2f2e](https://github.com/cssnano/cssnano/commit/88c2f2e0c20fcd3f3be20b10501e0cec9e453aeb))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-convert-values/CHANGELOG.md
+++ b/packages/postcss-convert-values/CHANGELOG.md
@@ -3,76 +3,52 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.2] (2021-11-01)
+# 5.0.2 (2021-11-01)
 
 ### Bug fixes
 
-* **postcss-convert-values:** preserve percentage-only properties ([#1212](https://github.com/cssnano/cssnano/pull/1212)) ([8f3453](https://github.com/cssnano/cssnano/commit/8f345385b210cf85e9d591382d387f76ca4b0f64))
-
+- **postcss-convert-values:** preserve percentage-only properties ([#1212](https://github.com/cssnano/cssnano/pull/1212)) ([8f3453](https://github.com/cssnano/cssnano/commit/8f345385b210cf85e9d591382d387f76ca4b0f64))
 
 ## [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-convert-values@5.0.0...postcss-convert-values@5.0.1) (2021-05-19)
 
 **Note:** Version bump only for package postcss-convert-values
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-convert-values@5.0.0-rc.2...postcss-convert-values@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-convert-values
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-convert-values@5.0.0-rc.1...postcss-convert-values@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-convert-values
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-convert-values@5.0.0-rc.0...postcss-convert-values@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-convert-values
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* Keep math functions together ([#895](https://github.com/cssnano/cssnano/issues/895)) ([4ddf843](https://github.com/cssnano/cssnano/commit/4ddf843ca5dc64059f488113224e76165211a669))
-* preservation of opacities defined as percentages ([#881](https://github.com/cssnano/cssnano/issues/881)) ([fd7b878](https://github.com/cssnano/cssnano/commit/fd7b878e72ed9bd20c145c9e2daa7b5d48cb1117))
-* units being removed in math functions ([#894](https://github.com/cssnano/cssnano/issues/894)) ([1ccbd5b](https://github.com/cssnano/cssnano/commit/1ccbd5b29e1b2121efaf7b24a69aa782848966dc))
-* **postcss-convert-values:** prevent zero units from being dropped in line-height. ([#801](https://github.com/cssnano/cssnano/issues/801)) ([d781855](https://github.com/cssnano/cssnano/commit/d78185567ae5ebcde0469cf0e55145a7a3130d3e))
-
+- Keep math functions together ([#895](https://github.com/cssnano/cssnano/issues/895)) ([4ddf843](https://github.com/cssnano/cssnano/commit/4ddf843ca5dc64059f488113224e76165211a669))
+- preservation of opacities defined as percentages ([#881](https://github.com/cssnano/cssnano/issues/881)) ([fd7b878](https://github.com/cssnano/cssnano/commit/fd7b878e72ed9bd20c145c9e2daa7b5d48cb1117))
+- units being removed in math functions ([#894](https://github.com/cssnano/cssnano/issues/894)) ([1ccbd5b](https://github.com/cssnano/cssnano/commit/1ccbd5b29e1b2121efaf7b24a69aa782848966dc))
+- **postcss-convert-values:** prevent zero units from being dropped in line-height. ([#801](https://github.com/cssnano/cssnano/issues/801)) ([d781855](https://github.com/cssnano/cssnano/commit/d78185567ae5ebcde0469cf0e55145a7a3130d3e))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-discard-comments/CHANGELOG.md
+++ b/packages/postcss-discard-comments/CHANGELOG.md
@@ -7,66 +7,41 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-discard-comments
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-discard-comments@5.0.0-rc.2...postcss-discard-comments@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-discard-comments
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-discard-comments@5.0.0-rc.1...postcss-discard-comments@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-discard-comments
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-discard-comments@5.0.0-rc.0...postcss-discard-comments@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-discard-comments
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Performance Improvements
 
-* **postcss-discard-comments:** increase perf ([#700](https://github.com/cssnano/cssnano/issues/700)) ([84294e9](https://github.com/cssnano/cssnano/commit/84294e97da82bd2fb5cf9299f0a9dc4441c8d70c))
-
-
+- **postcss-discard-comments:** increase perf ([#700](https://github.com/cssnano/cssnano/issues/700)) ([84294e9](https://github.com/cssnano/cssnano/commit/84294e97da82bd2fb5cf9299f0a9dc4441c8d70c))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-discard-duplicates/CHANGELOG.md
+++ b/packages/postcss-discard-duplicates/CHANGELOG.md
@@ -7,61 +7,37 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-discard-duplicates
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-discard-duplicates@5.0.0-rc.2...postcss-discard-duplicates@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-discard-duplicates
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-discard-duplicates@5.0.0-rc.1...postcss-discard-duplicates@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-discard-duplicates
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-discard-duplicates@5.0.0-rc.0...postcss-discard-duplicates@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-discard-duplicates
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.3 (2018-09-25)
 
-
-
 ## 4.1.1 (2018-09-24)
-
 
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-discard-empty/CHANGELOG.md
+++ b/packages/postcss-discard-empty/CHANGELOG.md
@@ -7,57 +7,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-discard-empty
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-discard-empty@5.0.0-rc.2...postcss-discard-empty@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-discard-empty
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-discard-empty@5.0.0-rc.1...postcss-discard-empty@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-discard-empty
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-discard-empty@5.0.0-rc.0...postcss-discard-empty@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-discard-empty
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-discard-overridden/CHANGELOG.md
+++ b/packages/postcss-discard-overridden/CHANGELOG.md
@@ -7,62 +7,39 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-discard-overridden
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-discard-overridden@5.0.0-rc.2...postcss-discard-overridden@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-discard-overridden
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-discard-overridden@5.0.0-rc.1...postcss-discard-overridden@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-discard-overridden
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-discard-overridden@5.0.0-rc.0...postcss-discard-overridden@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-discard-overridden
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* added files prop in package.json to prevent unit tests getting published ([#879](https://github.com/cssnano/cssnano/issues/879)) ([09bdf86](https://github.com/cssnano/cssnano/commit/09bdf862173a5b16fdc79fbc3b6f54f2e7386985))
-
+- added files prop in package.json to prevent unit tests getting published ([#879](https://github.com/cssnano/cssnano/issues/879)) ([09bdf86](https://github.com/cssnano/cssnano/commit/09bdf862173a5b16fdc79fbc3b6f54f2e7386985))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-discard-unused/CHANGELOG.md
+++ b/packages/postcss-discard-unused/CHANGELOG.md
@@ -7,57 +7,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-discard-unused
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-discard-unused@5.0.0-rc.2...postcss-discard-unused@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-discard-unused
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-discard-unused@5.0.0-rc.1...postcss-discard-unused@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-discard-unused
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-discard-unused@5.0.0-rc.0...postcss-discard-unused@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-discard-unused
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-merge-idents/CHANGELOG.md
+++ b/packages/postcss-merge-idents/CHANGELOG.md
@@ -7,63 +7,40 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-merge-idents
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-merge-idents@5.0.0-rc.2...postcss-merge-idents@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-merge-idents
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-merge-idents@5.0.0-rc.1...postcss-merge-idents@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-merge-idents
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-merge-idents@5.0.0-rc.0...postcss-merge-idents@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-merge-idents
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **merge-rules, merge-idents:** add support for nested at-rules ([#719](https://github.com/cssnano/cssnano/issues/719)) ([cdedda7](https://github.com/cssnano/cssnano/commit/cdedda7f9d67873d872add044ad34c91616579f3))
-
+- **merge-rules, merge-idents:** add support for nested at-rules ([#719](https://github.com/cssnano/cssnano/issues/719)) ([cdedda7](https://github.com/cssnano/cssnano/commit/cdedda7f9d67873d872add044ad34c91616579f3))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* better handle uppercase atrule and properties in `postcss-merge-idents` ([#610](https://github.com/cssnano/cssnano/issues/610)) ([d177936](https://github.com/cssnano/cssnano/commit/d177936b2656ad286490bedc3c4ab9773a63e5bc))
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- better handle uppercase atrule and properties in `postcss-merge-idents` ([#610](https://github.com/cssnano/cssnano/issues/610)) ([d177936](https://github.com/cssnano/cssnano/commit/d177936b2656ad286490bedc3c4ab9773a63e5bc))
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-merge-longhand/CHANGELOG.md
+++ b/packages/postcss-merge-longhand/CHANGELOG.md
@@ -7,150 +7,99 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug fixes
 
-* **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
+- **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
 
 ## [5.0.2](https://github.com/cssnano/cssnano/compare/postcss-merge-longhand@5.0.0...postcss-merge-longhand@5.0.2) (2021-05-19)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** mergeLonghand should not apply to CSS variables ([#1057](https://github.com/cssnano/cssnano/issues/1057)) ([8aa64c7](https://github.com/cssnano/cssnano/commit/8aa64c714f615db747605f6d79fcc043e9ee8e57)), closes [#1051](https://github.com/cssnano/cssnano/issues/1051)
-
-
-
-
+- **postcss-merge-longhand:** mergeLonghand should not apply to CSS variables ([#1057](https://github.com/cssnano/cssnano/issues/1057)) ([8aa64c7](https://github.com/cssnano/cssnano/commit/8aa64c714f615db747605f6d79fcc043e9ee8e57)), closes [#1051](https://github.com/cssnano/cssnano/issues/1051)
 
 ## [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-merge-longhand@5.0.0...postcss-merge-longhand@5.0.1) (2021-04-26)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** mergeLonghand should not apply to CSS variables ([#1057](https://github.com/cssnano/cssnano/issues/1057)) ([8aa64c7](https://github.com/cssnano/cssnano/commit/8aa64c714f615db747605f6d79fcc043e9ee8e57)), closes [#1051](https://github.com/cssnano/cssnano/issues/1051)
-
-
-
-
+- **postcss-merge-longhand:** mergeLonghand should not apply to CSS variables ([#1057](https://github.com/cssnano/cssnano/issues/1057)) ([8aa64c7](https://github.com/cssnano/cssnano/commit/8aa64c714f615db747605f6d79fcc043e9ee8e57)), closes [#1051](https://github.com/cssnano/cssnano/issues/1051)
 
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-merge-longhand@5.0.0-rc.2...postcss-merge-longhand@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-merge-longhand
 
-
-
-
-
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-merge-longhand@5.0.0-rc.1...postcss-merge-longhand@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-merge-longhand
-
-
-
-
 
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-merge-longhand@5.0.0-rc.0...postcss-merge-longhand@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-merge-longhand
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-merge-longhand:** guard against missing border-width props ([#744](https://github.com/cssnano/cssnano/issues/744)) ([f050fdf](https://github.com/cssnano/cssnano/commit/f050fdfaa4b1edac65a45764eade2326d01f87cc))
-* **postcss-merge-longhand:** resolve crash on empty declarations ([#770](https://github.com/cssnano/cssnano/issues/770)) ([3652430](https://github.com/cssnano/cssnano/commit/365243025f3efaefd11f264f7223f6048899fd50))
-
+- **postcss-merge-longhand:** guard against missing border-width props ([#744](https://github.com/cssnano/cssnano/issues/744)) ([f050fdf](https://github.com/cssnano/cssnano/commit/f050fdfaa4b1edac65a45764eade2326d01f87cc))
+- **postcss-merge-longhand:** resolve crash on empty declarations ([#770](https://github.com/cssnano/cssnano/issues/770)) ([3652430](https://github.com/cssnano/cssnano/commit/365243025f3efaefd11f264f7223f6048899fd50))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** better handle uppercase properties and values ([#703](https://github.com/cssnano/cssnano/issues/703)) ([ceb24a1](https://github.com/cssnano/cssnano/commit/ceb24a1bf3fde0bf39dced9fa05155cdd7cf6964))
-* bug in merging border properties with custom properties ([#653](https://github.com/cssnano/cssnano/issues/653)) ([4bb8d5e](https://github.com/cssnano/cssnano/commit/4bb8d5ec7f4c8f4007d76a23b2efdfb713f58558))
-* preserve case of css custom variables. Fixes [#648](https://github.com/cssnano/cssnano/issues/648) ([#649](https://github.com/cssnano/cssnano/issues/649)) ([9aa2731](https://github.com/cssnano/cssnano/commit/9aa273173bde6e6aca76cbd0eed4b486d7edfd4d))
-
-
+- **postcss-merge-longhand:** better handle uppercase properties and values ([#703](https://github.com/cssnano/cssnano/issues/703)) ([ceb24a1](https://github.com/cssnano/cssnano/commit/ceb24a1bf3fde0bf39dced9fa05155cdd7cf6964))
+- bug in merging border properties with custom properties ([#653](https://github.com/cssnano/cssnano/issues/653)) ([4bb8d5e](https://github.com/cssnano/cssnano/commit/4bb8d5ec7f4c8f4007d76a23b2efdfb713f58558))
+- preserve case of css custom variables. Fixes [#648](https://github.com/cssnano/cssnano/issues/648) ([#649](https://github.com/cssnano/cssnano/issues/649)) ([9aa2731](https://github.com/cssnano/cssnano/commit/9aa273173bde6e6aca76cbd0eed4b486d7edfd4d))
 
 ## 4.1.7 (2018-10-22)
 
-
-
 ## 4.1.6 (2018-10-22)
-
 
 ### Bug Fixes
 
-* doesn't throw error when merge a border property ([#639](https://github.com/cssnano/cssnano/issues/639)) ([#641](https://github.com/cssnano/cssnano/issues/641)) ([d181d30](https://github.com/cssnano/cssnano/commit/d181d30c560386f406de3c9322855b32e88848b4))
-
-
+- doesn't throw error when merge a border property ([#639](https://github.com/cssnano/cssnano/issues/639)) ([#641](https://github.com/cssnano/cssnano/issues/641)) ([d181d30](https://github.com/cssnano/cssnano/commit/d181d30c560386f406de3c9322855b32e88848b4))
 
 ## 4.1.5 (2018-10-17)
 
-
 ### Bug Fixes
 
-* do not merge properties with unset ([#633](https://github.com/cssnano/cssnano/issues/633)) ([857075c](https://github.com/cssnano/cssnano/commit/857075c27d1bbdb24079e201b3d95b2ccec5f6cf))
-* separate custom props to their longhand representation and merge concrete values ([#621](https://github.com/cssnano/cssnano/issues/621)) ([1ebc319](https://github.com/cssnano/cssnano/commit/1ebc3192629adbcb0e513452b4a9c1035730081e))
-
-
+- do not merge properties with unset ([#633](https://github.com/cssnano/cssnano/issues/633)) ([857075c](https://github.com/cssnano/cssnano/commit/857075c27d1bbdb24079e201b3d95b2ccec5f6cf))
+- separate custom props to their longhand representation and merge concrete values ([#621](https://github.com/cssnano/cssnano/issues/621)) ([1ebc319](https://github.com/cssnano/cssnano/commit/1ebc3192629adbcb0e513452b4a9c1035730081e))
 
 ## 4.1.1 (2018-09-24)
 
-
-
 # 4.1.0 (2018-08-24)
-
 
 ### Bug Fixes
 
-* **postcss-merge-longhand:** Should not mangle borders ([#579](https://github.com/cssnano/cssnano/issues/579)) ([#583](https://github.com/cssnano/cssnano/issues/583)) ([4d3b3f8](https://github.com/cssnano/cssnano/commit/4d3b3f8fa5a389329989b13f85f3523e56c81435))
-
-
+- **postcss-merge-longhand:** Should not mangle borders ([#579](https://github.com/cssnano/cssnano/issues/579)) ([#583](https://github.com/cssnano/cssnano/issues/583)) ([4d3b3f8](https://github.com/cssnano/cssnano/commit/4d3b3f8fa5a389329989b13f85f3523e56c81435))
 
 ## 4.0.5 (2018-07-30)
 
-
 ### Bug Fixes
 
-* border minification throwing error ([#570](https://github.com/cssnano/cssnano/issues/570)) ([#571](https://github.com/cssnano/cssnano/issues/571)) ([c8f151f](https://github.com/cssnano/cssnano/commit/c8f151f5f9d13e0158fdada5e6c4d375a4a17c4b))
-
-
+- border minification throwing error ([#570](https://github.com/cssnano/cssnano/issues/570)) ([#571](https://github.com/cssnano/cssnano/issues/571)) ([c8f151f](https://github.com/cssnano/cssnano/commit/c8f151f5f9d13e0158fdada5e6c4d375a4a17c4b))
 
 ## 4.0.4 (2018-07-25)
 
-
 ### Bug Fixes
 
-* don't drop border-width with custom property from border shorthand ([#562](https://github.com/cssnano/cssnano/issues/562)) ([24a4bb0](https://github.com/cssnano/cssnano/commit/24a4bb0d687691f611843d1bc5e86e43d0412f1e))
-* not convert currentColor ([#559](https://github.com/cssnano/cssnano/issues/559)) ([#560](https://github.com/cssnano/cssnano/issues/560)) ([81f488d](https://github.com/cssnano/cssnano/commit/81f488d97f57d08c60ab185c7f8c9fdc0c19227d))
-* not merge border properties if there is a shorthand property between them ([#557](https://github.com/cssnano/cssnano/issues/557)) ([#558](https://github.com/cssnano/cssnano/issues/558)) ([28d89b0](https://github.com/cssnano/cssnano/commit/28d89b011f3a4671a77dfa93b563cc33af4206c9))
-
-
+- don't drop border-width with custom property from border shorthand ([#562](https://github.com/cssnano/cssnano/issues/562)) ([24a4bb0](https://github.com/cssnano/cssnano/commit/24a4bb0d687691f611843d1bc5e86e43d0412f1e))
+- not convert currentColor ([#559](https://github.com/cssnano/cssnano/issues/559)) ([#560](https://github.com/cssnano/cssnano/issues/560)) ([81f488d](https://github.com/cssnano/cssnano/commit/81f488d97f57d08c60ab185c7f8c9fdc0c19227d))
+- not merge border properties if there is a shorthand property between them ([#557](https://github.com/cssnano/cssnano/issues/557)) ([#558](https://github.com/cssnano/cssnano/issues/558)) ([28d89b0](https://github.com/cssnano/cssnano/commit/28d89b011f3a4671a77dfa93b563cc33af4206c9))
 
 ## 4.0.3 (2018-07-18)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-merge-longhand/CHANGELOG.md
+++ b/packages/postcss-merge-longhand/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+# 5.0.4
+
+### Chore
+
+- 07172825ffbb4f4: **postcss-merge-longhand**: drop css-color-names dependency
 
 # [5.0.3]
 

--- a/packages/postcss-merge-longhand/package.json
+++ b/packages/postcss-merge-longhand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-merge-longhand",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Merge longhand properties into shorthand with PostCSS.",
   "main": "dist/index.js",
   "files": [

--- a/packages/postcss-merge-rules/CHANGELOG.md
+++ b/packages/postcss-merge-rules/CHANGELOG.md
@@ -3,91 +3,64 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.2](2021-05-28)
+## 5.0.2 (2021-05-28)
 
 ### Bug fixes
 
-* Check all intersections when merging rules (https://github.com/cssnano/cssnano/commit/069c4249dc10a71e0fef455bf4ebea17776dbcf2)
+- Check all intersections when merging rules (https://github.com/cssnano/cssnano/commit/069c4249dc10a71e0fef455bf4ebea17776dbcf2)
 
 ## [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-merge-rules@5.0.0...postcss-merge-rules@5.0.1) (2021-05-19)
 
-
 ### Bug Fixes
 
-* **postcss-merge-rules:** add some missing known pseudo classes. ([#1099](https://github.com/cssnano/cssnano/issues/1099)) ([4d7fe36](https://github.com/cssnano/cssnano/commit/4d7fe367bebab86c7b5664ed4621ee7586ca7d86))
-* **postcss-merge-rules:** prevent breaking rule merges ([#1072](https://github.com/cssnano/cssnano/issues/1072)) ([c5e0a5e](https://github.com/cssnano/cssnano/commit/c5e0a5eac171089ae994fcba21d9c565fb462577)), closes [#999](https://github.com/cssnano/cssnano/issues/999)
-
-
-
-
+- **postcss-merge-rules:** add some missing known pseudo classes. ([#1099](https://github.com/cssnano/cssnano/issues/1099)) ([4d7fe36](https://github.com/cssnano/cssnano/commit/4d7fe367bebab86c7b5664ed4621ee7586ca7d86))
+- **postcss-merge-rules:** prevent breaking rule merges ([#1072](https://github.com/cssnano/cssnano/issues/1072)) ([c5e0a5e](https://github.com/cssnano/cssnano/commit/c5e0a5eac171089ae994fcba21d9c565fb462577)), closes [#999](https://github.com/cssnano/cssnano/issues/999)
 
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-merge-rules@5.0.0-rc.2...postcss-merge-rules@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-merge-rules
 
-
-
-
-
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-merge-rules@5.0.0-rc.1...postcss-merge-rules@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-merge-rules
-
-
-
-
 
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-merge-rules@5.0.0-rc.0...postcss-merge-rules@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-merge-rules
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* don't unsafe merge 'all' declaration ([#872](https://github.com/cssnano/cssnano/issues/872)) ([6ea9e5d](https://github.com/cssnano/cssnano/commit/6ea9e5dcad2d8ea22be7209332ee29d352c807de))
-* focus-visible issue ([#882](https://github.com/cssnano/cssnano/issues/882)) ([4cfcaaf](https://github.com/cssnano/cssnano/commit/4cfcaaf25b162ec2b0308907a408d7dba6a354c3))
-* **merge-rules, merge-idents:** add support for nested at-rules ([#719](https://github.com/cssnano/cssnano/issues/719)) ([cdedda7](https://github.com/cssnano/cssnano/commit/cdedda7f9d67873d872add044ad34c91616579f3))
-* **postcss-merge-rules:** don't change specificity of prefixed properties ([#723](https://github.com/cssnano/cssnano/issues/723)) ([863cf2b](https://github.com/cssnano/cssnano/commit/863cf2b3470d3172523a3165dc368abcfa18809c))
-
+- don't unsafe merge 'all' declaration ([#872](https://github.com/cssnano/cssnano/issues/872)) ([6ea9e5d](https://github.com/cssnano/cssnano/commit/6ea9e5dcad2d8ea22be7209332ee29d352c807de))
+- focus-visible issue ([#882](https://github.com/cssnano/cssnano/issues/882)) ([4cfcaaf](https://github.com/cssnano/cssnano/commit/4cfcaaf25b162ec2b0308907a408d7dba6a354c3))
+- **merge-rules, merge-idents:** add support for nested at-rules ([#719](https://github.com/cssnano/cssnano/issues/719)) ([cdedda7](https://github.com/cssnano/cssnano/commit/cdedda7f9d67873d872add044ad34c91616579f3))
+- **postcss-merge-rules:** don't change specificity of prefixed properties ([#723](https://github.com/cssnano/cssnano/issues/723)) ([863cf2b](https://github.com/cssnano/cssnano/commit/863cf2b3470d3172523a3165dc368abcfa18809c))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-* **postcss-merge-rules:** merge at-rules ([#722](https://github.com/cssnano/cssnano/issues/722)) ([8d4610a](https://github.com/cssnano/cssnano/commit/8d4610a6391ddab29bcb08ef0522d0b7ce2d6582))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
+- **postcss-merge-rules:** merge at-rules ([#722](https://github.com/cssnano/cssnano/issues/722)) ([8d4610a](https://github.com/cssnano/cssnano/commit/8d4610a6391ddab29bcb08ef0522d0b7ce2d6582))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Performance Improvements
 
-* **postcss-merge-rules:** increase perf ([#681](https://github.com/cssnano/cssnano/issues/681)) ([35bad2b](https://github.com/cssnano/cssnano/commit/35bad2b70fca5390c88eaabc24c25bb8d28b2f95))
-
-
+- **postcss-merge-rules:** increase perf ([#681](https://github.com/cssnano/cssnano/issues/681)) ([35bad2b](https://github.com/cssnano/cssnano/commit/35bad2b70fca5390c88eaabc24c25bb8d28b2f95))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* handle uppercase `all` property in merge rules ([#611](https://github.com/cssnano/cssnano/issues/611)) ([0dfe335](https://github.com/cssnano/cssnano/commit/0dfe3355951fa4a080a04dca34c6d99420def7ac))
-* merge same atrules with difference case ([#605](https://github.com/cssnano/cssnano/issues/605)) ([ca350fd](https://github.com/cssnano/cssnano/commit/ca350fda779bab5ca2eadf70299d92f8e495a273))
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- handle uppercase `all` property in merge rules ([#611](https://github.com/cssnano/cssnano/issues/611)) ([0dfe335](https://github.com/cssnano/cssnano/commit/0dfe3355951fa4a080a04dca34c6d99420def7ac))
+- merge same atrules with difference case ([#605](https://github.com/cssnano/cssnano/issues/605)) ([ca350fd](https://github.com/cssnano/cssnano/commit/ca350fda779bab5ca2eadf70299d92f8e495a273))
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-merge-rules/CHANGELOG.md
+++ b/packages/postcss-merge-rules/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+# 5.0.3 (2021-11-16)
+
+### Chore
+
+- 31d5c07dc07a4: refactor: drop one-liner dependencies
 
 ## 5.0.2 (2021-05-28)
 

--- a/packages/postcss-merge-rules/package.json
+++ b/packages/postcss-merge-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-merge-rules",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Merge CSS rules with PostCSS.",
   "main": "dist/index.js",
   "files": [

--- a/packages/postcss-minify-font-values/CHANGELOG.md
+++ b/packages/postcss-minify-font-values/CHANGELOG.md
@@ -7,67 +7,42 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-minify-font-values
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-minify-font-values@5.0.0-rc.2...postcss-minify-font-values@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-minify-font-values
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-minify-font-values@5.0.0-rc.1...postcss-minify-font-values@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-minify-font-values
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-minify-font-values@5.0.0-rc.0...postcss-minify-font-values@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-minify-font-values
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-minify-font-values:** correct minify font family with css variables ([#740](https://github.com/cssnano/cssnano/issues/740)) ([fc3eae9](https://github.com/cssnano/cssnano/commit/fc3eae9417974ad0ea38fa055668a2f52493b2ec))
-
+- **postcss-minify-font-values:** correct minify font family with css variables ([#740](https://github.com/cssnano/cssnano/issues/740)) ([fc3eae9](https://github.com/cssnano/cssnano/commit/fc3eae9417974ad0ea38fa055668a2f52493b2ec))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.3 (2018-09-25)
 
-
-
 ## 4.1.1 (2018-09-24)
-
 
 ### Bug Fixes
 
-* minify uppercase `weight` values in `font` property ([#612](https://github.com/cssnano/cssnano/issues/612)) ([a520e69](https://github.com/cssnano/cssnano/commit/a520e6906e7fa17951a64769f030ed7b6f44c38a))
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- minify uppercase `weight` values in `font` property ([#612](https://github.com/cssnano/cssnano/issues/612)) ([a520e69](https://github.com/cssnano/cssnano/commit/a520e6906e7fa17951a64769f030ed7b6f44c38a))
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-minify-gradients/CHANGELOG.md
+++ b/packages/postcss-minify-gradients/CHANGELOG.md
@@ -3,89 +3,61 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.3] (2021-11-01)
+# 5.0.3 (2021-11-01)
 
 ### Bug fixes
 
-* **postcss-minify-gradients:** handle 2 color-stop-length in linear gradient ([#1215](https://github.com/cssnano/cssnano/pull/1215)) ([8bb7ba6c](https://github.com/cssnano/cssnano/commit/8bb7ba6c1733fd12122589169d847b1a1212a6b5))
+- **postcss-minify-gradients:** handle 2 color-stop-length in linear gradient ([#1215](https://github.com/cssnano/cssnano/pull/1215)) ([8bb7ba6c](https://github.com/cssnano/cssnano/commit/8bb7ba6c1733fd12122589169d847b1a1212a6b5))
 
-
-# [5.0.2] (2021-08-18)
+# 5.0.2 (2021-08-18)
 
 ## Chore
 
-* **postcss-minify-gradients:** remove extra dependencies ([#1181](https://github.com/cssnano/cssnano/pull/1181)) ([50eb53](https://github.com/cssnano/cssnano/commit/50eb53e63b6eaae598ae4e51d02255ec8dcc9c8f))
-
+- **postcss-minify-gradients:** remove extra dependencies ([#1181](https://github.com/cssnano/cssnano/pull/1181)) ([50eb53](https://github.com/cssnano/cssnano/commit/50eb53e63b6eaae598ae4e51d02255ec8dcc9c8f))
 
 ## [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-minify-gradients@5.0.0...postcss-minify-gradients@5.0.1) (2021-05-19)
 
 **Note:** Version bump only for package postcss-minify-gradients
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-minify-gradients@5.0.0-rc.2...postcss-minify-gradients@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-minify-gradients
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-minify-gradients@5.0.0-rc.1...postcss-minify-gradients@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-minify-gradients
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-minify-gradients@5.0.0-rc.0...postcss-minify-gradients@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-minify-gradients
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-minify-gradients:** don't break gradients with `var` and `env` functions ([#735](https://github.com/cssnano/cssnano/issues/735)) ([7fabd9d](https://github.com/cssnano/cssnano/commit/7fabd9d03c81142c5854d0c0a50bee15ed86c219))
-
+- **postcss-minify-gradients:** don't break gradients with `var` and `env` functions ([#735](https://github.com/cssnano/cssnano/issues/735)) ([7fabd9d](https://github.com/cssnano/cssnano/commit/7fabd9d03c81142c5854d0c0a50bee15ed86c219))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Bug Fixes
 
-* **postcss-minify-gradients:** handle uppercase ([#706](https://github.com/cssnano/cssnano/issues/706)) ([acd5d0e](https://github.com/cssnano/cssnano/commit/acd5d0eb59e76fe62b70faad89d6ee0f76f798ef))
-
-
+- **postcss-minify-gradients:** handle uppercase ([#706](https://github.com/cssnano/cssnano/issues/706)) ([acd5d0e](https://github.com/cssnano/cssnano/commit/acd5d0eb59e76fe62b70faad89d6ee0f76f798ef))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-minify-params/CHANGELOG.md
+++ b/packages/postcss-minify-params/CHANGELOG.md
@@ -7,72 +7,46 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-minify-params
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-minify-params@5.0.0-rc.2...postcss-minify-params@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-minify-params
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-minify-params@5.0.0-rc.1...postcss-minify-params@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-minify-params
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-minify-params@5.0.0-rc.0...postcss-minify-params@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-minify-params
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Bug Fixes
 
-* do not mangle `[@page](https://github.com/page) :first` rules ([#678](https://github.com/cssnano/cssnano/issues/678)) ([69aab0b](https://github.com/cssnano/cssnano/commit/69aab0b527198979e2232a57554cf888ad868231))
-
+- do not mangle `[@page](https://github.com/page) :first` rules ([#678](https://github.com/cssnano/cssnano/issues/678)) ([69aab0b](https://github.com/cssnano/cssnano/commit/69aab0b527198979e2232a57554cf888ad868231))
 
 ### Performance Improvements
 
-* **postcss-minify-params:** increase perf ([e06a24e](https://github.com/cssnano/cssnano/commit/e06a24e44aae8935290b7bc05d9da51b99367d2b))
-
-
+- **postcss-minify-params:** increase perf ([e06a24e](https://github.com/cssnano/cssnano/commit/e06a24e44aae8935290b7bc05d9da51b99367d2b))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* add `browserslist` to dependencies for `postcss-minify-params` ([#594](https://github.com/cssnano/cssnano/issues/594)) ([9d40806](https://github.com/cssnano/cssnano/commit/9d40806151026dcd2272dc22a76009b27224d512))
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- add `browserslist` to dependencies for `postcss-minify-params` ([#594](https://github.com/cssnano/cssnano/issues/594)) ([9d40806](https://github.com/cssnano/cssnano/commit/9d40806151026dcd2272dc22a76009b27224d512))
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-minify-params/CHANGELOG.md
+++ b/packages/postcss-minify-params/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+# 5.0.2 (2021-11-16)
+
+### Chore
+
+- 31d5c07dc07a4: refactor: drop one-liner dependencies
 
 ## [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-minify-params@5.0.0...postcss-minify-params@5.0.1) (2021-05-19)
 

--- a/packages/postcss-minify-params/package.json
+++ b/packages/postcss-minify-params/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-minify-params",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Minify at-rule params with PostCSS",
   "keywords": [
     "postcss",

--- a/packages/postcss-minify-selectors/CHANGELOG.md
+++ b/packages/postcss-minify-selectors/CHANGELOG.md
@@ -5,77 +5,50 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [5.1.0](https://github.com/cssnano/cssnano/compare/postcss-minify-selectors@5.0.0...postcss-minify-selectors@5.1.0) (2021-05-19)
 
-
 ### Features
 
-* **postcss-minify-selectors:** upgrade postcss-selector-parser ([9bce2b6](https://github.com/cssnano/cssnano/commit/9bce2b6ccfa49c50be05efb0c80c1e3938b650b3))
-
-
-
-
+- **postcss-minify-selectors:** upgrade postcss-selector-parser ([9bce2b6](https://github.com/cssnano/cssnano/commit/9bce2b6ccfa49c50be05efb0c80c1e3938b650b3))
 
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-minify-selectors@5.0.0-rc.2...postcss-minify-selectors@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-minify-selectors
 
-
-
-
-
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-minify-selectors@5.0.0-rc.1...postcss-minify-selectors@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-minify-selectors
-
-
-
-
 
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-minify-selectors@5.0.0-rc.0...postcss-minify-selectors@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-minify-selectors
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-minify-selectors:** added check for node.operator for namespace ([#926](https://github.com/cssnano/cssnano/issues/926)) ([1197451](https://github.com/cssnano/cssnano/commit/11974512810272411256381527fc719a35a7492a))
-
+- **postcss-minify-selectors:** added check for node.operator for namespace ([#926](https://github.com/cssnano/cssnano/issues/926)) ([1197451](https://github.com/cssnano/cssnano/commit/11974512810272411256381527fc719a35a7492a))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Performance Improvements
 
-* **postcss-minify-selectors:** increase perf ([#697](https://github.com/cssnano/cssnano/issues/697)) ([043b231](https://github.com/cssnano/cssnano/commit/043b2314cec1358bee3341ba2fd4bfe9e2eacaa2))
-
-
+- **postcss-minify-selectors:** increase perf ([#697](https://github.com/cssnano/cssnano/issues/697)) ([043b231](https://github.com/cssnano/cssnano/commit/043b2314cec1358bee3341ba2fd4bfe9e2eacaa2))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* better minify selectors with uppercase values ([#609](https://github.com/cssnano/cssnano/issues/609)) ([e753beb](https://github.com/cssnano/cssnano/commit/e753beb4eb8b50f5ad2d17342be4b108e0814544))
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- better minify selectors with uppercase values ([#609](https://github.com/cssnano/cssnano/issues/609)) ([e753beb](https://github.com/cssnano/cssnano/commit/e753beb4eb8b50f5ad2d17342be4b108e0814544))
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-normalize-charset/CHANGELOG.md
+++ b/packages/postcss-normalize-charset/CHANGELOG.md
@@ -7,57 +7,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-normalize-charset
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-normalize-charset@5.0.0-rc.2...postcss-normalize-charset@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-normalize-charset
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-normalize-charset@5.0.0-rc.1...postcss-normalize-charset@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-normalize-charset
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-normalize-charset@5.0.0-rc.0...postcss-normalize-charset@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-normalize-charset
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.2 (2018-09-25)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-normalize-display-values/CHANGELOG.md
+++ b/packages/postcss-normalize-display-values/CHANGELOG.md
@@ -7,66 +7,41 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-normalize-display-values
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-normalize-display-values@5.0.0-rc.2...postcss-normalize-display-values@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-normalize-display-values
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-normalize-display-values@5.0.0-rc.1...postcss-normalize-display-values@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-normalize-display-values
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-normalize-display-values@5.0.0-rc.0...postcss-normalize-display-values@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-normalize-display-values
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Performance Improvements
 
-* **postcss-normalize-display-values:** increase perf ([#695](https://github.com/cssnano/cssnano/issues/695)) ([33ebbfb](https://github.com/cssnano/cssnano/commit/33ebbfb63314d7c2b3670ae047bf92ba2507b7e6))
-
-
+- **postcss-normalize-display-values:** increase perf ([#695](https://github.com/cssnano/cssnano/issues/695)) ([33ebbfb](https://github.com/cssnano/cssnano/commit/33ebbfb63314d7c2b3670ae047bf92ba2507b7e6))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-normalize-positions/CHANGELOG.md
+++ b/packages/postcss-normalize-positions/CHANGELOG.md
@@ -7,73 +7,47 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-normalize-positions
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-normalize-positions@5.0.0-rc.2...postcss-normalize-positions@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-normalize-positions
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-normalize-positions@5.0.0-rc.1...postcss-normalize-positions@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-normalize-positions
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-normalize-positions@5.0.0-rc.0...postcss-normalize-positions@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-normalize-positions
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-normalize-positions:** correct optimize math (`calc` and etc) and variable functions (`var` and `env`) ([#750](https://github.com/cssnano/cssnano/issues/750)) ([a81e8df](https://github.com/cssnano/cssnano/commit/a81e8dfc1ad26067d5a9efab8081072cd4b15c44))
-* **postcss-normalize-repeat-style:** better handle css variables ([#753](https://github.com/cssnano/cssnano/issues/753)) ([7e18b0c](https://github.com/cssnano/cssnano/commit/7e18b0cbcd7cb5de58e60ab4ef1900a4d8eeefec))
-
+- **postcss-normalize-positions:** correct optimize math (`calc` and etc) and variable functions (`var` and `env`) ([#750](https://github.com/cssnano/cssnano/issues/750)) ([a81e8df](https://github.com/cssnano/cssnano/commit/a81e8dfc1ad26067d5a9efab8081072cd4b15c44))
+- **postcss-normalize-repeat-style:** better handle css variables ([#753](https://github.com/cssnano/cssnano/issues/753)) ([7e18b0c](https://github.com/cssnano/cssnano/commit/7e18b0cbcd7cb5de58e60ab4ef1900a4d8eeefec))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Performance Improvements
 
-* **postcss-normalize-positions:** increase perf ([#694](https://github.com/cssnano/cssnano/issues/694)) ([95639da](https://github.com/cssnano/cssnano/commit/95639da5659aef112586b9334a1e13ac0b61a525))
-
-
+- **postcss-normalize-positions:** increase perf ([#694](https://github.com/cssnano/cssnano/issues/694)) ([95639da](https://github.com/cssnano/cssnano/commit/95639da5659aef112586b9334a1e13ac0b61a525))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* handle uppercase property and values on `postcss-normalize-positions` ([#607](https://github.com/cssnano/cssnano/issues/607)) ([c521423](https://github.com/cssnano/cssnano/commit/c521423d5939039b771ba1b12fad5fe377a6c612))
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- handle uppercase property and values on `postcss-normalize-positions` ([#607](https://github.com/cssnano/cssnano/issues/607)) ([c521423](https://github.com/cssnano/cssnano/commit/c521423d5939039b771ba1b12fad5fe377a6c612))
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-normalize-repeat-style/CHANGELOG.md
+++ b/packages/postcss-normalize-repeat-style/CHANGELOG.md
@@ -7,71 +7,45 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-normalize-repeat-style
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-normalize-repeat-style@5.0.0-rc.2...postcss-normalize-repeat-style@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-normalize-repeat-style
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-normalize-repeat-style@5.0.0-rc.1...postcss-normalize-repeat-style@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-normalize-repeat-style
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-normalize-repeat-style@5.0.0-rc.0...postcss-normalize-repeat-style@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-normalize-repeat-style
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-normalize-repeat-style:** better handle css variables ([#753](https://github.com/cssnano/cssnano/issues/753)) ([7e18b0c](https://github.com/cssnano/cssnano/commit/7e18b0cbcd7cb5de58e60ab4ef1900a4d8eeefec))
-
+- **postcss-normalize-repeat-style:** better handle css variables ([#753](https://github.com/cssnano/cssnano/issues/753)) ([7e18b0c](https://github.com/cssnano/cssnano/commit/7e18b0cbcd7cb5de58e60ab4ef1900a4d8eeefec))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Performance Improvements
 
-* **postcss-normalize-repeat-style:** increase perf ([#690](https://github.com/cssnano/cssnano/issues/690)) ([2c900e4](https://github.com/cssnano/cssnano/commit/2c900e4176e4aabd484e468b32b1ed1011c00ef4))
-
-
+- **postcss-normalize-repeat-style:** increase perf ([#690](https://github.com/cssnano/cssnano/issues/690)) ([2c900e4](https://github.com/cssnano/cssnano/commit/2c900e4176e4aabd484e468b32b1ed1011c00ef4))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-normalize-string/CHANGELOG.md
+++ b/packages/postcss-normalize-string/CHANGELOG.md
@@ -7,71 +7,45 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-normalize-string
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-normalize-string@5.0.0-rc.2...postcss-normalize-string@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-normalize-string
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-normalize-string@5.0.0-rc.1...postcss-normalize-string@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-normalize-string
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-normalize-string@5.0.0-rc.0...postcss-normalize-string@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-normalize-string
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-ordered-values:** columns transform returning string instead of the AST ([#928](https://github.com/cssnano/cssnano/issues/928)) ([a5d6d36](https://github.com/cssnano/cssnano/commit/a5d6d364e0815ecb198a95de301f3554ccce4f78))
-
+- **postcss-ordered-values:** columns transform returning string instead of the AST ([#928](https://github.com/cssnano/cssnano/issues/928)) ([a5d6d36](https://github.com/cssnano/cssnano/commit/a5d6d364e0815ecb198a95de301f3554ccce4f78))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Performance Improvements
 
-* **postcss-normalize-string:** increase perf ([#689](https://github.com/cssnano/cssnano/issues/689)) ([07948cb](https://github.com/cssnano/cssnano/commit/07948cb3ff433825682c499516640abeeec7383a))
-
-
+- **postcss-normalize-string:** increase perf ([#689](https://github.com/cssnano/cssnano/issues/689)) ([07948cb](https://github.com/cssnano/cssnano/commit/07948cb3ff433825682c499516640abeeec7383a))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-normalize-timing-functions/CHANGELOG.md
+++ b/packages/postcss-normalize-timing-functions/CHANGELOG.md
@@ -7,77 +7,50 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-normalize-timing-functions
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-normalize-timing-functions@5.0.0-rc.2...postcss-normalize-timing-functions@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-normalize-timing-functions
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-normalize-timing-functions@5.0.0-rc.1...postcss-normalize-timing-functions@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-normalize-timing-functions
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-normalize-timing-functions@5.0.0-rc.0...postcss-normalize-timing-functions@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-normalize-timing-functions
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-normalize-timing-functions:** do not break invalid syntax ([#748](https://github.com/cssnano/cssnano/issues/748)) ([efd2077](https://github.com/cssnano/cssnano/commit/efd20775be85f9845cb343c69b5dc1bb25672a42))
-
+- **postcss-normalize-timing-functions:** do not break invalid syntax ([#748](https://github.com/cssnano/cssnano/issues/748)) ([efd2077](https://github.com/cssnano/cssnano/commit/efd20775be85f9845cb343c69b5dc1bb25672a42))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Bug Fixes
 
-* **postcss-normalize-timing-functions:** cache ([#693](https://github.com/cssnano/cssnano/issues/693)) ([7e6e481](https://github.com/cssnano/cssnano/commit/7e6e481244964bf77a1085d8db3f516597b264e9))
-
+- **postcss-normalize-timing-functions:** cache ([#693](https://github.com/cssnano/cssnano/issues/693)) ([7e6e481](https://github.com/cssnano/cssnano/commit/7e6e481244964bf77a1085d8db3f516597b264e9))
 
 ### Performance Improvements
 
-* **postcss-normalize-timing-functions:** increase perf ([#687](https://github.com/cssnano/cssnano/issues/687)) ([2bef7d1](https://github.com/cssnano/cssnano/commit/2bef7d1f4f9f6dc33d0a4fb120926a85b08403e7))
-
-
+- **postcss-normalize-timing-functions:** increase perf ([#687](https://github.com/cssnano/cssnano/issues/687)) ([2bef7d1](https://github.com/cssnano/cssnano/commit/2bef7d1f4f9f6dc33d0a4fb120926a85b08403e7))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* do not lowercased property ([#606](https://github.com/cssnano/cssnano/issues/606)) ([d40c657](https://github.com/cssnano/cssnano/commit/d40c6577f1d942d00aade671f5e7ab422870c517))
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- do not lowercased property ([#606](https://github.com/cssnano/cssnano/issues/606)) ([d40c657](https://github.com/cssnano/cssnano/commit/d40c6577f1d942d00aade671f5e7ab422870c517))
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-normalize-unicode/CHANGELOG.md
+++ b/packages/postcss-normalize-unicode/CHANGELOG.md
@@ -7,58 +7,36 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-normalize-unicode
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-normalize-unicode@5.0.0-rc.2...postcss-normalize-unicode@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-normalize-unicode
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-normalize-unicode@5.0.0-rc.1...postcss-normalize-unicode@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-normalize-unicode
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-normalize-unicode@5.0.0-rc.0...postcss-normalize-unicode@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-normalize-unicode
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* postcss-normalize-unicode add browserslist to dependencies ([#577](https://github.com/cssnano/cssnano/issues/577)) ([39ec020](https://github.com/cssnano/cssnano/commit/39ec020d9d6fc6ed72bf8de6e856752726d4fb51))
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- postcss-normalize-unicode add browserslist to dependencies ([#577](https://github.com/cssnano/cssnano/issues/577)) ([39ec020](https://github.com/cssnano/cssnano/commit/39ec020d9d6fc6ed72bf8de6e856752726d4fb51))
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-normalize-url/CHANGELOG.md
+++ b/packages/postcss-normalize-url/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+# 5.0.3 (2021-11-16)
+
+### Bug fixes
+
+- c38f14c3ce3d0b: **postcss-normalize-url**: avoid changing parameter encoding
 
 # 5.0.2 (2021-06-09)
 

--- a/packages/postcss-normalize-url/CHANGELOG.md
+++ b/packages/postcss-normalize-url/CHANGELOG.md
@@ -3,71 +3,47 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.2] (2021-06-09)
+# 5.0.2 (2021-06-09)
 
 ### Bug fixes
 
 **postcss-normalize-url**: bump normalize-url dependency to 6.0.1 (#1142)
 ([b60f54bed](https://github.com/cssnano/cssnano/commit/b60f54bedafe3781ff58f0888ab45ff5c56aee09))
 
-
-
 # [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-normalize-url@5.0.0...postcss-normalize-url@5.0.1) (2021-05-19)
 
 **Note:** Version bump only for package postcss-normalize-url
-
-
-
-
 
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-normalize-url@5.0.0-rc.2...postcss-normalize-url@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-normalize-url
 
-
-
-
-
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-normalize-url@5.0.0-rc.1...postcss-normalize-url@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-normalize-url
-
-
-
-
 
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-normalize-url@5.0.0-rc.0...postcss-normalize-url@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-normalize-url
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* do not handle uppercase data URI in url function ([#608](https://github.com/cssnano/cssnano/issues/608)) ([c43be8d](https://github.com/cssnano/cssnano/commit/c43be8d62b4c03b33390b177ff8e338b7192d824))
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- do not handle uppercase data URI in url function ([#608](https://github.com/cssnano/cssnano/issues/608)) ([c43be8d](https://github.com/cssnano/cssnano/commit/c43be8d62b4c03b33390b177ff8e338b7192d824))
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-normalize-url/package.json
+++ b/packages/postcss-normalize-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-normalize-url",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Normalize URLs with PostCSS",
   "main": "dist/index.js",
   "files": [

--- a/packages/postcss-normalize-whitespace/CHANGELOG.md
+++ b/packages/postcss-normalize-whitespace/CHANGELOG.md
@@ -7,75 +7,47 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-normalize-whitespace
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-normalize-whitespace@5.0.0-rc.2...postcss-normalize-whitespace@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-normalize-whitespace
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-normalize-whitespace@5.0.0-rc.1...postcss-normalize-whitespace@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-normalize-whitespace
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-normalize-whitespace@5.0.0-rc.0...postcss-normalize-whitespace@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-normalize-whitespace
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* normalize-whitespace for var/env/contant function ([#835](https://github.com/cssnano/cssnano/issues/835)) ([c8ff54f](https://github.com/cssnano/cssnano/commit/c8ff54f4f6a168ca2a6f74d6fdbef5f28dc89282))
-
+- normalize-whitespace for var/env/contant function ([#835](https://github.com/cssnano/cssnano/issues/835)) ([c8ff54f](https://github.com/cssnano/cssnano/commit/c8ff54f4f6a168ca2a6f74d6fdbef5f28dc89282))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Performance Improvements
 
-* **postcss-normalize-whitespace:** increase perf ([#699](https://github.com/cssnano/cssnano/issues/699)) ([fe19120](https://github.com/cssnano/cssnano/commit/fe19120a4fc1e3c8cb014c40fc0e01cb95ffac5a))
-
-
+- **postcss-normalize-whitespace:** increase perf ([#699](https://github.com/cssnano/cssnano/issues/699)) ([fe19120](https://github.com/cssnano/cssnano/commit/fe19120a4fc1e3c8cb014c40fc0e01cb95ffac5a))
 
 ## 4.1.5 (2018-10-17)
 
-
-
 ## 4.1.1 (2018-09-24)
-
 
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-ordered-values/CHANGELOG.md
+++ b/packages/postcss-ordered-values/CHANGELOG.md
@@ -3,100 +3,67 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-
-# [5.0.2] (2021-06-09)
+# 5.0.2 (2021-06-09)
 
 ### Bug fixes
 
 **postcss-ordered-values**: preserve columns count (#1144)
 ([9acd6a2fe3e](https://github.com/cssnano/cssnano/commit/9acd6a2fe3e188a5f29fef91cf406495fa74a877))
 
-
-
-
 # [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-ordered-values@5.0.0...postcss-ordered-values@5.0.1) (2021-05-19)
 
 **Note:** Version bump only for package postcss-ordered-values
-
-
-
-
 
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-ordered-values@5.0.0-rc.2...postcss-ordered-values@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-ordered-values
 
-
-
-
-
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-ordered-values@5.0.0-rc.1...postcss-ordered-values@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-ordered-values
-
-
-
-
 
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-ordered-values@5.0.0-rc.0...postcss-ordered-values@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-ordered-values
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **postcss-ordered-values:** columns transform returning string instead of the AST ([#928](https://github.com/cssnano/cssnano/issues/928)) ([a5d6d36](https://github.com/cssnano/cssnano/commit/a5d6d364e0815ecb198a95de301f3554ccce4f78))
-* **postcss-ordered-values:** respect env function ([#755](https://github.com/cssnano/cssnano/issues/755)) ([3122aae](https://github.com/cssnano/cssnano/commit/3122aae20900500198223830fafec93275d5b375))
-
+- **postcss-ordered-values:** columns transform returning string instead of the AST ([#928](https://github.com/cssnano/cssnano/issues/928)) ([a5d6d36](https://github.com/cssnano/cssnano/commit/a5d6d364e0815ecb198a95de301f3554ccce4f78))
+- **postcss-ordered-values:** respect env function ([#755](https://github.com/cssnano/cssnano/issues/755)) ([3122aae](https://github.com/cssnano/cssnano/commit/3122aae20900500198223830fafec93275d5b375))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* added support for grid-* ([#863](https://github.com/cssnano/cssnano/issues/863)) ([b720b69](https://github.com/cssnano/cssnano/commit/b720b69522ba5127699afc1fa131b425d68b4c08))
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-* **ordered-values:** added support for columns and column-rule ([#861](https://github.com/cssnano/cssnano/issues/861)) ([126fc7f](https://github.com/cssnano/cssnano/commit/126fc7ff618fde86b4f15c5d07cb57e882810526))
-* **ordered-values:** added support for more border props ([#858](https://github.com/cssnano/cssnano/issues/858)) ([8243401](https://github.com/cssnano/cssnano/commit/8243401cfd483b99e8d0458d39acde1779b15755))
-* **postcss-ordered-values:** compress more vendor properties ([#746](https://github.com/cssnano/cssnano/issues/746)) ([b479440](https://github.com/cssnano/cssnano/commit/b4794404bffa54558654b215eb550e6adb98e144))
-
+- added support for grid-\* ([#863](https://github.com/cssnano/cssnano/issues/863)) ([b720b69](https://github.com/cssnano/cssnano/commit/b720b69522ba5127699afc1fa131b425d68b4c08))
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
+- **ordered-values:** added support for columns and column-rule ([#861](https://github.com/cssnano/cssnano/issues/861)) ([126fc7f](https://github.com/cssnano/cssnano/commit/126fc7ff618fde86b4f15c5d07cb57e882810526))
+- **ordered-values:** added support for more border props ([#858](https://github.com/cssnano/cssnano/issues/858)) ([8243401](https://github.com/cssnano/cssnano/commit/8243401cfd483b99e8d0458d39acde1779b15755))
+- **postcss-ordered-values:** compress more vendor properties ([#746](https://github.com/cssnano/cssnano/issues/746)) ([b479440](https://github.com/cssnano/cssnano/commit/b4794404bffa54558654b215eb550e6adb98e144))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Performance Improvements
 
-* **postcss-ordered-values:** increase perf ([#692](https://github.com/cssnano/cssnano/issues/692)) ([4aca28b](https://github.com/cssnano/cssnano/commit/4aca28b1930e355246c9c5a1266507013ca473fa))
-
-
+- **postcss-ordered-values:** increase perf ([#692](https://github.com/cssnano/cssnano/issues/692)) ([4aca28b](https://github.com/cssnano/cssnano/commit/4aca28b1930e355246c9c5a1266507013ca473fa))
 
 ## 4.1.1 (2018-09-24)
 
-
-
 # 4.1.0 (2018-08-24)
-
 
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
-
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
 
 ### Features
 
-* **postcss-ordered-values:** support ordering animation values ([#574](https://github.com/cssnano/cssnano/issues/574)) ([17ec039](https://github.com/cssnano/cssnano/commit/17ec039dfbe7f596df12f5d5889bf3e6cd32afd6))
+- **postcss-ordered-values:** support ordering animation values ([#574](https://github.com/cssnano/cssnano/issues/574)) ([17ec039](https://github.com/cssnano/cssnano/commit/17ec039dfbe7f596df12f5d5889bf3e6cd32afd6))

--- a/packages/postcss-reduce-idents/CHANGELOG.md
+++ b/packages/postcss-reduce-idents/CHANGELOG.md
@@ -7,71 +7,45 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-reduce-idents
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-reduce-idents@5.0.0-rc.2...postcss-reduce-idents@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-reduce-idents
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-reduce-idents@5.0.0-rc.1...postcss-reduce-idents@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-reduce-idents
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-reduce-idents@5.0.0-rc.0...postcss-reduce-idents@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-reduce-idents
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **reduce-idents:** improve encode ([#862](https://github.com/cssnano/cssnano/issues/862)) ([c7b5879](https://github.com/cssnano/cssnano/commit/c7b5879077bca75ae1c1cbef7abc9389337bcfe5))
-
+- **reduce-idents:** improve encode ([#862](https://github.com/cssnano/cssnano/issues/862)) ([c7b5879](https://github.com/cssnano/cssnano/commit/c7b5879077bca75ae1c1cbef7abc9389337bcfe5))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Bug Fixes
 
-* **postcss-reduce-idents:** handle uppercase ([#705](https://github.com/cssnano/cssnano/issues/705)) ([ca38bd0](https://github.com/cssnano/cssnano/commit/ca38bd0ebe09af2f43e594f3ca347d0f1939d189))
-
-
+- **postcss-reduce-idents:** handle uppercase ([#705](https://github.com/cssnano/cssnano/issues/705)) ([ca38bd0](https://github.com/cssnano/cssnano/commit/ca38bd0ebe09af2f43e594f3ca347d0f1939d189))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-reduce-initial/CHANGELOG.md
+++ b/packages/postcss-reduce-initial/CHANGELOG.md
@@ -7,73 +7,47 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-reduce-initial
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-reduce-initial@5.0.0-rc.2...postcss-reduce-initial@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-reduce-initial
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-reduce-initial@5.0.0-rc.1...postcss-reduce-initial@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-reduce-initial
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-reduce-initial@5.0.0-rc.0...postcss-reduce-initial@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-reduce-initial
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* min-width/height issue ([#852](https://github.com/cssnano/cssnano/issues/852)) ([f6e767b](https://github.com/cssnano/cssnano/commit/f6e767b7ba672c5c1b4a1350f23b4b65a4851f96))
-
+- min-width/height issue ([#852](https://github.com/cssnano/cssnano/issues/852)) ([f6e767b](https://github.com/cssnano/cssnano/commit/f6e767b7ba672c5c1b4a1350f23b4b65a4851f96))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-* **postcss-reduce-initial:** added ignore options ([#929](https://github.com/cssnano/cssnano/issues/929)) ([2e63fe5](https://github.com/cssnano/cssnano/commit/2e63fe55b8059fc14d78aa11920d7ebf9a3682a1))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
+- **postcss-reduce-initial:** added ignore options ([#929](https://github.com/cssnano/cssnano/issues/929)) ([2e63fe5](https://github.com/cssnano/cssnano/commit/2e63fe55b8059fc14d78aa11920d7ebf9a3682a1))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Bug Fixes
 
-* **postcss-reduce-initial:** handle uppercase value toInitial ([#685](https://github.com/cssnano/cssnano/issues/685)) ([0e7beb3](https://github.com/cssnano/cssnano/commit/0e7beb3508fa8f85db67e3464bf8b8941bb6ca12))
-* change mask-repeat initial value on repeat ([#679](https://github.com/cssnano/cssnano/issues/679)) ([cebd6d5](https://github.com/cssnano/cssnano/commit/cebd6d5b789a9c700f92dc8b40cdd8ef9545441a))
-
-
+- **postcss-reduce-initial:** handle uppercase value toInitial ([#685](https://github.com/cssnano/cssnano/issues/685)) ([0e7beb3](https://github.com/cssnano/cssnano/commit/0e7beb3508fa8f85db67e3464bf8b8941bb6ca12))
+- change mask-repeat initial value on repeat ([#679](https://github.com/cssnano/cssnano/issues/679)) ([cebd6d5](https://github.com/cssnano/cssnano/commit/cebd6d5b789a9c700f92dc8b40cdd8ef9545441a))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-reduce-transforms/CHANGELOG.md
+++ b/packages/postcss-reduce-transforms/CHANGELOG.md
@@ -7,72 +7,46 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-reduce-transforms
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-reduce-transforms@5.0.0-rc.2...postcss-reduce-transforms@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-reduce-transforms
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-reduce-transforms@5.0.0-rc.1...postcss-reduce-transforms@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-reduce-transforms
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-reduce-transforms@5.0.0-rc.0...postcss-reduce-transforms@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-reduce-transforms
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-* **postcss-reduce-transforms:** improve optimizations ([#745](https://github.com/cssnano/cssnano/issues/745)) ([b0f0d89](https://github.com/cssnano/cssnano/commit/b0f0d892316d7b77e8033a6dc8d67745043a5072))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
+- **postcss-reduce-transforms:** improve optimizations ([#745](https://github.com/cssnano/cssnano/issues/745)) ([b0f0d89](https://github.com/cssnano/cssnano/commit/b0f0d892316d7b77e8033a6dc8d67745043a5072))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Bug Fixes
 
-* **fix-postcss-reduce-transforms:** cache ([#691](https://github.com/cssnano/cssnano/issues/691)) ([e07309f](https://github.com/cssnano/cssnano/commit/e07309ff0c07fb36ef2340bbed6b3aee3dad18be))
-
+- **fix-postcss-reduce-transforms:** cache ([#691](https://github.com/cssnano/cssnano/issues/691)) ([e07309f](https://github.com/cssnano/cssnano/commit/e07309ff0c07fb36ef2340bbed6b3aee3dad18be))
 
 ### Performance Improvements
 
-* **postcss-reduce-transforms:** increase perf ([#688](https://github.com/cssnano/cssnano/issues/688)) ([84ccba0](https://github.com/cssnano/cssnano/commit/84ccba00cead30e80510525cbcd27ba259c26065))
-
-
+- **postcss-reduce-transforms:** increase perf ([#688](https://github.com/cssnano/cssnano/issues/688)) ([84ccba0](https://github.com/cssnano/cssnano/commit/84ccba00cead30e80510525cbcd27ba259c26065))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-svgo/CHANGELOG.md
+++ b/packages/postcss-svgo/CHANGELOG.md
@@ -3,96 +3,69 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.3] (2021-11-01)
+# 5.0.3 (2021-11-01)
 
 ### Bug fixes
 
-* **postcss-svgo:** normalize SVG with escaped quote characters ([#1200](https://github.com/cssnano/cssnano/pull/1200)) ([4ef5e41](https://github.com/cssnano/cssnano/commit/4ef5e41a6c61a23094001da82a76321ca746b22f))
+- **postcss-svgo:** normalize SVG with escaped quote characters ([#1200](https://github.com/cssnano/cssnano/pull/1200)) ([4ef5e41](https://github.com/cssnano/cssnano/commit/4ef5e41a6c61a23094001da82a76321ca746b22f))
 
 ### Chore
 
-* **postcss-svgo:** update svgo to 2.7 ([#1209](https://github.com/cssnano/cssnano/pull/1209))
-([2b5841](https://github.com/cssnano/cssnano/commit/2b5841e06808f9c04e03c07b5da0f5a36de88cd3))
+- **postcss-svgo:** update svgo to 2.7 ([#1209](https://github.com/cssnano/cssnano/pull/1209))
+  ([2b5841](https://github.com/cssnano/cssnano/commit/2b5841e06808f9c04e03c07b5da0f5a36de88cd3))
 
-
-## [5.0.2] (2021-05-28)
+## 5.0.2 (2021-05-28)
 
 ### Bug fixes
 
-* Prevent crash when input contains relative URL (https://github.com/cssnano/cssnano/commit/0ff1716e4cd69152ad1f98d512fdeb6f311e8ad5) 
+- Prevent crash when input contains relative URL (https://github.com/cssnano/cssnano/commit/0ff1716e4cd69152ad1f98d512fdeb6f311e8ad5)
 
 ## [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-svgo@5.0.0...postcss-svgo@5.0.1) (2021-05-19)
+
 **Note:** Version bump only for package postcss-svgo
-
-
-
-
 
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-svgo@5.0.0-rc.2...postcss-svgo@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-svgo
 
-
-
-
-
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-svgo@5.0.0-rc.1...postcss-svgo@5.0.0-rc.2) (2021-03-15)
-
 
 ### Bug Fixes
 
-* update SVGO ([aa07cfd](https://github.com/cssnano/cssnano/commit/aa07cfd62c82ed4b1e87219eea8d0ed99635e4ca))
-
-
-
-
+- update SVGO ([aa07cfd](https://github.com/cssnano/cssnano/commit/aa07cfd62c82ed4b1e87219eea8d0ed99635e4ca))
 
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-svgo@5.0.0-rc.0...postcss-svgo@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-svgo
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* preserve base64 url suffixes in postcss-svgo ([#808](https://github.com/cssnano/cssnano/issues/808)) ([4336afd](https://github.com/cssnano/cssnano/commit/4336afdfc602004bb8b74ed19c0846914d87493d))
-* **postcss-svgo:** security problem with `js-yaml` ([#736](https://github.com/cssnano/cssnano/issues/736)) ([7241049](https://github.com/cssnano/cssnano/commit/724104992e22d1b51e65383a9c6fbeb89a6a73f0))
-
+- preserve base64 url suffixes in postcss-svgo ([#808](https://github.com/cssnano/cssnano/issues/808)) ([4336afd](https://github.com/cssnano/cssnano/commit/4336afdfc602004bb8b74ed19c0846914d87493d))
+- **postcss-svgo:** security problem with `js-yaml` ([#736](https://github.com/cssnano/cssnano/issues/736)) ([7241049](https://github.com/cssnano/cssnano/commit/724104992e22d1b51e65383a9c6fbeb89a6a73f0))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Performance Improvements
 
-* **postcss-svgo:** increase perf ([#698](https://github.com/cssnano/cssnano/issues/698)) ([829bd7c](https://github.com/cssnano/cssnano/commit/829bd7c2fa4a3505c74fe500b08d66f66178788b))
-
-
+- **postcss-svgo:** increase perf ([#698](https://github.com/cssnano/cssnano/issues/698)) ([829bd7c](https://github.com/cssnano/cssnano/commit/829bd7c2fa4a3505c74fe500b08d66f66178788b))
 
 ## 4.1.2 (2018-09-25)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-unique-selectors/CHANGELOG.md
+++ b/packages/postcss-unique-selectors/CHANGELOG.md
@@ -7,62 +7,39 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-unique-selectors
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-unique-selectors@5.0.0-rc.2...postcss-unique-selectors@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-unique-selectors
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-unique-selectors@5.0.0-rc.1...postcss-unique-selectors@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-unique-selectors
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-unique-selectors@5.0.0-rc.0...postcss-unique-selectors@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-unique-selectors
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### Bug Fixes
 
-* **unique-selector:** removed sorting and involving selector comments ([#857](https://github.com/cssnano/cssnano/issues/857)) ([3fa875d](https://github.com/cssnano/cssnano/commit/3fa875dade2138e1a531dce1f8b79814cb39dbc9))
-
+- **unique-selector:** removed sorting and involving selector comments ([#857](https://github.com/cssnano/cssnano/issues/857)) ([3fa875d](https://github.com/cssnano/cssnano/commit/3fa875dade2138e1a531dce1f8b79814cb39dbc9))
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/postcss-unique-selectors/CHANGELOG.md
+++ b/packages/postcss-unique-selectors/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+# 5.0.2 (2021-11-16)
+
+### Chore
+
+- 31d5c07dc07a4: refactor: drop one-liner dependencies
 
 ## [5.0.1](https://github.com/cssnano/cssnano/compare/postcss-unique-selectors@5.0.0...postcss-unique-selectors@5.0.1) (2021-05-19)
 

--- a/packages/postcss-unique-selectors/package.json
+++ b/packages/postcss-unique-selectors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-unique-selectors",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Ensure CSS selectors are unique.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/postcss-zindex/CHANGELOG.md
+++ b/packages/postcss-zindex/CHANGELOG.md
@@ -7,57 +7,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package postcss-zindex
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/postcss-zindex@5.0.0-rc.2...postcss-zindex@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package postcss-zindex
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/postcss-zindex@5.0.0-rc.1...postcss-zindex@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package postcss-zindex
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/postcss-zindex@5.0.0-rc.0...postcss-zindex@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package postcss-zindex
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.2 (2018-09-25)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/packages/stylehacks/CHANGELOG.md
+++ b/packages/stylehacks/CHANGELOG.md
@@ -7,75 +7,47 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package stylehacks
 
-
-
-
-
 # [5.0.0](https://github.com/cssnano/cssnano/compare/stylehacks@5.0.0-rc.2...stylehacks@5.0.0) (2021-04-06)
 
 **Note:** Version bump only for package stylehacks
-
-
-
-
 
 # [5.0.0-rc.2](https://github.com/cssnano/cssnano/compare/stylehacks@5.0.0-rc.1...stylehacks@5.0.0-rc.2) (2021-03-15)
 
 **Note:** Version bump only for package stylehacks
 
-
-
-
-
 # [5.0.0-rc.1](https://github.com/cssnano/cssnano/compare/stylehacks@5.0.0-rc.0...stylehacks@5.0.0-rc.1) (2021-03-04)
 
 **Note:** Version bump only for package stylehacks
 
-
-
-
-
 # 5.0.0-rc.0 (2021-02-19)
-
 
 ### chore
 
-* minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
-
+- minimum require version of node is 10.13 ([#871](https://github.com/cssnano/cssnano/issues/871)) ([28bda24](https://github.com/cssnano/cssnano/commit/28bda243e32ce3ba89b3c358a5f78727b3732f11))
 
 ### Features
 
-* migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
-
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 
 ### BREAKING CHANGES
 
-* minimum supported `postcss` version is `8.2.1`
-* minimum require version of node is 10.13
-
-
+- minimum supported `postcss` version is `8.2.1`
+- minimum require version of node is 10.13
 
 ## 4.1.10 (2019-02-14)
 
-
 ### Bug Fixes
 
-* **stylehacks:** doesn't throw error on `[attr]` selector ([#711](https://github.com/cssnano/cssnano/issues/711)) ([a4a43c3](https://github.com/cssnano/cssnano/commit/a4a43c37c58eb9dec3123072485f12e20f627bd1))
-
-
+- **stylehacks:** doesn't throw error on `[attr]` selector ([#711](https://github.com/cssnano/cssnano/issues/711)) ([a4a43c3](https://github.com/cssnano/cssnano/commit/a4a43c37c58eb9dec3123072485f12e20f627bd1))
 
 ## 4.1.9 (2019-02-12)
 
-
 ### Bug Fixes
 
-* **stylehacks:** better handle uppercase ([#704](https://github.com/cssnano/cssnano/issues/704)) ([8d48058](https://github.com/cssnano/cssnano/commit/8d48058b0f5be6943c443e4ce653fb156794f6b7))
-
-
+- **stylehacks:** better handle uppercase ([#704](https://github.com/cssnano/cssnano/issues/704)) ([8d48058](https://github.com/cssnano/cssnano/commit/8d48058b0f5be6943c443e4ce653fb156794f6b7))
 
 ## 4.1.1 (2018-09-24)
 
-
 ### Bug Fixes
 
-* **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)
+- **postcss-merge-longhand:** not mangle border output ([#555](https://github.com/cssnano/cssnano/issues/555)) ([9a70605](https://github.com/cssnano/cssnano/commit/9a706050b621e7795a9bf74eb7110b5c81804ffe)), closes [#553](https://github.com/cssnano/cssnano/issues/553) [#554](https://github.com/cssnano/cssnano/issues/554)

--- a/site/docs/changelog.md
+++ b/site/docs/changelog.md
@@ -12,6 +12,13 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 
+## \[5.1.10] (2021-11-05)
+
+#### Bug fixes
+
+- **postcss-merge-longhand:** prevent crash in some situations ([#1222](https://github.com/cssnano/cssnano/pull/1222)) ([83009a](https://github.com/cssnano/cssnano/commit/83009a04e7200c80d4dfc478881eb1b231d2548f))
+
+
 ## \[5.0.9] (2021-11-01)
 
 #### Bug fixes
@@ -121,7 +128,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 #### Features
 
 - css declaration sorter ([#855](https://github.com/cssnano/cssnano/issues/855)) ([613d562](https://github.com/cssnano/cssnano/commit/613d562ae79e7e169c80b523b7c2c9b0093bc1d8))
-- migarete to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
+- migrate to PostCSS 8 ([#975](https://github.com/cssnano/cssnano/issues/975)) ([40b82dc](https://github.com/cssnano/cssnano/commit/40b82dca7f53ac02cd4fe62846dec79b898ccb49))
 - **postcss-reduce-transforms:** improve optimizations ([#745](https://github.com/cssnano/cssnano/issues/745)) ([b0f0d89](https://github.com/cssnano/cssnano/commit/b0f0d892316d7b77e8033a6dc8d67745043a5072))
 
 #### BREAKING CHANGES

--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -64,22 +64,34 @@ be edited by hand.
 
 ### Releasing
 
-We use lerna and conventional commits to update the changelog and tag releases.
-To tag a pre-release and generate the changelog, run:
+We use @changesets/cli to update the changelog and tag releases.
+First make sure a changeset exists for every change you want to publish. A changeset is a text file
+with the description of the change and the affected packages.
+To create a changeset run
 
 ```
-yarn lerna version --conventional-commits --conventional-prerelease  --preid rc
+yarn changeset
 ```
 
-Use `--conventional-graduate` to generate the tags for a stable release.
-
-To publish the pre-release to npm, run:
+It's best to select the affected packages by hand rather than rely on the tools automatically
+discovering dependencies. For example, if a change affects a plugin `cssnano-preset-default`,
+select the plugin and `cssnano-preset-default` by hand (as well as any other dependent presets).
+To tag a release and generate the changelog, run:
 
 ```
-yarn lerna publish from-package --dist-tag next
+yarn changeset version
 ```
 
-To publish a stable release, use `latest` instead of `next`.
+To publish release to npm, run:
+
+```
+yarn all-publish
+```
+
+If you don't use the `package.json` script, do not forget to rebuild the packages first!
+
+1. `yarn prepare`
+2. `yarn changeset publish`
 
 
 ## Are there other ways of contributing?


### PR DESCRIPTION
Release https://github.com/cssnano/cssnano/pull/1226 fix and removed dependencies

* https://github.com/cssnano/cssnano/commit/07172825ffbb4f4ae7cfbbea3460fc18c92f8ef6
* https://github.com/cssnano/cssnano/commit/c38f14c3ce3d0be6ea03f6ea5d007b7d60b4d5af
* https://github.com/cssnano/cssnano/commit/31d5c07dc07a40fdffd47d3e3e62d39ff1f6c40f