### PR TITLE
chore(postcss-normalize-url): inline is-absolute-url dep

### DIFF
--- a/packages/postcss-normalize-url/package.json
+++ b/packages/postcss-normalize-url/package.json
@@ -23,7 +23,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "is-absolute-url": "^3.0.3",
     "normalize-url": "^6.0.1",
     "postcss-value-parser": "^4.2.0"
   },

--- a/packages/postcss-normalize-url/src/index.js
+++ b/packages/postcss-normalize-url/src/index.js
@@ -1,11 +1,28 @@
 import path from 'path';
 import valueParser from 'postcss-value-parser';
 import normalize from 'normalize-url';
-import isAbsolute from 'is-absolute-url';
 
 const multiline = /\\[\r\n]/;
 // eslint-disable-next-line no-useless-escape
 const escapeChars = /([\s\(\)"'])/g;
+
+// Scheme: https://tools.ietf.org/html/rfc3986#section-3.1
+// Absolute URL: https://tools.ietf.org/html/rfc3986#section-4.3
+const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z\d+\-.]*?:/;
+// Windows paths like `c:\`
+const WINDOWS_PATH_REGEX = /^[a-zA-Z]:\\/;
+
+/**
+ * Originally in sindresorhus/is-absolute-url
+ *
+ * @param {string} url
+ */
+function isAbsolute(url) {
+  if (WINDOWS_PATH_REGEX.test(url)) {
+    return false;
+  }
+  return ABSOLUTE_URL_REGEX.test(url);
+}
 
 function convert(url, options) {
   if (isAbsolute(url) || url.startsWith('//')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,11 +1980,6 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-is-absolute-url@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-3.0.3.tgz#96c6a22b6a23929b11ea0afb1836c36ad4a5d698"
-  integrity sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==
-
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"


### PR DESCRIPTION
is-absolute-url has become ESM only. It boils down to two
short regexes, so we can inline it.
The license is MIT which is the same as cssnano.
