### PR TITLE
chore: move camelcase dependency declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "babel-jest": "^27.2.1",
     "babel-plugin-add-module-exports": "^1.0.2",
     "browserslist": "^4.17.4",
-    "camelcase": "^6.2.0",
     "chalk": "^4.1.0",
     "cross-env": "^7.0.3",
     "diff": "^5.0.0",

--- a/site/package.json
+++ b/site/package.json
@@ -14,6 +14,7 @@
     "@docusaurus/core": "^2.0.0-beta.9",
     "@docusaurus/preset-classic": "^2.0.0-beta.9",
     "@monaco-editor/react": "^4.3.1",
+    "camelcase": "^6.2.1",
     "classnames": "^2.3.1",
     "cssnano-preset-advanced": "^5.1.7",
     "cssnano-preset-default": "^5.1.7",

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -2522,7 +2522,7 @@ camelcase-css@2.0.1:
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
-camelcase@^6.0.0, camelcase@^6.2.0:
+camelcase@^6.0.0, camelcase@^6.2.0, camelcase@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.1.tgz#250fd350cfd555d0d2160b1d51510eaf8326e86e"
   integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==


### PR DESCRIPTION
It's used in sit/util/buildMetadata.mjs