### PR TITLE
test: reduce circular dependencies in tests

### DIFF
--- a/packages/cssnano-preset-advanced/src/__tests__/autoprefixer.js
+++ b/packages/cssnano-preset-advanced/src/__tests__/autoprefixer.js
@@ -1,5 +1,5 @@
 import { test } from 'uvu';
-import { processCSSWithPresetFactory } from '../../../../util/testHelpers';
+import { processCSSWithPresetFactory } from '../../../../util/integrationTestHelpers';
 import preset from '..';
 
 const { processCSS } = processCSSWithPresetFactory(preset);

--- a/packages/cssnano-preset-advanced/src/__tests__/integrations.js
+++ b/packages/cssnano-preset-advanced/src/__tests__/integrations.js
@@ -1,6 +1,9 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { integrationTests, loadPreset } from '../../../../util/testHelpers.js';
+import {
+  integrationTests,
+  loadPreset,
+} from '../../../../util/integrationTestHelpers.js';
 import preset from '..';
 
 test(

--- a/packages/cssnano-preset-default/src/__tests__/css-declaration-sorter.js
+++ b/packages/cssnano-preset-default/src/__tests__/css-declaration-sorter.js
@@ -1,5 +1,5 @@
 import { test } from 'uvu';
-import { processCSSWithPresetFactory } from '../../../../util/testHelpers';
+import { processCSSWithPresetFactory } from '../../../../util/integrationTestHelpers';
 import preset from '..';
 
 const { processCSS, passthroughCSS } = processCSSWithPresetFactory(preset);

--- a/packages/cssnano-preset-default/src/__tests__/integrations.js
+++ b/packages/cssnano-preset-default/src/__tests__/integrations.js
@@ -1,6 +1,9 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { integrationTests, loadPreset } from '../../../../util/testHelpers.js';
+import {
+  integrationTests,
+  loadPreset,
+} from '../../../../util/integrationTestHelpers.js';
 import preset from '..';
 
 test(

--- a/packages/cssnano-preset-lite/src/__tests__/index.js
+++ b/packages/cssnano-preset-lite/src/__tests__/index.js
@@ -1,5 +1,5 @@
 import { test } from 'uvu';
-import { processCSSWithPresetFactory } from '../../../../util/testHelpers';
+import { processCSSWithPresetFactory } from '../../../../util/integrationTestHelpers';
 import preset from '..';
 
 const { processCSS } = processCSSWithPresetFactory(preset);

--- a/packages/cssnano-preset-lite/src/__tests__/integrations.js
+++ b/packages/cssnano-preset-lite/src/__tests__/integrations.js
@@ -1,5 +1,5 @@
 import { test } from 'uvu';
-import { integrationTests } from '../../../../util/testHelpers.js';
+import { integrationTests } from '../../../../util/integrationTestHelpers.js';
 import preset from '..';
 
 test(

--- a/packages/postcss-colormin/src/__tests__/index.js
+++ b/packages/postcss-colormin/src/__tests__/index.js
@@ -2,8 +2,8 @@ import { test } from 'uvu';
 import {
   usePostCSSPlugin,
   processCSSFactory,
-  processCSSWithPresetFactory,
 } from '../../../../util/testHelpers';
+import { processCSSWithPresetFactory } from '../../../../util/integrationTestHelpers';
 import plugin from '..';
 
 const { passthroughCSS, processCSS } = processCSSFactory(plugin);

--- a/packages/postcss-discard-empty/src/__tests__/index.js
+++ b/packages/postcss-discard-empty/src/__tests__/index.js
@@ -3,8 +3,8 @@ import * as assert from 'uvu/assert';
 import {
   usePostCSSPlugin,
   processCSSFactory,
-  processCSSWithPresetFactory,
 } from '../../../../util/testHelpers';
+import { processCSSWithPresetFactory } from '../../../../util/integrationTestHelpers';
 import plugin from '..';
 
 const { passthroughCSS, processor } = processCSSFactory(plugin);

--- a/packages/postcss-minify-font-values/src/__tests__/index.js
+++ b/packages/postcss-minify-font-values/src/__tests__/index.js
@@ -2,8 +2,8 @@ import { test } from 'uvu';
 import {
   usePostCSSPlugin,
   processCSSFactory,
-  processCSSWithPresetFactory,
 } from '../../../../util/testHelpers';
+import { processCSSWithPresetFactory } from '../../../../util/integrationTestHelpers';
 import plugin from '..';
 
 const { passthroughCSS, processCSS } = processCSSFactory(plugin);

--- a/packages/postcss-normalize-whitespace/src/__tests__/index.js
+++ b/packages/postcss-normalize-whitespace/src/__tests__/index.js
@@ -1,8 +1,6 @@
 import { test } from 'uvu';
-import {
-  processCSSFactory,
-  processCSSWithPresetFactory,
-} from '../../../../util/testHelpers';
+import { processCSSFactory } from '../../../../util/testHelpers';
+import { processCSSWithPresetFactory } from '../../../../util/integrationTestHelpers';
 import plugin from '..';
 
 const { processCSS } = processCSSFactory(plugin);

--- a/util/integrationTestHelpers.js
+++ b/util/integrationTestHelpers.js
@@ -1,0 +1,41 @@
+import path from 'path';
+import fs from 'fs';
+import postcss from 'postcss';
+import * as assert from 'uvu/assert';
+import cssnano from '../packages/cssnano/src/index.js';
+import { processCSSFactory } from './testHelpers.js';
+
+export function processCSSWithPresetFactory(preset) {
+  return processCSSFactory([cssnano({ preset })]);
+}
+
+export function loadPreset(preset) {
+  return postcss(cssnano({ preset }));
+}
+
+export function integrationTests(preset, integrations) {
+  const frameworks = new Map();
+  for (const framework of fs.readdirSync(
+    path.join(__dirname, '../frameworks')
+  )) {
+    frameworks.set(
+      path.basename(framework, '.css'),
+      fs.readFileSync(path.join(__dirname, '../frameworks', framework), 'utf8')
+    );
+  }
+
+  const expectations = [];
+  for (const [framework, css] of frameworks) {
+    expectations.push(
+      postcss([cssnano({ preset })])
+        .process(css, { from: undefined })
+        .then((result) => {
+          assert.is(
+            result.css,
+            fs.readFileSync(`${integrations}/${framework}.css`, 'utf8')
+          );
+        })
+    );
+  }
+  return () => Promise.all(expectations);
+}

--- a/util/testHelpers.js
+++ b/util/testHelpers.js
@@ -1,8 +1,5 @@
-import fs from 'fs';
-import path from 'path';
 import postcss from 'postcss';
 import * as assert from 'uvu/assert';
-import cssnano from '../packages/cssnano/src/index';
 
 export function usePostCSSPlugin(plugin) {
   return () => {
@@ -53,39 +50,4 @@ export function processCSSFactory(plugin) {
   }
 
   return { processor, processCSS, passthroughCSS };
-}
-
-export function processCSSWithPresetFactory(preset) {
-  return processCSSFactory([cssnano({ preset })]);
-}
-
-export function loadPreset(preset) {
-  return postcss(cssnano({ preset }));
-}
-
-export function integrationTests(preset, integrations) {
-  const frameworks = new Map();
-  for (const framework of fs.readdirSync(
-    path.join(__dirname, '../frameworks')
-  )) {
-    frameworks.set(
-      path.basename(framework, '.css'),
-      fs.readFileSync(path.join(__dirname, '../frameworks', framework), 'utf8')
-    );
-  }
-
-  const expectations = [];
-  for (const [framework, css] of frameworks) {
-    expectations.push(
-      postcss([cssnano({ preset })])
-        .process(css, { from: undefined })
-        .then((result) => {
-          assert.is(
-            result.css,
-            fs.readFileSync(`${integrations}/${framework}.css`, 'utf8')
-          );
-        })
-    );
-  }
-  return () => Promise.all(expectations);
 }


### PR DESCRIPTION
Separate test helpers from integration test helpers,
so we can run most tests without loading the cssnano package,
which causes loading cssnano-preset-default and so most of the repository.

I noticed this issue because pointing the `main` field to the wrong file in the
package.json of postcss-normalize-timing-functions
causes every test to fail even it does not depend on postcss-normalize-timing-functions.