### PR TITLE
refactor(postcss-convert-values): remove unnecessary steps

### DIFF
--- a/packages/postcss-convert-values/src/lib/convert.js
+++ b/packages/postcss-convert-values/src/lib/convert.js
@@ -1,19 +1,19 @@
-const lengthConv = {
-  in: 96,
-  px: 1,
-  pt: 4 / 3,
-  pc: 16,
-};
+const lengthConv = new Map([
+  ['in', 96],
+  ['px', 1],
+  ['pt', 4 / 3],
+  ['pc', 16],
+]);
 
-const timeConv = {
-  s: 1000,
-  ms: 1,
-};
+const timeConv = new Map([
+  ['s', 1000],
+  ['ms', 1],
+]);
 
-const angleConv = {
-  turn: 360,
-  deg: 1,
-};
+const angleConv = new Map([
+  ['turn', 360],
+  ['deg', 1],
+]);
 
 function dropLeadingZero(number) {
   const value = String(number);
@@ -31,41 +31,32 @@ function dropLeadingZero(number) {
   return value;
 }
 
-function transform(number, unit, conversion) {
-  const lowerCasedUnit = unit.toLowerCase();
-  let one, base;
-  let convertionUnits = Object.keys(conversion).filter((u) => {
-    if (conversion[u] === 1) {
-      one = u;
-    }
-    return lowerCasedUnit !== u;
+function transform(number, originalUnit, conversions) {
+  let conversionUnits = [...conversions.keys()].filter((u) => {
+    return originalUnit !== u;
   });
 
-  if (lowerCasedUnit === one) {
-    base = number / conversion[lowerCasedUnit];
-  } else {
-    base = number * conversion[lowerCasedUnit];
-  }
+  const base = number * conversions.get(originalUnit);
 
-  return convertionUnits
-    .map((u) => dropLeadingZero(base / conversion[u]) + u)
+  return conversionUnits
+    .map((u) => dropLeadingZero(base / conversions.get(u)) + u)
     .reduce((a, b) => (a.length < b.length ? a : b));
 }
 
 export default function (number, unit, { time, length, angle }) {
   let value = dropLeadingZero(number) + (unit ? unit : '');
   let converted;
-
-  if (length !== false && unit.toLowerCase() in lengthConv) {
-    converted = transform(number, unit, lengthConv);
+  const lowerCaseUnit = unit.toLowerCase();
+  if (length !== false && lengthConv.has(lowerCaseUnit)) {
+    converted = transform(number, lowerCaseUnit, lengthConv);
   }
 
-  if (time !== false && unit.toLowerCase() in timeConv) {
-    converted = transform(number, unit, timeConv);
+  if (time !== false && timeConv.has(lowerCaseUnit)) {
+    converted = transform(number, lowerCaseUnit, timeConv);
   }
 
-  if (angle !== false && unit.toLowerCase() in angleConv) {
-    converted = transform(number, unit, angleConv);
+  if (angle !== false && angleConv.has(lowerCaseUnit)) {
+    converted = transform(number, lowerCaseUnit, angleConv);
   }
 
   if (converted && converted.length < value.length) {


### PR DESCRIPTION
- lower case unit once
- if unit is one no need to multiply or divide