### PR TITLE
fix(postcss-minify-gradients): handle node values as strings

### DIFF
--- a/packages/postcss-minify-gradients/src/index.js
+++ b/packages/postcss-minify-gradients/src/index.js
@@ -83,7 +83,7 @@ function optimise(decl) {
           }
 
           if (lastStop && thisStop && isLessThan(lastStop, thisStop)) {
-            arg[2].value = 0;
+            arg[2].value = '0';
           }
 
           lastStop = thisStop;
@@ -119,7 +119,7 @@ function optimise(decl) {
           }
 
           if (lastStop && thisStop && isLessThan(lastStop, thisStop)) {
-            arg[2].value = 0;
+            arg[2].value = '0';
           }
 
           lastStop = thisStop;
@@ -162,7 +162,7 @@ function optimise(decl) {
           color = color.toLowerCase();
 
           const colorStop =
-            stop || stop === 0
+            stop !== undefined
               ? isColorStop(color, stop.toLowerCase())
               : isColorStop(color);
 
@@ -179,7 +179,7 @@ function optimise(decl) {
           }
 
           if (lastStop && thisStop && isLessThan(lastStop, thisStop)) {
-            arg[2].value = 0;
+            arg[2].value = '0';
           }
 
           lastStop = thisStop;


### PR DESCRIPTION
Explicitly convert numbers to strings before assigning them to a
node value, so it's clearer how to compare them.