### PR TITLE
refactor: use Map as cache instead of object

### DIFF
--- a/packages/postcss-colormin/src/index.js
+++ b/packages/postcss-colormin/src/index.js
@@ -87,7 +87,7 @@ function pluginCreator(config = {}) {
         env: resultOptions.env,
       });
 
-      const cache = {};
+      const cache = new Map();
       const options = addPluginDefaults(config, browsers);
 
       return {
@@ -109,8 +109,8 @@ function pluginCreator(config = {}) {
 
             const cacheKey = JSON.stringify({ value, options, browsers });
 
-            if (cache[cacheKey]) {
-              decl.value = cache[cacheKey];
+            if (cache.has(cacheKey)) {
+              decl.value = cache.get(cacheKey);
 
               return;
             }
@@ -118,7 +118,7 @@ function pluginCreator(config = {}) {
             const newValue = transform(value, options);
 
             decl.value = newValue;
-            cache[cacheKey] = newValue;
+            cache.set(cacheKey, newValue);
           });
         },
       };

--- a/packages/postcss-merge-rules/src/index.js
+++ b/packages/postcss-merge-rules/src/index.js
@@ -56,7 +56,7 @@ function sameDeclarationsAndOrder(a, b) {
  * @param {postcss.Rule} ruleA
  * @param {postcss.Rule} ruleB
  * @param {string[]=} browsers
- * @param {Object.<string, boolean>=} compatibilityCache
+ * @param {Map<string, boolean>=} compatibilityCache
  * @return {boolean}
  */
 function canMerge(ruleA, ruleB, browsers, compatibilityCache) {
@@ -306,7 +306,7 @@ function partialMerge(first, second) {
 
 /**
  * @param {string[]} browsers
- * @param {Object.<string, boolean>} compatibilityCache
+ * @param {Map<string, boolean>} compatibilityCache
  * @return {function(postcss.Rule)}
  */
 function selectorMerger(browsers, compatibilityCache) {
@@ -368,7 +368,7 @@ function pluginCreator() {
         env: resultOpts.env,
       });
 
-      const compatibilityCache = {};
+      const compatibilityCache = new Map();
       return {
         OnceExit(css) {
           css.walkRules(selectorMerger(browsers, compatibilityCache));

--- a/packages/postcss-merge-rules/src/lib/ensureCompatibility.js
+++ b/packages/postcss-merge-rules/src/lib/ensureCompatibility.js
@@ -106,16 +106,16 @@ function isHostPseudoClass(selector) {
   return selector.includes(':host');
 }
 
-const isSupportedCache = {};
+const isSupportedCache = new Map();
 
 // Move to util in future
 function isSupportedCached(feature, browsers) {
   const key = JSON.stringify({ feature, browsers });
-  let result = isSupportedCache[key];
+  let result = isSupportedCache.get(key);
 
   if (!result) {
     result = isSupported(feature, browsers);
-    isSupportedCache[key] = result;
+    isSupportedCache.set(key, result);
   }
 
   return result;
@@ -135,8 +135,8 @@ export function ensureCompatibility(selectors, browsers, compatibilityCache) {
     if (simpleSelectorRe.test(selector)) {
       return true;
     }
-    if (compatibilityCache && selector in compatibilityCache) {
-      return compatibilityCache[selector];
+    if (compatibilityCache && compatibilityCache.has(selector)) {
+      return compatibilityCache.get(selector);
     }
     let compatible = true;
     selectorParser((ast) => {
@@ -189,7 +189,7 @@ export function ensureCompatibility(selectors, browsers, compatibilityCache) {
       });
     }).processSync(selector);
     if (compatibilityCache) {
-      compatibilityCache[selector] = compatible;
+      compatibilityCache.set(selector, compatible);
     }
     return compatible;
   });

--- a/packages/postcss-minify-font-values/src/index.js
+++ b/packages/postcss-minify-font-values/src/index.js
@@ -45,7 +45,7 @@ function pluginCreator(opts) {
   return {
     postcssPlugin: 'postcss-minify-font-values',
     prepare() {
-      const cache = {};
+      const cache = new Map();
       return {
         OnceExit(css) {
           css.walkDecls(/font/i, (decl) => {
@@ -59,8 +59,8 @@ function pluginCreator(opts) {
 
             const cacheKey = `${prop}|${value}`;
 
-            if (cache[cacheKey]) {
-              decl.value = cache[cacheKey];
+            if (cache.has(cacheKey)) {
+              decl.value = cache.get(cacheKey);
 
               return;
             }
@@ -68,7 +68,7 @@ function pluginCreator(opts) {
             const newValue = transform(prop, value, opts);
 
             decl.value = newValue;
-            cache[cacheKey] = newValue;
+            cache.set(cacheKey, newValue);
           });
         },
       };

--- a/packages/postcss-minify-selectors/src/index.js
+++ b/packages/postcss-minify-selectors/src/index.js
@@ -167,7 +167,7 @@ function pluginCreator() {
     postcssPlugin: 'postcss-minify-selectors',
 
     OnceExit(css) {
-      const cache = {};
+      const cache = new Map();
       const processor = parser((selectors) => {
         selectors.nodes = sort(selectors.nodes, { insensitive: true });
 
@@ -209,8 +209,8 @@ function pluginCreator() {
           return;
         }
 
-        if (cache[selector]) {
-          rule.selector = cache[selector];
+        if (cache.has(selector)) {
+          rule.selector = cache.get(selector);
 
           return;
         }
@@ -218,7 +218,7 @@ function pluginCreator() {
         const optimizedSelector = processor.processSync(selector);
 
         rule.selector = optimizedSelector;
-        cache[selector] = optimizedSelector;
+        cache.set(selector, optimizedSelector);
       });
     },
   };

--- a/packages/postcss-normalize-display-values/src/index.js
+++ b/packages/postcss-normalize-display-values/src/index.js
@@ -32,7 +32,7 @@ function pluginCreator() {
     postcssPlugin: 'postcss-normalize-display-values',
 
     prepare() {
-      const cache = {};
+      const cache = new Map();
       return {
         OnceExit(css) {
           css.walkDecls(/^display$/i, (decl) => {
@@ -42,8 +42,8 @@ function pluginCreator() {
               return;
             }
 
-            if (cache[value]) {
-              decl.value = cache[value];
+            if (cache.has(value)) {
+              decl.value = cache.get(value);
 
               return;
             }
@@ -51,7 +51,7 @@ function pluginCreator() {
             const result = transform(value);
 
             decl.value = result;
-            cache[value] = result;
+            cache.set(value, result);
           });
         },
       };

--- a/packages/postcss-normalize-positions/src/index.js
+++ b/packages/postcss-normalize-positions/src/index.js
@@ -188,7 +188,7 @@ function pluginCreator() {
     postcssPlugin: 'postcss-normalize-positions',
 
     OnceExit(css) {
-      const cache = {};
+      const cache = new Map();
 
       css.walkDecls(
         /^(background(-position)?|(-\w+-)?perspective-origin)$/i,
@@ -199,8 +199,8 @@ function pluginCreator() {
             return;
           }
 
-          if (cache[value]) {
-            decl.value = cache[value];
+          if (cache.has(value)) {
+            decl.value = cache.get(value);
 
             return;
           }
@@ -208,7 +208,7 @@ function pluginCreator() {
           const result = transform(value);
 
           decl.value = result;
-          cache[value] = result;
+          cache.set(value, result);
         }
       );
     },

--- a/packages/postcss-normalize-string/src/index.js
+++ b/packages/postcss-normalize-string/src/index.js
@@ -245,7 +245,7 @@ function pluginCreator(opts) {
     postcssPlugin: 'postcss-normalize-string',
 
     OnceExit(css) {
-      const cache = {};
+      const cache = new Map();
 
       css.walk((node) => {
         const { type } = node;
@@ -254,8 +254,8 @@ function pluginCreator(opts) {
           const param = params[type];
           const key = node[param] + '|' + preferredQuote;
 
-          if (cache[key]) {
-            node[param] = cache[key];
+          if (cache.has(key)) {
+            node[param] = cache.get(key);
 
             return;
           }
@@ -263,7 +263,7 @@ function pluginCreator(opts) {
           const newValue = normalize(node[param], preferredQuote);
 
           node[param] = newValue;
-          cache[key] = newValue;
+          cache.set(key, newValue);
         }
       });
     },

--- a/packages/postcss-normalize-timing-functions/src/index.js
+++ b/packages/postcss-normalize-timing-functions/src/index.js
@@ -103,15 +103,15 @@ function pluginCreator() {
     postcssPlugin: 'postcss-normalize-timing-functions',
 
     OnceExit(css) {
-      const cache = {};
+      const cache = new Map();
 
       css.walkDecls(
         /^(-\w+-)?(animation|transition)(-timing-function)?$/i,
         (decl) => {
           const value = decl.value;
 
-          if (cache[value]) {
-            decl.value = cache[value];
+          if (cache.has(value)) {
+            decl.value = cache.get(value);
 
             return;
           }
@@ -119,7 +119,7 @@ function pluginCreator() {
           const result = transform(value);
 
           decl.value = result;
-          cache[value] = result;
+          cache.set(value, result);
         }
       );
     },

--- a/packages/postcss-normalize-unicode/src/index.js
+++ b/packages/postcss-normalize-unicode/src/index.js
@@ -74,7 +74,7 @@ function pluginCreator() {
   return {
     postcssPlugin: 'postcss-normalize-unicode',
     prepare(result) {
-      const cache = {};
+      const cache = new Map();
       const resultOpts = result.opts || {};
       const browsers = browserslist(null, {
         stats: resultOpts.stats,
@@ -88,8 +88,8 @@ function pluginCreator() {
           css.walkDecls(/^unicode-range$/i, (decl) => {
             const value = decl.value;
 
-            if (cache[value]) {
-              decl.value = cache[value];
+            if (cache.has(value)) {
+              decl.value = cache.get(value);
 
               return;
             }
@@ -97,7 +97,7 @@ function pluginCreator() {
             const newValue = transform(value, isLegacy);
 
             decl.value = newValue;
-            cache[value] = newValue;
+            cache.set(value, newValue);
           });
         },
       };

--- a/packages/postcss-normalize-whitespace/src/index.js
+++ b/packages/postcss-normalize-whitespace/src/index.js
@@ -35,7 +35,7 @@ function pluginCreator() {
     postcssPlugin: 'postcss-normalize-whitespace',
 
     OnceExit(css) {
-      const cache = {};
+      const cache = new Map();
 
       css.walk((node) => {
         const { type } = node;
@@ -55,15 +55,15 @@ function pluginCreator() {
 
           const value = node.value;
 
-          if (cache[value]) {
-            node.value = cache[value];
+          if (cache.has(value)) {
+            node.value = cache.get(value);
           } else {
             const parsed = valueParser(node.value);
             const result = parsed.walk(reduceWhitespaces).toString();
 
             // Trim whitespace inside functions & dividers
             node.value = result;
-            cache[value] = result;
+            cache.set(value, result);
           }
 
           // Remove extra semicolons and whitespace before the declaration

--- a/packages/postcss-ordered-values/src/index.js
+++ b/packages/postcss-ordered-values/src/index.js
@@ -98,7 +98,7 @@ function pluginCreator() {
   return {
     postcssPlugin: 'postcss-ordered-values',
     prepare() {
-      const cache = {};
+      const cache = new Map();
       return {
         OnceExit(css) {
           css.walkDecls((decl) => {
@@ -112,8 +112,8 @@ function pluginCreator() {
 
             const value = getValue(decl);
 
-            if (cache[value]) {
-              decl.value = cache[value];
+            if (cache.has(value)) {
+              decl.value = cache.get(value);
 
               return;
             }
@@ -121,7 +121,7 @@ function pluginCreator() {
             const parsed = valueParser(value);
 
             if (parsed.nodes.length < 2 || shouldAbort(parsed)) {
-              cache[value] = value;
+              cache.set(value, value);
 
               return;
             }
@@ -129,7 +129,7 @@ function pluginCreator() {
             const result = processor(parsed);
 
             decl.value = result.toString();
-            cache[value] = result.toString();
+            cache.set(value, result.toString());
           });
         },
       };

--- a/packages/postcss-reduce-transforms/src/index.js
+++ b/packages/postcss-reduce-transforms/src/index.js
@@ -230,7 +230,7 @@ function pluginCreator() {
   return {
     postcssPlugin: 'postcss-reduce-transforms',
     prepare() {
-      const cache = {};
+      const cache = new Map();
       return {
         OnceExit(css) {
           css.walkDecls(/transform$/i, (decl) => {
@@ -240,8 +240,8 @@ function pluginCreator() {
               return;
             }
 
-            if (cache[value]) {
-              decl.value = cache[value];
+            if (cache.has(value)) {
+              decl.value = cache.get(value);
 
               return;
             }
@@ -249,7 +249,7 @@ function pluginCreator() {
             const result = valueParser(value).walk(reduce).toString();
 
             decl.value = result;
-            cache[value] = result;
+            cache.set(value, result);
           });
         },
       };


### PR DESCRIPTION
Fix a surprising issue when trying to generate types. 
Prevent TypeScript from sometimes inferring the type of cache as {}, which sometimes prevent setting a cache value even in non-strict mode.
I think `Map()` is clearer when you read the code.