### PR TITLE
chore(css-size): drop gzip-size and brotli-size deps

### DIFF
--- a/packages/css-size/package.json
+++ b/packages/css-size/package.json
@@ -34,10 +34,8 @@
   },
   "repository": "cssnano/cssnano",
   "dependencies": {
-    "brotli-size": "^4.0.0",
     "cli-table3": "^0.6.0",
     "cssnano": "^5.0.3",
-    "gzip-size": "^6.0.0",
     "minimist": "^1.2.0",
     "pretty-bytes": "^5.6.0",
     "read-file-stdin": "^0.2.1"

--- a/packages/css-size/src/index.js
+++ b/packages/css-size/src/index.js
@@ -1,9 +1,23 @@
+import zlib from 'zlib';
 import prettyBytes from 'pretty-bytes';
 import postcss from 'postcss';
-import { sync as gzip } from 'gzip-size';
-import { sync as brotli } from 'brotli-size';
 import Table from 'cli-table3';
 import nano from 'cssnano';
+
+/* Returns the size of the gzipped input */
+function gzip(input) {
+  return zlib.gzipSync(input, { level: 9 }).byteLength;
+}
+
+/* Returns the size of the brotli-compressed input */
+function brotli(input) {
+  return zlib.brotliCompressSync(input, {
+    params: {
+      [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
+      [zlib.constants.BROTLI_PARAM_SIZE_HINT]: getBinarySize(input),
+    },
+  }).byteLength;
+}
 
 const getBinarySize = (string) => {
   return Buffer.byteLength(string, 'utf8');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,13 +1872,6 @@ breakword@^1.0.5:
   dependencies:
     wcwidth "^1.0.1"
 
-brotli-size@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/brotli-size/-/brotli-size-4.0.0.tgz#a05ee3faad3c0e700a2f2da826ba6b4d76e69e5e"
-  integrity sha512-uA9fOtlTRC0iqKfzff1W34DXUA3GyVqbUaeo3Rw3d4gd1eavKVCETXrn3NzO74W+UVkG3UHu8WxUi+XvKI/huA==
-  dependencies:
-    duplexer "0.1.1"
-
 brotli@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/brotli/-/brotli-1.3.2.tgz#525a9cad4fcba96475d7d388f6aecb13eed52f46"
@@ -2446,16 +2439,6 @@ domutils@^2.5.2, domutils@^2.6.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
-
-duplexer@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
-  integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
-
-duplexer@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
-  integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
 electron-to-chromium@^1.3.867:
   version "1.3.873"
@@ -3069,13 +3052,6 @@ grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
-
-gzip-size@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
-  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
-  dependencies:
-    duplexer "^0.1.2"
 
 hard-rejection@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Using the Node.js standard library directly is as convenient.

These packages bundle a bunch of ways to call the standard library functions (ex. on a stream, with promises, sync). They set the maximum compression level by default. Then they return `length` or `byteLength` of the result buffer (`byteLength` === `length` because a Node.js `Buffer` is a  subclass of `UInt8Array` https://nodejs.org/api/buffer.html#buffer).