### PR TITLE
test(postcss-svgo): use new SVGO plugins API

### DIFF
--- a/packages/postcss-svgo/src/__tests__/index.js
+++ b/packages/postcss-svgo/src/__tests__/index.js
@@ -1,7 +1,6 @@
 import { readFileSync as file } from 'fs';
 import postcss from 'postcss';
 import filters from 'pleeease-filters';
-import { extendDefaultPlugins } from 'svgo';
 import plugin from '../';
 import { encode, decode } from '../lib/url';
 import {
@@ -108,9 +107,16 @@ test(
     'h1{background:url(\'data:image/svg+xml;utf-8,<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"><circle cx="50" cy="50" r="40" fill="yellow" /><!--test comment--></svg>\')}',
     'h1{background:url(\'data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve"><circle cx="50" cy="50" r="40" fill="%23ff0"/><!--test comment--></svg>\')}',
     {
-      plugins: extendDefaultPlugins([
-        { name: 'removeComments', active: false },
-      ]),
+      plugins: [
+        {
+          name: 'preset-default',
+          params: {
+            overrides: {
+              removeComments: false,
+            },
+          },
+        },
+      ],
     }
   )
 );


### PR DESCRIPTION
Remove warning "extendDefaultPlugins utility is deprecated" during test run.
Could not find any usage outside of test.