### PR TITLE
docs: add missing license

### DIFF
--- a/packages/cssnano-utils/LICENSE
+++ b/packages/cssnano-utils/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) Ben Briggs <beneb.info@gmail.com> (http://beneb.info)
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/cssnano-utils/package.json
+++ b/packages/cssnano-utils/package.json
@@ -17,7 +17,8 @@
     "node": "^10 || ^12 || >=14.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "LICENSE"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/packages/postcss-minify-font-values/package.json
+++ b/packages/postcss-minify-font-values/package.json
@@ -4,7 +4,8 @@
   "description": "Minify font declarations with PostCSS",
   "main": "dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "LICENSE"
   ],
   "author": "Bogdan Chadkin <trysound@yandex.ru>",
   "license": "MIT",

--- a/packages/postcss-minify-params/package.json
+++ b/packages/postcss-minify-params/package.json
@@ -12,7 +12,8 @@
   ],
   "main": "dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "LICENSE"
   ],
   "author": "Bogdan Chadkin <trysound@yandex.ru>",
   "license": "MIT",

--- a/packages/postcss-normalize-charset/package.json
+++ b/packages/postcss-normalize-charset/package.json
@@ -10,7 +10,8 @@
   ],
   "author": "Bogdan Chadkin <trysound@yandex.ru>",
   "files": [
-    "dist"
+    "dist",
+    "LICENSE"
   ],
   "license": "MIT",
   "repository": "cssnano/cssnano",


### PR DESCRIPTION
The MIT license requires including the full license text.