### PR TITLE
fix(cssnano): replace is-resolvable dep

### DIFF
--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -25,7 +25,6 @@
     "license": "MIT",
     "dependencies": {
         "cssnano-preset-default": "^5.1.9",
-        "is-resolvable": "^1.1.0",
         "lilconfig": "^2.0.3",
         "yaml": "^1.10.2"
     },

--- a/packages/cssnano/src/index.js
+++ b/packages/cssnano/src/index.js
@@ -2,9 +2,21 @@ import path from 'path';
 import postcss from 'postcss';
 import yaml from 'yaml';
 import { lilconfigSync } from 'lilconfig';
-import isResolvable from 'is-resolvable';
 
 const cssnano = 'cssnano';
+
+/*
+ * @param {string} moduleId
+ * @returns {boolean}
+ */
+function isResolvable(moduleId) {
+  try {
+    require.resolve(moduleId);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
 
 /*
  * preset can be one of four possibilities:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2088,11 +2088,6 @@ is-regex@^1.1.4:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-resolvable@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
-  integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
-
 is-shared-array-buffer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"


### PR DESCRIPTION
is-resolvable cannot find modules when installed in a pnpm monorepo . It's a tiny [wrapper around require.resolve](https://github.com/shinnn/is-resolvable),
so we can drop it easily. This solves the issue when running cssnano inside a pnpm monorepo (see [before](https://github.com/cssnano/cssnano/actions/runs/1579937249) and [after](https://github.com/cssnano/cssnano/actions/runs/1593701210)).