### PR TITLE
refactor: replace objects with maps and avoid excessively dynamic code

### DIFF
--- a/packages/postcss-normalize-positions/src/__tests__/index.js
+++ b/packages/postcss-normalize-positions/src/__tests__/index.js
@@ -279,6 +279,14 @@ test(
 );
 
 test(
+  'should normalize with background size and right alignment',
+  processCSS(
+    'background: url(/media/examples/hand.jpg) right center / 200px 100px',
+    'background: url(/media/examples/hand.jpg) 100% / 200px 100px'
+  )
+);
+
+test(
   'should normalize with multiple background positions',
   processCSS(
     'background: url("/media/examples/lizard.png") center center no-repeat, url("/media/examples/lizard.png") center center no-repeat',

--- a/packages/postcss-normalize-positions/src/index.js
+++ b/packages/postcss-normalize-positions/src/index.js
@@ -3,8 +3,14 @@ import valueParser, { unit } from 'postcss-value-parser';
 const directionKeywords = ['top', 'right', 'bottom', 'left', 'center'];
 
 const center = '50%';
-const horizontal = { right: '100%', left: '0' };
-const verticalValue = { bottom: '100%', top: '0' };
+const horizontal = new Map([
+  ['right', '100%'],
+  ['left', '0'],
+]);
+const verticalValue = new Map([
+  ['bottom', '100%'],
+  ['top', '0'],
+]);
 
 function isCommaNode(node) {
   return node.type === 'div' && node.value === ',';
@@ -140,12 +146,10 @@ function transform(value) {
         nodes[2].value = nodes[1].value = '';
       }
 
-      const map = Object.assign({}, horizontal, {
-        center,
-      });
+      const map = new Map([...horizontal, ['center', center]]);
 
-      if (Object.prototype.hasOwnProperty.call(map, firstNode)) {
-        nodes[0].value = map[firstNode];
+      if (map.has(firstNode)) {
+        nodes[0].value = map.get(firstNode);
       }
 
       return;
@@ -154,27 +158,20 @@ function transform(value) {
     if (firstNode === 'center' && directionKeywords.includes(secondNode)) {
       nodes[0].value = nodes[1].value = '';
 
-      if (Object.prototype.hasOwnProperty.call(horizontal, secondNode)) {
-        nodes[2].value = horizontal[secondNode];
+      if (horizontal.has(secondNode)) {
+        nodes[2].value = horizontal.get(secondNode);
       }
-
       return;
     }
 
-    if (
-      Object.prototype.hasOwnProperty.call(horizontal, firstNode) &&
-      Object.prototype.hasOwnProperty.call(verticalValue, secondNode)
-    ) {
-      nodes[0].value = horizontal[firstNode];
-      nodes[2].value = verticalValue[secondNode];
+    if (horizontal.has(firstNode) && verticalValue.has(secondNode)) {
+      nodes[0].value = horizontal.get(firstNode);
+      nodes[2].value = verticalValue.get(secondNode);
 
       return;
-    } else if (
-      Object.prototype.hasOwnProperty.call(verticalValue, firstNode) &&
-      Object.prototype.hasOwnProperty.call(horizontal, secondNode)
-    ) {
-      nodes[0].value = horizontal[secondNode];
-      nodes[2].value = verticalValue[firstNode];
+    } else if (verticalValue.has(firstNode) && horizontal.has(secondNode)) {
+      nodes[0].value = horizontal.get(secondNode);
+      nodes[2].value = verticalValue.get(firstNode);
 
       return;
     }

--- a/packages/postcss-reduce-transforms/src/index.js
+++ b/packages/postcss-reduce-transforms/src/index.js
@@ -189,15 +189,15 @@ function translate3d(node, values) {
   }
 }
 
-const reducers = {
-  matrix3d,
-  rotate3d,
-  rotateZ,
-  scale,
-  scale3d,
-  translate,
-  translate3d,
-};
+const reducers = new Map([
+  ['matrix3d', matrix3d],
+  ['rotate3d', rotate3d],
+  ['rotateZ', rotateZ],
+  ['scale', scale],
+  ['scale3d', scale3d],
+  ['translate', translate],
+  ['translate3d', translate3d],
+]);
 
 function normalizeReducerName(name) {
   const lowerCasedName = name.toLowerCase();
@@ -210,16 +210,13 @@ function normalizeReducerName(name) {
 }
 
 function reduce(node) {
-  const { nodes, type, value } = node;
-  const normalizedReducerName = normalizeReducerName(value);
-
-  if (
-    type === 'function' &&
-    Object.prototype.hasOwnProperty.call(reducers, normalizedReducerName)
-  ) {
-    reducers[normalizedReducerName](node, nodes.reduce(getValues, []));
+  if (node.type === 'function') {
+    const normalizedReducerName = normalizeReducerName(node.value);
+    const reducer = reducers.get(normalizedReducerName);
+    if (reducer !== undefined) {
+      reducer(node, node.nodes.reduce(getValues, []));
+    }
   }
-
   return false;
 }
 


### PR DESCRIPTION
* use maps instead of objects when the object is only used as a map
* make function dispatching a little more explicit.
* test: add one test for uncovered case in background positions