### PR TITLE
fix: fix bad parameters and conversions

### DIFF
--- a/packages/postcss-minify-gradients/src/__tests__/isColorStop.js
+++ b/packages/postcss-minify-gradients/src/__tests__/isColorStop.js
@@ -8,5 +8,6 @@ test('should recognise color stops', () => {
   assert.is(isColorStop('yellow', 'px'), false);
   assert.is(isColorStop('yellow', 'calc(100%)'), true);
   assert.is(isColorStop(undefined), false);
+  assert.is(isColorStop('yellow', '0'), true);
 });
 test.run();

--- a/packages/postcss-minify-gradients/src/isColorStop.js
+++ b/packages/postcss-minify-gradients/src/isColorStop.js
@@ -34,10 +34,8 @@ function isStop(str) {
   if (!stop) {
     const node = unit(str);
     if (node) {
-      if (
-        node.number === 0 ||
-        (!isNaN(node.number) && isCSSLengthUnit(node.unit))
-      ) {
+      const number = Number(node.number);
+      if (number === 0 || (!isNaN(number) && isCSSLengthUnit(node.unit))) {
         stop = true;
       }
     } else {

--- a/packages/postcss-minify-selectors/src/index.js
+++ b/packages/postcss-minify-selectors/src/index.js
@@ -62,7 +62,7 @@ function combinator(selector) {
   selector.spaces.before = '';
   selector.spaces.after = '';
   selector.rawSpaceBefore = '';
-  selector.rawsSpaceAfter = '';
+  selector.rawSpaceAfter = '';
   selector.value = value.length ? value : ' ';
 }
 

--- a/packages/postcss-zindex/src/index.js
+++ b/packages/postcss-zindex/src/index.js
@@ -4,7 +4,7 @@ function pluginCreator(opts = {}) {
   return {
     postcssPlugin: 'postcss-zindex',
     prepare() {
-      const cache = new LayerCache(opts);
+      const cache = new LayerCache();
       return {
         OnceExit(css) {
           const nodes = [];


### PR DESCRIPTION
- `postcssValueParser.unit()` [returns the number as a string](https://github.com/TrySound/postcss-value-parser/blob/11a4436e74930f4eaf9cbdb2063656bcce8ebf6a/lib/unit.js#L117), so checking against `0` will always fail

- It's `rawSpaceAfter` with just one `s`. It seems to make no difference in the tests though
- in postcss-zindex, `LayerCache` constructor does not take parameters