### PR TITLE
fix(example): move postcss to dependencies

### DIFF
--- a/example-cli-usage/package.json
+++ b/example-cli-usage/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "cssnano": "^5.0.3",
+    "postcss": "^8.4.4",
     "postcss-cli": "^8.3.0"
   },
   "scripts": {
@@ -22,8 +23,5 @@
     "email": "beneb.info@gmail.com",
     "url": "http://beneb.info"
   },
-  "version": "5.0.3",
-  "peerDependencies": {
-    "postcss": "^8.2.15"
-  }
+  "version": "5.0.3"
 }


### PR DESCRIPTION
This is supposed to be an example of setting up a project for the end
user, so postcss should be installed as a dependency.