### PR TITLE
refactor: remove implicit boolean conversion

### DIFF
--- a/packages/css-size/src/__tests__/index.js
+++ b/packages/css-size/src/__tests__/index.js
@@ -40,17 +40,17 @@ function stripColors(str) {
 test('cli', () => {
   return setup(['test.css']).then((results) => {
     let out = results[0];
-    assert.is(!!~out.indexOf('43 B'), true);
-    assert.is(!!~out.indexOf('34 B'), true);
-    assert.is(!!~out.indexOf('9 B'), true);
-    assert.is(!!~out.indexOf('79.07%'), true);
+    assert.is(out.includes('43 B'), true);
+    assert.is(out.includes('34 B'), true);
+    assert.is(out.includes('9 B'), true);
+    assert.is(out.includes('79.07%'), true);
   });
 });
 
 test('cli with processor argument', () => {
   return setup(['-p', noopProcessorPath, 'test.css']).then((results) => {
     let out = results[0];
-    assert.is(!!~out.indexOf('100%'), true);
+    assert.is(out.includes('100%'), true);
   });
 });
 

--- a/packages/postcss-colormin/src/index.js
+++ b/packages/postcss-colormin/src/index.js
@@ -19,10 +19,7 @@ function walk(parent, callback) {
  *
  * https://developer.mozilla.org/en-US/docs/Web/Events/click#Internet_Explorer
  */
-
-function hasTransparentBug(browser) {
-  return ['ie 8', 'ie 9'].includes(browser);
-}
+const browsersWithTransparentBug = new Set(['ie 8', 'ie 9']);
 
 function isMathFunctionNode(node) {
   if (node.type !== 'function') {
@@ -68,8 +65,11 @@ function transform(value, options) {
 
 function addPluginDefaults(options, browsers) {
   const defaults = {
-    transparent: browsers.some(hasTransparentBug) === false, // Does the browser support 4 & 8 character hex notation
-    alphaHex: isSupported('css-rrggbbaa', browsers), // Does the browser support "transparent" value properly
+    // Does the browser support 4 & 8 character hex notation
+    transparent:
+      browsers.some((b) => browsersWithTransparentBug.has(b)) === false,
+    // Does the browser support "transparent" value properly
+    alphaHex: isSupported('css-rrggbbaa', browsers),
     name: true,
   };
   return { ...defaults, ...options };

--- a/packages/postcss-colormin/src/index.js
+++ b/packages/postcss-colormin/src/index.js
@@ -21,7 +21,7 @@ function walk(parent, callback) {
  */
 
 function hasTransparentBug(browser) {
-  return ~['ie 8', 'ie 9'].indexOf(browser);
+  return ['ie 8', 'ie 9'].includes(browser);
 }
 
 function isMathFunctionNode(node) {

--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -56,7 +56,7 @@ function parseWord(node, opts, keepZeroUnit) {
     if (num === 0) {
       node.value =
         0 +
-        (keepZeroUnit || (!~LENGTH_UNITS.indexOf(u.toLowerCase()) && u !== '%')
+        (keepZeroUnit || (!LENGTH_UNITS.includes(u.toLowerCase()) && u !== '%')
           ? u
           : '');
     } else {
@@ -65,7 +65,7 @@ function parseWord(node, opts, keepZeroUnit) {
       if (
         typeof opts.precision === 'number' &&
         u.toLowerCase() === 'px' &&
-        ~pair.number.indexOf('.')
+        pair.number.includes('.')
       ) {
         const precision = Math.pow(10, opts.precision);
         node.value =
@@ -92,7 +92,7 @@ function shouldKeepZeroUnit(decl) {
   const { parent } = decl;
   const lowerCasedProp = decl.prop.toLowerCase();
   return (
-    (~decl.value.indexOf('%') &&
+    (decl.value.includes('%') &&
       (lowerCasedProp === 'max-height' || lowerCasedProp === 'height')) ||
     (parent.parent &&
       parent.parent.name &&
@@ -105,7 +105,7 @@ function shouldKeepZeroUnit(decl) {
 function transform(opts, decl) {
   const lowerCasedProp = decl.prop.toLowerCase();
   if (
-    ~lowerCasedProp.indexOf('flex') ||
+    lowerCasedProp.includes('flex') ||
     lowerCasedProp.indexOf('--') === 0 ||
     notALength.has(lowerCasedProp)
   ) {

--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -1,7 +1,7 @@
 import valueParser, { unit, walk } from 'postcss-value-parser';
 import convert from './lib/convert';
 
-const LENGTH_UNITS = [
+const LENGTH_UNITS = new Set([
   'em',
   'ex',
   'ch',
@@ -17,7 +17,7 @@ const LENGTH_UNITS = [
   'pt',
   'pc',
   'px',
-];
+]);
 
 // These properties only accept percentages, so no point in trying to transform
 const notALength = new Set([
@@ -56,7 +56,7 @@ function parseWord(node, opts, keepZeroUnit) {
     if (num === 0) {
       node.value =
         0 +
-        (keepZeroUnit || (!LENGTH_UNITS.includes(u.toLowerCase()) && u !== '%')
+        (keepZeroUnit || (!LENGTH_UNITS.has(u.toLowerCase()) && u !== '%')
           ? u
           : '');
     } else {

--- a/packages/postcss-discard-duplicates/src/index.js
+++ b/packages/postcss-discard-duplicates/src/index.js
@@ -87,7 +87,7 @@ function dedupeRule(last, nodes) {
 }
 
 function dedupeNode(last, nodes) {
-  let index = ~nodes.indexOf(last) ? nodes.indexOf(last) - 1 : nodes.length - 1;
+  let index = nodes.includes(last) ? nodes.indexOf(last) - 1 : nodes.length - 1;
 
   while (index >= 0) {
     const node = nodes[index--];

--- a/packages/postcss-discard-empty/src/__tests__/index.js
+++ b/packages/postcss-discard-empty/src/__tests__/index.js
@@ -35,7 +35,7 @@ function testRemovals(fixture, expected, removedSelectors) {
           m.plugin !== 'postcss-discard-empty' ||
           m.type !== 'removal' ||
           m.selector !== undefined ||
-          ~removedSelectors.indexOf(m.selector)
+          removedSelectors.includes(m.selector)
         ) {
           throw new Error(
             'unexpected selector `' + m.selector + '` was removed'

--- a/packages/postcss-discard-overridden/src/index.js
+++ b/packages/postcss-discard-overridden/src/index.js
@@ -6,11 +6,11 @@ function vendorUnprefixed(prop) {
 }
 
 function isOverridable(name) {
-  return ~OVERRIDABLE_RULES.indexOf(vendorUnprefixed(name.toLowerCase()));
+  return OVERRIDABLE_RULES.includes(vendorUnprefixed(name.toLowerCase()));
 }
 
 function isScope(name) {
-  return ~SCOPE_RULES.indexOf(vendorUnprefixed(name.toLowerCase()));
+  return SCOPE_RULES.includes(vendorUnprefixed(name.toLowerCase()));
 }
 
 function getScope(node) {

--- a/packages/postcss-discard-overridden/src/index.js
+++ b/packages/postcss-discard-overridden/src/index.js
@@ -1,16 +1,16 @@
-const OVERRIDABLE_RULES = ['keyframes', 'counter-style'];
-const SCOPE_RULES = ['media', 'supports'];
+const OVERRIDABLE_RULES = new Set(['keyframes', 'counter-style']);
+const SCOPE_RULES = new Set(['media', 'supports']);
 
 function vendorUnprefixed(prop) {
   return prop.replace(/^-\w+-/, '');
 }
 
 function isOverridable(name) {
-  return OVERRIDABLE_RULES.includes(vendorUnprefixed(name.toLowerCase()));
+  return OVERRIDABLE_RULES.has(vendorUnprefixed(name.toLowerCase()));
 }
 
 function isScope(name) {
-  return SCOPE_RULES.includes(vendorUnprefixed(name.toLowerCase()));
+  return SCOPE_RULES.has(vendorUnprefixed(name.toLowerCase()));
 }
 
 function getScope(node) {

--- a/packages/postcss-discard-unused/src/index.js
+++ b/packages/postcss-discard-unused/src/index.js
@@ -43,7 +43,7 @@ function filterNamespace({ atRules, rules }) {
 }
 
 function hasFont(fontFamily, cache, comma) {
-  return comma(fontFamily).some((font) => cache.some((c) => ~c.indexOf(font)));
+  return comma(fontFamily).some((font) => cache.some((c) => c.includes(font)));
 }
 
 // fonts have slightly different logic
@@ -92,8 +92,8 @@ function pluginCreator(opts) {
           css.walk((node) => {
             const { type, prop, selector, name } = node;
 
-            if (type === rule && namespace && ~selector.indexOf('|')) {
-              if (~selector.indexOf('[')) {
+            if (type === rule && namespace && selector.includes('|')) {
+              if (selector.includes('[')) {
                 // Attribute selector, so we should parse further.
                 selectorParser((ast) => {
                   ast.walkAttributes(({ namespace: ns }) => {

--- a/packages/postcss-merge-longhand/src/lib/colornames.js
+++ b/packages/postcss-merge-longhand/src/lib/colornames.js
@@ -1,5 +1,5 @@
 /* https://www.w3.org/TR/css-color-4/#named-colors */
-export default [
+export default new Set([
   'aliceblue',
   'antiquewhite',
   'aqua',
@@ -148,4 +148,4 @@ export default [
   'whitesmoke',
   'yellow',
   'yellowgreen',
-];
+]);

--- a/packages/postcss-merge-longhand/src/lib/decl/borders.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/borders.js
@@ -46,7 +46,7 @@ const allProperties = precedence.reduce((a, b) => a.concat(b));
 
 function getLevel(prop) {
   for (let i = 0; i < precedence.length; i++) {
-    if (~precedence[i].indexOf(prop.toLowerCase())) {
+    if (precedence[i].includes(prop.toLowerCase())) {
       return i;
     }
   }
@@ -135,7 +135,7 @@ function getDistinctShorthands(mapped) {
   return mapped.reduce((a, b) => {
     a = Array.isArray(a) ? a : [a];
 
-    if (!~a.indexOf(b)) {
+    if (!a.includes(b)) {
       a.push(b);
     }
 
@@ -538,7 +538,7 @@ function merge(rule) {
       const props = nodes.filter(
         (node) =>
           node.prop &&
-          ~names.indexOf(node.prop) &&
+          names.includes(node.prop) &&
           node.important === lastNode.important
       );
       const rules = getRules(props, names);
@@ -573,7 +573,7 @@ function merge(rule) {
           value,
         });
 
-        decls = decls.filter((node) => !~rules.indexOf(node));
+        decls = decls.filter((node) => !rules.includes(node));
         rules.forEach(remove);
       }
     });
@@ -693,12 +693,12 @@ function merge(rule) {
         node !== lastNode &&
         node.important === lastNode.important &&
         getLevel(node.prop) > getLevel(lastNode.prop) &&
-        (!!~node.prop.toLowerCase().indexOf(lastNode.prop) ||
+        (node.prop.toLowerCase().includes(lastNode.prop) ||
           node.prop.toLowerCase().endsWith(lastPart))
     );
 
     lesser.forEach(remove);
-    decls = decls.filter((node) => !~lesser.indexOf(node));
+    decls = decls.filter((node) => !lesser.includes(node));
 
     // get duplicate properties
     let duplicates = decls.filter(
@@ -724,7 +724,7 @@ function merge(rule) {
     }
 
     decls = decls.filter(
-      (node) => node !== lastNode && !~duplicates.indexOf(node)
+      (node) => node !== lastNode && !duplicates.includes(node)
     );
   }
 }

--- a/packages/postcss-merge-longhand/src/lib/decl/boxBase.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/boxBase.js
@@ -32,7 +32,7 @@ export default (prop) => {
       );
 
       lesser.forEach(remove);
-      decls = decls.filter((node) => !~lesser.indexOf(node));
+      decls = decls.filter((node) => !lesser.includes(node));
 
       // get duplicate properties
       let duplicates = decls.filter(
@@ -47,7 +47,7 @@ export default (prop) => {
 
       duplicates.forEach(remove);
       decls = decls.filter(
-        (node) => node !== lastNode && !~duplicates.indexOf(node)
+        (node) => node !== lastNode && !duplicates.includes(node)
       );
     }
   };

--- a/packages/postcss-merge-longhand/src/lib/decl/columns.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/columns.js
@@ -95,7 +95,7 @@ function cleanup(rule) {
     );
 
     lesser.forEach(remove);
-    decls = decls.filter((node) => !~lesser.indexOf(node));
+    decls = decls.filter((node) => !lesser.includes(node));
 
     // get duplicate properties
     let duplicates = decls.filter(
@@ -110,7 +110,7 @@ function cleanup(rule) {
 
     duplicates.forEach(remove);
     decls = decls.filter(
-      (node) => node !== lastNode && !~duplicates.indexOf(node)
+      (node) => node !== lastNode && !duplicates.includes(node)
     );
   }
 }

--- a/packages/postcss-merge-longhand/src/lib/getDecls.js
+++ b/packages/postcss-merge-longhand/src/lib/getDecls.js
@@ -1,5 +1,5 @@
 export default function getDecls(rule, properties) {
   return rule.nodes.filter(
-    ({ prop }) => prop && ~properties.indexOf(prop.toLowerCase())
+    ({ prop }) => prop && properties.includes(prop.toLowerCase())
   );
 }

--- a/packages/postcss-merge-longhand/src/lib/hasAllProps.js
+++ b/packages/postcss-merge-longhand/src/lib/hasAllProps.js
@@ -1,5 +1,5 @@
 export default (rule, ...props) => {
   return props.every((p) =>
-    rule.some(({ prop }) => prop && ~prop.toLowerCase().indexOf(p))
+    rule.some(({ prop }) => prop && prop.toLowerCase().includes(p))
   );
 };

--- a/packages/postcss-merge-longhand/src/lib/mergeRules.js
+++ b/packages/postcss-merge-longhand/src/lib/mergeRules.js
@@ -40,7 +40,7 @@ export default function mergeRules(rule, properties, callback) {
 
     if (hasAllProps(rules, ...properties) && !hasConflicts(rules, rule.nodes)) {
       if (callback(rules, last, props)) {
-        decls = decls.filter((node) => !~rules.indexOf(node));
+        decls = decls.filter((node) => !rules.includes(node));
       }
     }
 

--- a/packages/postcss-merge-longhand/src/lib/validateWsc.js
+++ b/packages/postcss-merge-longhand/src/lib/validateWsc.js
@@ -1,7 +1,7 @@
 import colors from './colornames.js';
 
-const widths = ['thin', 'medium', 'thick'];
-const styles = [
+const widths = new Set(['thin', 'medium', 'thick']);
+const styles = new Set([
   'none',
   'hidden',
   'dotted',
@@ -12,15 +12,15 @@ const styles = [
   'ridge',
   'inset',
   'outset',
-];
+]);
 
 export function isStyle(value) {
-  return value && styles.includes(value.toLowerCase());
+  return value && styles.has(value.toLowerCase());
 }
 
 export function isWidth(value) {
   return (
-    (value && widths.includes(value.toLowerCase())) ||
+    (value && widths.has(value.toLowerCase())) ||
     /^(\d+(\.\d+)?|\.\d+)(\w+)?$/.test(value)
   );
 }
@@ -52,7 +52,7 @@ export function isColor(value) {
     return true;
   }
 
-  return colors.includes(value);
+  return colors.has(value);
 }
 
 export function isValidWsc(wscs) {

--- a/packages/postcss-merge-longhand/src/lib/validateWsc.js
+++ b/packages/postcss-merge-longhand/src/lib/validateWsc.js
@@ -15,12 +15,12 @@ const styles = [
 ];
 
 export function isStyle(value) {
-  return value && !!~styles.indexOf(value.toLowerCase());
+  return value && styles.includes(value.toLowerCase());
 }
 
 export function isWidth(value) {
   return (
-    (value && !!~widths.indexOf(value.toLowerCase())) ||
+    (value && widths.includes(value.toLowerCase())) ||
     /^(\d+(\.\d+)?|\.\d+)(\w+)?$/.test(value)
   );
 }
@@ -52,7 +52,7 @@ export function isColor(value) {
     return true;
   }
 
-  return !!~colors.indexOf(value);
+  return colors.includes(value);
 }
 
 export function isValidWsc(wscs) {

--- a/packages/postcss-merge-rules/src/index.js
+++ b/packages/postcss-merge-rules/src/index.js
@@ -71,7 +71,7 @@ function canMerge(ruleA, ruleB, browsers, compatibilityCache) {
 
   const parent = sameParent(ruleA, ruleB);
   const { name } = ruleA.parent;
-  if (parent && name && ~name.indexOf('keyframes')) {
+  if (parent && name && name.includes('keyframes')) {
     return false;
   }
   return parent && (selectors.every(noVendor) || sameVendor(a, b));

--- a/packages/postcss-merge-rules/src/lib/ensureCompatibility.js
+++ b/packages/postcss-merge-rules/src/lib/ensureCompatibility.js
@@ -152,10 +152,10 @@ export function ensureCompatibility(selectors, browsers, compatibilityCache) {
           }
         }
         if (type === 'combinator') {
-          if (~value.indexOf('~')) {
+          if (value.includes('~')) {
             compatible = isSupportedCached(cssSel3, browsers);
           }
-          if (~value.indexOf('>') || ~value.indexOf('+')) {
+          if (value.includes('>') || value.includes('+')) {
             compatible = isSupportedCached(cssSel2, browsers);
           }
         }
@@ -167,11 +167,11 @@ export function ensureCompatibility(selectors, browsers, compatibilityCache) {
 
           if (value) {
             // [foo="bar"], [foo~="bar"], [foo|="bar"]
-            if (~['=', '~=', '|='].indexOf(node.operator)) {
+            if (['=', '~=', '|='].includes(node.operator)) {
               compatible = isSupportedCached(cssSel2, browsers);
             }
             // [foo^="bar"], [foo$="bar"], [foo*="bar"]
-            if (~['^=', '$=', '*='].indexOf(node.operator)) {
+            if (['^=', '$=', '*='].includes(node.operator)) {
               compatible = isSupportedCached(cssSel3, browsers);
             }
           }

--- a/packages/postcss-minify-font-values/src/lib/keywords.js
+++ b/packages/postcss-minify-font-values/src/lib/keywords.js
@@ -1,7 +1,7 @@
 export default {
-  style: ['italic', 'oblique'],
-  variant: ['small-caps'],
-  weight: [
+  style: new Set(['italic', 'oblique']),
+  variant: new Set(['small-caps']),
+  weight: new Set([
     '100',
     '200',
     '300',
@@ -14,8 +14,8 @@ export default {
     'bold',
     'lighter',
     'bolder',
-  ],
-  stretch: [
+  ]),
+  stretch: new Set([
     'ultra-condensed',
     'extra-condensed',
     'condensed',
@@ -24,8 +24,8 @@ export default {
     'expanded',
     'extra-expanded',
     'ultra-expanded',
-  ],
-  size: [
+  ]),
+  size: new Set([
     'xx-small',
     'x-small',
     'small',
@@ -35,5 +35,5 @@ export default {
     'xx-large',
     'larger',
     'smaller',
-  ],
+  ]),
 };

--- a/packages/postcss-minify-font-values/src/lib/minify-family.js
+++ b/packages/postcss-minify-font-values/src/lib/minify-family.js
@@ -192,7 +192,7 @@ export default function (nodes, opts) {
 
   if (opts.removeAfterKeyword) {
     for (i = 0, max = family.length; i < max; i += 1) {
-      if (~genericFontFamilykeywords.indexOf(family[i].toLowerCase())) {
+      if (genericFontFamilykeywords.includes(family[i].toLowerCase())) {
         family = family.slice(0, i + 1);
         break;
       }

--- a/packages/postcss-minify-font-values/src/lib/minify-family.js
+++ b/packages/postcss-minify-font-values/src/lib/minify-family.js
@@ -3,14 +3,14 @@ import uniqueExcept from './uniqs';
 
 const uniqs = uniqueExcept('monospace');
 const globalKeywords = ['inherit', 'initial', 'unset'];
-const genericFontFamilykeywords = [
+const genericFontFamilykeywords = new Set([
   'sans-serif',
   'serif',
   'fantasy',
   'cursive',
   'monospace',
   'system-ui',
-];
+]);
 
 function makeArray(value, length) {
   let array = [];
@@ -66,7 +66,7 @@ function escape(string, escapeForString) {
 }
 
 const regexKeyword = new RegExp(
-  genericFontFamilykeywords.concat(globalKeywords).join('|'),
+  [...genericFontFamilykeywords].concat(globalKeywords).join('|'),
   'i'
 );
 const regexInvalidIdentifier = /^(-?\d|--)/;
@@ -192,7 +192,7 @@ export default function (nodes, opts) {
 
   if (opts.removeAfterKeyword) {
     for (i = 0, max = family.length; i < max; i += 1) {
-      if (genericFontFamilykeywords.includes(family[i].toLowerCase())) {
+      if (genericFontFamilykeywords.has(family[i].toLowerCase())) {
         family = family.slice(0, i + 1);
         break;
       }

--- a/packages/postcss-minify-font-values/src/lib/minify-font.js
+++ b/packages/postcss-minify-font-values/src/lib/minify-font.js
@@ -24,16 +24,16 @@ export default function (nodes, opts) {
         value === 'unset'
       ) {
         familyStart = i;
-      } else if (keywords.style.includes(value) || unit(value)) {
+      } else if (keywords.style.has(value) || unit(value)) {
         familyStart = i;
-      } else if (keywords.variant.includes(value)) {
+      } else if (keywords.variant.has(value)) {
         familyStart = i;
-      } else if (keywords.weight.includes(value)) {
+      } else if (keywords.weight.has(value)) {
         node.value = minifyWeight(value);
         familyStart = i;
-      } else if (keywords.stretch.includes(value)) {
+      } else if (keywords.stretch.has(value)) {
         familyStart = i;
-      } else if (keywords.size.includes(value) || unit(value)) {
+      } else if (keywords.size.has(value) || unit(value)) {
         familyStart = i;
         hasSize = true;
       }

--- a/packages/postcss-minify-font-values/src/lib/minify-font.js
+++ b/packages/postcss-minify-font-values/src/lib/minify-font.js
@@ -24,16 +24,16 @@ export default function (nodes, opts) {
         value === 'unset'
       ) {
         familyStart = i;
-      } else if (~keywords.style.indexOf(value) || unit(value)) {
+      } else if (keywords.style.includes(value) || unit(value)) {
         familyStart = i;
-      } else if (~keywords.variant.indexOf(value)) {
+      } else if (keywords.variant.includes(value)) {
         familyStart = i;
-      } else if (~keywords.weight.indexOf(value)) {
+      } else if (keywords.weight.includes(value)) {
         node.value = minifyWeight(value);
         familyStart = i;
-      } else if (~keywords.stretch.indexOf(value)) {
+      } else if (keywords.stretch.includes(value)) {
         familyStart = i;
-      } else if (~keywords.size.indexOf(value) || unit(value)) {
+      } else if (keywords.size.includes(value) || unit(value)) {
         familyStart = i;
         hasSize = true;
       }

--- a/packages/postcss-minify-params/src/index.js
+++ b/packages/postcss-minify-params/src/index.js
@@ -93,7 +93,7 @@ function transform(legacy, rule) {
 }
 
 function hasAllBug(browser) {
-  return ~['ie 10', 'ie 11'].indexOf(browser);
+  return ['ie 10', 'ie 11'].includes(browser);
 }
 
 function pluginCreator(options = {}) {

--- a/packages/postcss-minify-selectors/src/index.js
+++ b/packages/postcss-minify-selectors/src/index.js
@@ -120,7 +120,7 @@ function pseudo(selector) {
     if (child.type === 'selector') {
       const childStr = String(child);
 
-      if (!~uniques.indexOf(childStr)) {
+      if (!uniques.includes(childStr)) {
         uniques.push(childStr);
       } else {
         child.remove();
@@ -128,7 +128,7 @@ function pseudo(selector) {
     }
   });
 
-  if (~pseudoElements.indexOf(value)) {
+  if (pseudoElements.includes(value)) {
     selector.value = selector.value.slice(1);
   }
 }
@@ -188,7 +188,7 @@ function pluginCreator() {
           const toString = String(sel);
 
           if (type === 'selector' && sel.parent.type !== 'pseudo') {
-            if (!~uniqueSelectors.indexOf(toString)) {
+            if (!uniqueSelectors.includes(toString)) {
               uniqueSelectors.push(toString);
             } else {
               sel.remove();

--- a/packages/postcss-normalize-positions/src/__tests__/index.js
+++ b/packages/postcss-normalize-positions/src/__tests__/index.js
@@ -100,8 +100,8 @@ function suite(property, additional = '', tail = '') {
       .filter((d) => {
         if (
           d === direction ||
-          (~hkeys.indexOf(d) && ~hkeys.indexOf(direction)) ||
-          (~vkeys.indexOf(d) && ~vkeys.indexOf(direction))
+          (hkeys.includes(d) && hkeys.includes(direction)) ||
+          (vkeys.includes(d) && vkeys.includes(direction))
         ) {
           return false;
         }
@@ -111,7 +111,7 @@ function suite(property, additional = '', tail = '') {
       .forEach((other) => {
         let result;
 
-        if (~Object.keys(horizontal).indexOf(direction)) {
+        if (Object.keys(horizontal).includes(direction)) {
           result = horizontal[direction] + ' ' + vertical[other];
         } else {
           result = horizontal[other] + ' ' + vertical[direction];

--- a/packages/postcss-normalize-unicode/src/index.js
+++ b/packages/postcss-normalize-unicode/src/index.js
@@ -51,7 +51,7 @@ function unicode(range) {
  */
 
 function hasLowerCaseUPrefixBug(browser) {
-  return ~browserslist('ie <=11, edge <= 15').indexOf(browser);
+  return browserslist('ie <=11, edge <= 15').includes(browser);
 }
 
 function transform(value, isLegacy = false) {

--- a/packages/postcss-normalize-whitespace/src/index.js
+++ b/packages/postcss-normalize-whitespace/src/index.js
@@ -40,7 +40,7 @@ function pluginCreator() {
       css.walk((node) => {
         const { type } = node;
 
-        if (~[decl, rule, atrule].indexOf(type) && node.raws.before) {
+        if ([decl, rule, atrule].includes(type) && node.raws.before) {
           node.raws.before = node.raws.before.replace(/\s/g, '');
         }
 

--- a/packages/postcss-ordered-values/src/index.js
+++ b/packages/postcss-ordered-values/src/index.js
@@ -73,7 +73,7 @@ function shouldAbort(parsed) {
     if (
       node.type === 'comment' ||
       isVariableFunctionNode(node) ||
-      (node.type === 'word' && ~node.value.indexOf(`___CSS_LOADER_IMPORT___`))
+      (node.type === 'word' && node.value.includes(`___CSS_LOADER_IMPORT___`))
     ) {
       abort = true;
 

--- a/packages/postcss-ordered-values/src/rules/flexFlow.js
+++ b/packages/postcss-ordered-values/src/rules/flexFlow.js
@@ -11,12 +11,12 @@ export default function normalizeFlexFlow(flexFlow) {
   };
 
   flexFlow.walk(({ value }) => {
-    if (~flexDirection.indexOf(value.toLowerCase())) {
+    if (flexDirection.includes(value.toLowerCase())) {
       order.direction = value;
       return;
     }
 
-    if (~flexWrap.indexOf(value.toLowerCase())) {
+    if (flexWrap.includes(value.toLowerCase())) {
       order.wrap = value;
       return;
     }

--- a/packages/postcss-ordered-values/src/rules/transition.js
+++ b/packages/postcss-ordered-values/src/rules/transition.js
@@ -5,7 +5,7 @@ import getValue from '../lib/getValue';
 
 // transition: [ none | <single-transition-property> ] || <time> || <single-transition-timing-function> || <time>
 
-const timingFunctions = [
+const timingFunctions = new Set([
   'ease',
   'linear',
   'ease-in',
@@ -13,7 +13,7 @@ const timingFunctions = [
   'ease-in-out',
   'step-start',
   'step-end',
-];
+]);
 
 export default function normalizeTransition(parsed) {
   let args = getArguments(parsed);
@@ -35,7 +35,7 @@ export default function normalizeTransition(parsed) {
 
       if (
         type === 'function' &&
-        ['steps', 'cubic-bezier'].includes(value.toLowerCase())
+        new Set(['steps', 'cubic-bezier']).has(value.toLowerCase())
       ) {
         state.timingFunction = [...state.timingFunction, node, addSpace()];
       } else if (unit(value)) {
@@ -44,7 +44,7 @@ export default function normalizeTransition(parsed) {
         } else {
           state.time2 = [...state.time2, node, addSpace()];
         }
-      } else if (timingFunctions.includes(value.toLowerCase())) {
+      } else if (timingFunctions.has(value.toLowerCase())) {
         state.timingFunction = [...state.timingFunction, node, addSpace()];
       } else {
         state.property = [...state.property, node, addSpace()];

--- a/packages/postcss-ordered-values/src/rules/transition.js
+++ b/packages/postcss-ordered-values/src/rules/transition.js
@@ -35,7 +35,7 @@ export default function normalizeTransition(parsed) {
 
       if (
         type === 'function' &&
-        ~['steps', 'cubic-bezier'].indexOf(value.toLowerCase())
+        ['steps', 'cubic-bezier'].includes(value.toLowerCase())
       ) {
         state.timingFunction = [...state.timingFunction, node, addSpace()];
       } else if (unit(value)) {
@@ -44,7 +44,7 @@ export default function normalizeTransition(parsed) {
         } else {
           state.time2 = [...state.time2, node, addSpace()];
         }
-      } else if (~timingFunctions.indexOf(value.toLowerCase())) {
+      } else if (timingFunctions.includes(value.toLowerCase())) {
         state.timingFunction = [...state.timingFunction, node, addSpace()];
       } else {
         state.property = [...state.property, node, addSpace()];

--- a/packages/postcss-reduce-idents/src/lib/keyframes.js
+++ b/packages/postcss-reduce-idents/src/lib/keyframes.js
@@ -34,7 +34,7 @@ export default function () {
         decl.value = valueParser(decl.value)
           .walk((node) => {
             if (node.type === 'word' && node.value in cache) {
-              if (!~referenced.indexOf(node.value)) {
+              if (!referenced.includes(node.value)) {
                 referenced.push(node.value);
               }
 
@@ -49,7 +49,7 @@ export default function () {
       atRules.forEach((rule) => {
         const cached = cache[rule.params];
 
-        if (cached && cached.count > 0 && !!~referenced.indexOf(rule.params)) {
+        if (cached && cached.count > 0 && referenced.includes(rule.params)) {
           rule.params = cached.ident;
         }
       });

--- a/packages/postcss-reduce-idents/src/lib/keyframes.js
+++ b/packages/postcss-reduce-idents/src/lib/keyframes.js
@@ -27,15 +27,15 @@ export default function () {
     },
 
     transform() {
-      let referenced = [];
+      const referenced = new Set();
 
       // Iterate each property and change their names
       decls.forEach((decl) => {
         decl.value = valueParser(decl.value)
           .walk((node) => {
             if (node.type === 'word' && node.value in cache) {
-              if (!referenced.includes(node.value)) {
-                referenced.push(node.value);
+              if (!referenced.has(node.value)) {
+                referenced.add(node.value);
               }
 
               cache[node.value].count++;
@@ -49,7 +49,7 @@ export default function () {
       atRules.forEach((rule) => {
         const cached = cache[rule.params];
 
-        if (cached && cached.count > 0 && referenced.includes(rule.params)) {
+        if (cached && cached.count > 0 && referenced.has(rule.params)) {
           rule.params = cached.ident;
         }
       });

--- a/packages/stylehacks/src/index.js
+++ b/packages/stylehacks/src/index.js
@@ -27,7 +27,7 @@ function pluginCreator(opts = {}) {
 
       css.walk((node) => {
         processors.forEach((proc) => {
-          if (!~proc.nodeTypes.indexOf(node.type)) {
+          if (!proc.nodeTypes.includes(node.type)) {
             return;
           }
 

--- a/packages/stylehacks/src/plugin.js
+++ b/packages/stylehacks/src/plugin.js
@@ -17,7 +17,7 @@ export default function plugin(targets, nodeTypes, detect) {
     }
 
     any(node) {
-      if (~this.nodeTypes.indexOf(node.type)) {
+      if (this.nodeTypes.includes(node.type)) {
         detect.apply(this, arguments);
 
         return !!node._stylehacks;

--- a/packages/stylehacks/src/plugins/leadingStar.js
+++ b/packages/stylehacks/src/plugins/leadingStar.js
@@ -23,7 +23,7 @@ export default plugin([IE_5_5, IE_6, IE_7], [ATRULE, DECL], function (node) {
       return;
     }
     hacks.some((hack) => {
-      if (~before.indexOf(hack)) {
+      if (before.includes(hack)) {
         this.push(node, {
           identifier: PROPERTY,
           hack: `${before.trim()}${node.prop}`,

--- a/packages/stylehacks/src/plugins/leadingUnderscore.js
+++ b/packages/stylehacks/src/plugins/leadingUnderscore.js
@@ -14,7 +14,7 @@ function vendorPrefix(prop) {
 export default plugin([IE_6], [DECL], function (decl) {
   const { before } = decl.raws;
 
-  if (before && ~before.indexOf('_')) {
+  if (before && before.includes('_')) {
     this.push(decl, {
       identifier: PROPERTY,
       hack: `${before.trim()}${decl.prop}`,


### PR DESCRIPTION
Avoid implicitly converting numbers to booleans as it makes it harder to understand for TypeScript and for humans
1. Replace `~indexOf` with `includes` for strings and arrays
2. Replace arrays of with sets if we use the arrays only to check membership 

`Array.includes` and `Array.indexOf` behave differently with `NaN`, but in our case if `NaN` is involved I think we would already have a bug somewhere...