### PR TITLE
ci: fix coverage report format

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -4,5 +4,6 @@
     "packages/postcss-reduce-initial/script/lib/io.mjs",
     "packages/postcss-reduce-initial/script/lib/mdnCssProps.mjs"
   ],
-  "all": true
+  "all": true,
+  "reporter": ["text", "lcovonly"]
 }


### PR DESCRIPTION
Add lconv.info output. Codecov fails to parse the JSON output, let's see if this works.
