### PR TITLE
refactor: improve types

### DIFF
--- a/packages/postcss-discard-unused/src/index.js
+++ b/packages/postcss-discard-unused/src/index.js
@@ -9,9 +9,9 @@ function addValues(cache, { value }, comma, space) {
 }
 
 function filterAtRule({ atRules, values }) {
-  values = new Set(values);
+  const uniqueValues = new Set(values);
   atRules.forEach((node) => {
-    const hasAtRule = values.has(node.params);
+    const hasAtRule = uniqueValues.has(node.params);
 
     if (!hasAtRule) {
       node.remove();
@@ -20,7 +20,7 @@ function filterAtRule({ atRules, values }) {
 }
 
 function filterNamespace({ atRules, rules }) {
-  rules = new Set(rules);
+  const uniqueRules = new Set(rules);
   atRules.forEach((atRule) => {
     const { 0: param, length: len } = atRule.params.split(' ').filter(Boolean);
 
@@ -28,7 +28,7 @@ function filterNamespace({ atRules, rules }) {
       return;
     }
 
-    const hasRule = rules.has(param) || rules.has('*');
+    const hasRule = uniqueRules.has(param) || uniqueRules.has('*');
 
     if (!hasRule) {
       atRule.remove();

--- a/packages/postcss-minify-font-values/src/lib/minify-family.js
+++ b/packages/postcss-minify-font-values/src/lib/minify-family.js
@@ -39,7 +39,7 @@ function escape(string, escapeForString) {
 
   while (counter < string.length) {
     character = string.charAt(counter++);
-    charCode = character.charCodeAt();
+    charCode = character.charCodeAt(0);
 
     // \r is already tokenized away at this point
     // `:` can be escaped as `\:`, but that fails in IE < 8
@@ -152,7 +152,7 @@ function escapeIdentifierSequence(string) {
 }
 
 export default function (nodes, opts) {
-  let family = [];
+  const family = [];
   let last = null;
   let i, max;
 
@@ -175,7 +175,7 @@ export default function (nodes, opts) {
     }
   });
 
-  family = family.map((node) => {
+  let normalizedFamilies = family.map((node) => {
     if (node.type === 'string') {
       const isKeyword = regexKeyword.test(node.value);
 
@@ -198,22 +198,22 @@ export default function (nodes, opts) {
   });
 
   if (opts.removeAfterKeyword) {
-    for (i = 0, max = family.length; i < max; i += 1) {
-      if (genericFontFamilykeywords.has(family[i].toLowerCase())) {
-        family = family.slice(0, i + 1);
+    for (i = 0, max = normalizedFamilies.length; i < max; i += 1) {
+      if (genericFontFamilykeywords.has(normalizedFamilies[i].toLowerCase())) {
+        normalizedFamilies = normalizedFamilies.slice(0, i + 1);
         break;
       }
     }
   }
 
   if (opts.removeDuplicates) {
-    family = uniqueFontFamilies(family);
+    normalizedFamilies = uniqueFontFamilies(normalizedFamilies);
   }
 
   return [
     {
       type: 'word',
-      value: family.join(),
+      value: normalizedFamilies.join(),
     },
   ];
 }

--- a/packages/postcss-minify-params/src/index.js
+++ b/packages/postcss-minify-params/src/index.js
@@ -51,10 +51,13 @@ function transform(legacy, rule) {
         node.nodes[4] &&
         node.nodes[0].value.toLowerCase().indexOf('-aspect-ratio') === 3
       ) {
-        const [a, b] = aspectRatio(node.nodes[2].value, node.nodes[4].value);
+        const [a, b] = aspectRatio(
+          Number(node.nodes[2].value),
+          Number(node.nodes[4].value)
+        );
 
-        node.nodes[2].value = a;
-        node.nodes[4].value = b;
+        node.nodes[2].value = a.toString();
+        node.nodes[4].value = b.toString();
       }
     } else if (node.type === 'space') {
       node.value = ' ';


### PR DESCRIPTION
- avoid assigning different types to the same variable
- pass explicit 0 argument to `charCodeAt()`
- avoid implicitly converting back and forth between string and number