### PR TITLE
test: remove unused test helper

### DIFF
--- a/util/getData.js
+++ b/util/getData.js
@@ -1,6 +1,0 @@
-export default function getData(mappings) {
-  return mappings.reduce((list, mapping) => {
-    list[mapping[0]] = mapping[1].join(' ');
-    return list;
-  }, {});
-}


### PR DESCRIPTION
getData() was used to test getMatch() the we've removed in #1279.