### PR TITLE
chore: remove glob from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "eslint-plugin-import": "^2.23.3",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.25.1",
-    "glob": "^7.1.4",
     "html-to-text": "^8.0.0",
     "nanospy": "^0.4.0",
     "node-fetch": "^2.6.1",

--- a/site/package.json
+++ b/site/package.json
@@ -19,7 +19,6 @@
     "cssnano-preset-advanced": "^5.1.7",
     "cssnano-preset-default": "^5.1.7",
     "cssnano-preset-lite": "^2.0.1",
-    "glob": "^7.2.0",
     "mdast-util-heading-range": "^3.1.0",
     "postcss": "^8.3.11",
     "react": "^17.0.2",

--- a/site/util/getPackages.mjs
+++ b/site/util/getPackages.mjs
@@ -1,17 +1,18 @@
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import glob from 'glob';
+import { readdir } from 'fs';
 
 export default function getPackages() {
+  const pkgDir = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../packages'
+  );
   return new Promise((resolve, reject) => {
-    glob(
-      `${join(dirname(fileURLToPath(import.meta.url)), '../../packages')}/*`,
-      (err, packages) => {
-        if (err) {
-          return reject(err);
-        }
-        return resolve(packages);
+    readdir(pkgDir, (err, packages) => {
+      if (err) {
+        return reject(err);
       }
-    );
+      return resolve(packages.map((pkg) => join(pkgDir, pkg)));
+    });
   });
 }

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -4005,7 +4005,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.0.0, glob@^7.1.3, glob@^7.1.6, glob@^7.2.0:
+glob@^7.0.0, glob@^7.1.3, glob@^7.1.6:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==

--- a/util/buildFrameworks.mjs
+++ b/util/buildFrameworks.mjs
@@ -1,8 +1,7 @@
 import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs/promises';
-import { readdirSync, readFileSync } from 'fs';
-import glob from 'glob';
+import { readdirSync, readFileSync, readdir } from 'fs';
 import postcss from 'postcss';
 import cssnano from '../packages/cssnano/dist/index.js';
 
@@ -32,15 +31,11 @@ function rebuild(pkg) {
   });
 }
 
-glob(
-  `${join(
-    dirname(fileURLToPath(import.meta.url)),
-    '../packages'
-  )}/cssnano-preset-*`,
-  (err, packages) => {
-    if (err) {
-      throw err;
+const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '../packages');
+readdir(pkgDir, (err, packages) => {
+  for (const pkg of packages) {
+    if (pkg.startsWith('cssnano-preset-')) {
+      rebuild(join(pkgDir, pkg));
     }
-    packages.forEach(rebuild);
   }
-);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,7 +888,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001264, caniuse-lite@^1.0.30001265, caniuse-lite@^1.0.30001280:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001264, caniuse-lite@^1.0.30001280:
   version "1.0.30001283"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz#8573685bdae4d733ef18f78d44ba0ca5fe9e896b"
   integrity sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==
@@ -1288,7 +1288,7 @@ domutils@^2.5.2, domutils@^2.6.0:
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
 
-electron-to-chromium@^1.3.867, electron-to-chromium@^1.3.896:
+electron-to-chromium@^1.3.896:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.4.tgz#57311918524c1a26878c330537f967804d43788a"
   integrity sha512-teHtgwcmVcL46jlFvAaqjyiTLWuMrUQO1JqV303JKB4ysXG6m8fXSFhbjal9st0r9mNskI22AraJZorb1VcLVg==
@@ -1793,9 +1793,9 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
     is-glob "^4.0.1"
 
 glob@^7.0.0, glob@^7.1.3, glob@^7.1.4:
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
-  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2562,7 +2562,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-releases@^2.0.0, node-releases@^2.0.1:
+node-releases@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
   integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==


### PR DESCRIPTION
We're just listing directory contents, no need for globs.