### PR TITLE
refactor(stylehacks): use standard JavaScript subclasses

### DIFF
--- a/packages/stylehacks/src/index.js
+++ b/packages/stylehacks/src/index.js
@@ -15,7 +15,7 @@ function pluginCreator(opts = {}) {
       const processors = plugins.reduce((list, Plugin) => {
         const hack = new Plugin(result);
         const applied = browsers.some((browser) => {
-          return hack.targets.some((target) => browser === target);
+          return hack.targets.has(browser);
         });
 
         if (applied) {
@@ -27,7 +27,7 @@ function pluginCreator(opts = {}) {
 
       css.walk((node) => {
         processors.forEach((proc) => {
-          if (!proc.nodeTypes.includes(node.type)) {
+          if (!proc.nodeTypes.has(node.type)) {
             return;
           }
 

--- a/packages/stylehacks/src/plugin.js
+++ b/packages/stylehacks/src/plugin.js
@@ -1,59 +1,59 @@
-export default function plugin(targets, nodeTypes, detect) {
-  class Plugin {
-    constructor(result) {
-      this.nodes = [];
-      this.result = result;
-      this.targets = targets;
-      this.nodeTypes = nodeTypes;
-    }
-
-    push(node, metadata) {
-      node._stylehacks = Object.assign({}, metadata, {
-        message: `Bad ${metadata.identifier}: ${metadata.hack}`,
-        browsers: this.targets,
-      });
-
-      this.nodes.push(node);
-    }
-
-    any(node) {
-      if (this.nodeTypes.includes(node.type)) {
-        detect.apply(this, arguments);
-
-        return !!node._stylehacks;
-      }
-
-      return false;
-    }
-
-    detectAndResolve(...args) {
-      this.nodes = [];
-
-      detect.apply(this, args);
-
-      return this.resolve();
-    }
-
-    detectAndWarn(...args) {
-      this.nodes = [];
-
-      detect.apply(this, args);
-
-      return this.warn();
-    }
-
-    resolve() {
-      return this.nodes.forEach((node) => node.remove());
-    }
-
-    warn() {
-      return this.nodes.forEach((node) => {
-        const { message, browsers, identifier, hack } = node._stylehacks;
-
-        return node.warn(this.result, message, { browsers, identifier, hack });
-      });
-    }
+export default class BasePlugin {
+  constructor(targets, nodeTypes, result) {
+    this.nodes = [];
+    this.targets = new Set(targets);
+    this.nodeTypes = new Set(nodeTypes);
+    this.result = result;
   }
 
-  return Plugin;
+  push(node, metadata) {
+    node._stylehacks = Object.assign({}, metadata, {
+      message: `Bad ${metadata.identifier}: ${metadata.hack}`,
+      browsers: this.targets,
+    });
+
+    this.nodes.push(node);
+  }
+
+  any(node) {
+    if (this.nodeTypes.has(node.type)) {
+      this.detect(node);
+
+      return !!node._stylehacks;
+    }
+
+    return false;
+  }
+
+  detectAndResolve(node) {
+    this.nodes = [];
+
+    this.detect(node);
+
+    return this.resolve();
+  }
+
+  detectAndWarn(node) {
+    this.nodes = [];
+
+    this.detect(node);
+
+    return this.warn();
+  }
+  // eslint-disable-next-line no-unused-vars
+  detect(node) {
+    throw new Error('You need to implement this method in a subclass.');
+  }
+
+  resolve() {
+    return this.nodes.forEach((node) => node.remove());
+  }
+
+  warn() {
+    return this.nodes.forEach((node) => {
+      const { message, browsers, identifier, hack } = node._stylehacks;
+
+      return node.warn(this.result, message, { browsers, identifier, hack });
+    });
+  }
 }

--- a/packages/stylehacks/src/plugins/bodyEmpty.js
+++ b/packages/stylehacks/src/plugins/bodyEmpty.js
@@ -1,33 +1,39 @@
 import parser from 'postcss-selector-parser';
 import exists from '../exists';
 import isMixin from '../isMixin';
-import plugin from '../plugin';
+import BasePlugin from '../plugin';
 import { FF_2 } from '../dictionary/browsers';
 import { SELECTOR } from '../dictionary/identifiers';
 import { RULE } from '../dictionary/postcss';
 import { BODY } from '../dictionary/tags';
 
-function analyse(ctx, rule) {
-  return (selectors) => {
-    selectors.each((selector) => {
-      if (
-        exists(selector, 0, BODY) &&
-        exists(selector, 1, ':empty') &&
-        exists(selector, 2, ' ') &&
-        selector.at(3)
-      ) {
-        ctx.push(rule, {
-          identifier: SELECTOR,
-          hack: selector.toString(),
-        });
-      }
-    });
-  };
-}
-
-export default plugin([FF_2], [RULE], function (rule) {
-  if (isMixin(rule)) {
-    return;
+export default class BodyEmpty extends BasePlugin {
+  constructor(result) {
+    super([FF_2], [RULE], result);
   }
-  parser(analyse(this, rule)).processSync(rule.selector);
-});
+
+  detect(rule) {
+    if (isMixin(rule)) {
+      return;
+    }
+    parser(this.analyse(rule)).processSync(rule.selector);
+  }
+
+  analyse(rule) {
+    return (selectors) => {
+      selectors.each((selector) => {
+        if (
+          exists(selector, 0, BODY) &&
+          exists(selector, 1, ':empty') &&
+          exists(selector, 2, ' ') &&
+          selector.at(3)
+        ) {
+          this.push(rule, {
+            identifier: SELECTOR,
+            hack: selector.toString(),
+          });
+        }
+      });
+    };
+  }
+}

--- a/packages/stylehacks/src/plugins/htmlCombinatorCommentBody.js
+++ b/packages/stylehacks/src/plugins/htmlCombinatorCommentBody.js
@@ -1,39 +1,45 @@
 import parser from 'postcss-selector-parser';
 import exists from '../exists';
 import isMixin from '../isMixin';
-import plugin from '../plugin';
+import BasePlugin from '../plugin';
 import { IE_5_5, IE_6, IE_7 } from '../dictionary/browsers';
 import { SELECTOR } from '../dictionary/identifiers';
 import { RULE } from '../dictionary/postcss';
 import { BODY, HTML } from '../dictionary/tags';
 
-function analyse(ctx, rule) {
-  return (selectors) => {
-    selectors.each((selector) => {
-      if (
-        exists(selector, 0, HTML) &&
-        (exists(selector, 1, '>') || exists(selector, 1, '~')) &&
-        selector.at(2) &&
-        selector.at(2).type === 'comment' &&
-        exists(selector, 3, ' ') &&
-        exists(selector, 4, BODY) &&
-        exists(selector, 5, ' ') &&
-        selector.at(6)
-      ) {
-        ctx.push(rule, {
-          identifier: SELECTOR,
-          hack: selector.toString(),
-        });
-      }
-    });
-  };
-}
+export default class HtmlCombinatorCommentBody extends BasePlugin {
+  constructor(result) {
+    super([IE_5_5, IE_6, IE_7], [RULE], result);
+  }
 
-export default plugin([IE_5_5, IE_6, IE_7], [RULE], function (rule) {
-  if (isMixin(rule)) {
-    return;
+  detect(rule) {
+    if (isMixin(rule)) {
+      return;
+    }
+    if (rule.raws.selector && rule.raws.selector.raw) {
+      parser(this.analyse(rule)).processSync(rule.raws.selector.raw);
+    }
   }
-  if (rule.raws.selector && rule.raws.selector.raw) {
-    parser(analyse(this, rule)).processSync(rule.raws.selector.raw);
+
+  analyse(rule) {
+    return (selectors) => {
+      selectors.each((selector) => {
+        if (
+          exists(selector, 0, HTML) &&
+          (exists(selector, 1, '>') || exists(selector, 1, '~')) &&
+          selector.at(2) &&
+          selector.at(2).type === 'comment' &&
+          exists(selector, 3, ' ') &&
+          exists(selector, 4, BODY) &&
+          exists(selector, 5, ' ') &&
+          selector.at(6)
+        ) {
+          this.push(rule, {
+            identifier: SELECTOR,
+            hack: selector.toString(),
+          });
+        }
+      });
+    };
   }
-});
+}

--- a/packages/stylehacks/src/plugins/htmlFirstChild.js
+++ b/packages/stylehacks/src/plugins/htmlFirstChild.js
@@ -1,33 +1,40 @@
 import parser from 'postcss-selector-parser';
 import exists from '../exists';
 import isMixin from '../isMixin';
-import plugin from '../plugin';
+import BasePlugin from '../plugin';
 import { OP_9 } from '../dictionary/browsers';
 import { SELECTOR } from '../dictionary/identifiers';
 import { RULE } from '../dictionary/postcss';
 import { HTML } from '../dictionary/tags';
 
-function analyse(ctx, rule) {
-  return (selectors) => {
-    selectors.each((selector) => {
-      if (
-        exists(selector, 0, HTML) &&
-        exists(selector, 1, ':first-child') &&
-        exists(selector, 2, ' ') &&
-        selector.at(3)
-      ) {
-        ctx.push(rule, {
-          identifier: SELECTOR,
-          hack: selector.toString(),
-        });
-      }
-    });
-  };
-}
-
-export default plugin([OP_9], [RULE], function (rule) {
-  if (isMixin(rule)) {
-    return;
+export default class HtmlFirstChild extends BasePlugin {
+  constructor(result) {
+    super([OP_9], [RULE], result);
   }
-  parser(analyse(this, rule)).processSync(rule.selector);
-});
+
+  detect(rule) {
+    if (isMixin(rule)) {
+      return;
+    }
+
+    parser(this.analyse(rule)).processSync(rule.selector);
+  }
+
+  analyse(rule) {
+    return (selectors) => {
+      selectors.each((selector) => {
+        if (
+          exists(selector, 0, HTML) &&
+          exists(selector, 1, ':first-child') &&
+          exists(selector, 2, ' ') &&
+          selector.at(3)
+        ) {
+          this.push(rule, {
+            identifier: SELECTOR,
+            hack: selector.toString(),
+          });
+        }
+      });
+    };
+  }
+}

--- a/packages/stylehacks/src/plugins/important.js
+++ b/packages/stylehacks/src/plugins/important.js
@@ -1,14 +1,20 @@
-import plugin from '../plugin';
+import BasePlugin from '../plugin';
 import { IE_5_5, IE_6, IE_7 } from '../dictionary/browsers';
 import { DECL } from '../dictionary/postcss';
 
-export default plugin([IE_5_5, IE_6, IE_7], [DECL], function (decl) {
-  const match = decl.value.match(/!\w/);
-  if (match) {
-    const hack = decl.value.substr(match.index, decl.value.length - 1);
-    this.push(decl, {
-      identifier: '!important',
-      hack,
-    });
+export default class Important extends BasePlugin {
+  constructor(result) {
+    super([IE_5_5, IE_6, IE_7], [DECL], result);
   }
-});
+
+  detect(decl) {
+    const match = decl.value.match(/!\w/);
+    if (match) {
+      const hack = decl.value.substr(match.index, decl.value.length - 1);
+      this.push(decl, {
+        identifier: '!important',
+        hack,
+      });
+    }
+  }
+}

--- a/packages/stylehacks/src/plugins/leadingStar.js
+++ b/packages/stylehacks/src/plugins/leadingStar.js
@@ -1,45 +1,51 @@
-import plugin from '../plugin';
+import BasePlugin from '../plugin';
 import { IE_5_5, IE_6, IE_7 } from '../dictionary/browsers';
 import { PROPERTY } from '../dictionary/identifiers';
 import { ATRULE, DECL } from '../dictionary/postcss';
 
 const hacks = '!_$_&_*_)_=_%_+_,_._/_`_]_#_~_?_:_|'.split('_');
 
-export default plugin([IE_5_5, IE_6, IE_7], [ATRULE, DECL], function (node) {
-  if (node.type === DECL) {
-    // some values are not picked up by before, so ensure they are
-    // at the beginning of the value
-    hacks.some((hack) => {
-      if (!node.prop.indexOf(hack)) {
-        this.push(node, {
-          identifier: PROPERTY,
-          hack: node.prop,
-        });
-        return true;
-      }
-    });
-    let { before } = node.raws;
-    if (!before) {
-      return;
-    }
-    hacks.some((hack) => {
-      if (before.includes(hack)) {
-        this.push(node, {
-          identifier: PROPERTY,
-          hack: `${before.trim()}${node.prop}`,
-        });
-        return true;
-      }
-    });
-  } else {
-    // test for the @property: value; hack
-    let { name } = node;
-    let len = name.length - 1;
-    if (name.lastIndexOf(':') === len) {
-      this.push(node, {
-        identifier: PROPERTY,
-        hack: `@${name.substr(0, len)}`,
+export default class LeadingStar extends BasePlugin {
+  constructor(result) {
+    super([IE_5_5, IE_6, IE_7], [ATRULE, DECL], result);
+  }
+
+  detect(node) {
+    if (node.type === DECL) {
+      // some values are not picked up by before, so ensure they are
+      // at the beginning of the value
+      hacks.some((hack) => {
+        if (!node.prop.indexOf(hack)) {
+          this.push(node, {
+            identifier: PROPERTY,
+            hack: node.prop,
+          });
+          return true;
+        }
       });
+      let { before } = node.raws;
+      if (!before) {
+        return;
+      }
+      hacks.some((hack) => {
+        if (before.includes(hack)) {
+          this.push(node, {
+            identifier: PROPERTY,
+            hack: `${before.trim()}${node.prop}`,
+          });
+          return true;
+        }
+      });
+    } else {
+      // test for the @property: value; hack
+      let { name } = node;
+      let len = name.length - 1;
+      if (name.lastIndexOf(':') === len) {
+        this.push(node, {
+          identifier: PROPERTY,
+          hack: `@${name.substr(0, len)}`,
+        });
+      }
     }
   }
-});
+}

--- a/packages/stylehacks/src/plugins/leadingUnderscore.js
+++ b/packages/stylehacks/src/plugins/leadingUnderscore.js
@@ -1,4 +1,4 @@
-import plugin from '../plugin';
+import BasePlugin from '../plugin';
 import { IE_6 } from '../dictionary/browsers';
 import { PROPERTY } from '../dictionary/identifiers';
 import { DECL } from '../dictionary/postcss';
@@ -11,24 +11,31 @@ function vendorPrefix(prop) {
 
   return '';
 }
-export default plugin([IE_6], [DECL], function (decl) {
-  const { before } = decl.raws;
 
-  if (before && before.includes('_')) {
-    this.push(decl, {
-      identifier: PROPERTY,
-      hack: `${before.trim()}${decl.prop}`,
-    });
+export default class LeadingUnderscore extends BasePlugin {
+  constructor(result) {
+    super([IE_6], [DECL], result);
   }
 
-  if (
-    decl.prop[0] === '-' &&
-    decl.prop[1] !== '-' &&
-    vendorPrefix(decl.prop) === ''
-  ) {
-    this.push(decl, {
-      identifier: PROPERTY,
-      hack: decl.prop,
-    });
+  detect(decl) {
+    const { before } = decl.raws;
+
+    if (before && before.includes('_')) {
+      this.push(decl, {
+        identifier: PROPERTY,
+        hack: `${before.trim()}${decl.prop}`,
+      });
+    }
+
+    if (
+      decl.prop[0] === '-' &&
+      decl.prop[1] !== '-' &&
+      vendorPrefix(decl.prop) === ''
+    ) {
+      this.push(decl, {
+        identifier: PROPERTY,
+        hack: decl.prop,
+      });
+    }
   }
-});
+}

--- a/packages/stylehacks/src/plugins/mediaSlash0.js
+++ b/packages/stylehacks/src/plugins/mediaSlash0.js
@@ -1,15 +1,21 @@
-import plugin from '../plugin';
+import BasePlugin from '../plugin';
 import { IE_8 } from '../dictionary/browsers';
 import { MEDIA_QUERY } from '../dictionary/identifiers';
 import { ATRULE } from '../dictionary/postcss';
 
-export default plugin([IE_8], [ATRULE], function (rule) {
-  const params = rule.params.trim();
-
-  if (params.toLowerCase() === '\\0screen') {
-    this.push(rule, {
-      identifier: MEDIA_QUERY,
-      hack: params,
-    });
+export default class MediaSlash0 extends BasePlugin {
+  constructor(result) {
+    super([IE_8], [ATRULE], result);
   }
-});
+
+  detect(rule) {
+    const params = rule.params.trim();
+
+    if (params.toLowerCase() === '\\0screen') {
+      this.push(rule, {
+        identifier: MEDIA_QUERY,
+        hack: params,
+      });
+    }
+  }
+}

--- a/packages/stylehacks/src/plugins/mediaSlash0Slash9.js
+++ b/packages/stylehacks/src/plugins/mediaSlash0Slash9.js
@@ -1,15 +1,21 @@
-import plugin from '../plugin';
+import BasePlugin from '../plugin';
 import { IE_5_5, IE_6, IE_7, IE_8 } from '../dictionary/browsers';
 import { MEDIA_QUERY } from '../dictionary/identifiers';
 import { ATRULE } from '../dictionary/postcss';
 
-export default plugin([IE_5_5, IE_6, IE_7, IE_8], [ATRULE], function (rule) {
-  const params = rule.params.trim();
-
-  if (params.toLowerCase() === '\\0screen\\,screen\\9') {
-    this.push(rule, {
-      identifier: MEDIA_QUERY,
-      hack: params,
-    });
+export default class MediaSlash0Slash9 extends BasePlugin {
+  constructor(result) {
+    super([IE_5_5, IE_6, IE_7, IE_8], [ATRULE], result);
   }
-});
+
+  detect(rule) {
+    const params = rule.params.trim();
+
+    if (params.toLowerCase() === '\\0screen\\,screen\\9') {
+      this.push(rule, {
+        identifier: MEDIA_QUERY,
+        hack: params,
+      });
+    }
+  }
+}

--- a/packages/stylehacks/src/plugins/mediaSlash9.js
+++ b/packages/stylehacks/src/plugins/mediaSlash9.js
@@ -1,15 +1,21 @@
-import plugin from '../plugin';
+import BasePlugin from '../plugin';
 import { IE_5_5, IE_6, IE_7 } from '../dictionary/browsers';
 import { MEDIA_QUERY } from '../dictionary/identifiers';
 import { ATRULE } from '../dictionary/postcss';
 
-export default plugin([IE_5_5, IE_6, IE_7], [ATRULE], function (rule) {
-  const params = rule.params.trim();
-
-  if (params.toLowerCase() === 'screen\\9') {
-    this.push(rule, {
-      identifier: MEDIA_QUERY,
-      hack: params,
-    });
+export default class MediaSlash9 extends BasePlugin {
+  constructor(result) {
+    super([IE_5_5, IE_6, IE_7], [ATRULE], result);
   }
-});
+
+  detect(rule) {
+    const params = rule.params.trim();
+
+    if (params.toLowerCase() === 'screen\\9') {
+      this.push(rule, {
+        identifier: MEDIA_QUERY,
+        hack: params,
+      });
+    }
+  }
+}

--- a/packages/stylehacks/src/plugins/slash9.js
+++ b/packages/stylehacks/src/plugins/slash9.js
@@ -1,14 +1,20 @@
-import plugin from '../plugin';
+import BasePlugin from '../plugin.js';
 import { IE_6, IE_7, IE_8 } from '../dictionary/browsers';
 import { VALUE } from '../dictionary/identifiers';
 import { DECL } from '../dictionary/postcss';
 
-export default plugin([IE_6, IE_7, IE_8], [DECL], function (decl) {
-  let v = decl.value;
-  if (v && v.length > 2 && v.indexOf('\\9') === v.length - 2) {
-    this.push(decl, {
-      identifier: VALUE,
-      hack: v,
-    });
+export default class Slash9 extends BasePlugin {
+  constructor(result) {
+    super([IE_6, IE_7, IE_8], [DECL], result);
   }
-});
+
+  detect(decl) {
+    let v = decl.value;
+    if (v && v.length > 2 && v.indexOf('\\9') === v.length - 2) {
+      this.push(decl, {
+        identifier: VALUE,
+        hack: v,
+      });
+    }
+  }
+}

--- a/packages/stylehacks/src/plugins/starHtml.js
+++ b/packages/stylehacks/src/plugins/starHtml.js
@@ -1,35 +1,40 @@
 import parser from 'postcss-selector-parser';
 import exists from '../exists';
 import isMixin from '../isMixin';
-import plugin from '../plugin';
+import BasePlugin from '../plugin';
 import { IE_5_5, IE_6 } from '../dictionary/browsers';
 import { SELECTOR } from '../dictionary/identifiers';
 import { RULE } from '../dictionary/postcss';
 import { HTML } from '../dictionary/tags';
 
-function analyse(ctx, rule) {
-  return (selectors) => {
-    selectors.each((selector) => {
-      if (
-        exists(selector, 0, '*') &&
-        exists(selector, 1, ' ') &&
-        exists(selector, 2, HTML) &&
-        exists(selector, 3, ' ') &&
-        selector.at(4)
-      ) {
-        ctx.push(rule, {
-          identifier: SELECTOR,
-          hack: selector.toString(),
-        });
-      }
-    });
-  };
-}
-
-export default plugin([IE_5_5, IE_6], [RULE], function (rule) {
-  if (isMixin(rule)) {
-    return;
+export default class StarHtml extends BasePlugin {
+  constructor(result) {
+    super([IE_5_5, IE_6], [RULE], result);
   }
 
-  parser(analyse(this, rule)).processSync(rule.selector);
-});
+  detect(rule) {
+    if (isMixin(rule)) {
+      return;
+    }
+    parser(this.analyse(rule)).processSync(rule.selector);
+  }
+
+  analyse(rule) {
+    return (selectors) => {
+      selectors.each((selector) => {
+        if (
+          exists(selector, 0, '*') &&
+          exists(selector, 1, ' ') &&
+          exists(selector, 2, HTML) &&
+          exists(selector, 3, ' ') &&
+          selector.at(4)
+        ) {
+          this.push(rule, {
+            identifier: SELECTOR,
+            hack: selector.toString(),
+          });
+        }
+      });
+    };
+  }
+}

--- a/packages/stylehacks/src/plugins/trailingSlashComma.js
+++ b/packages/stylehacks/src/plugins/trailingSlashComma.js
@@ -1,24 +1,30 @@
-import plugin from '../plugin';
+import BasePlugin from '../plugin';
 import isMixin from '../isMixin';
 import { IE_5_5, IE_6, IE_7 } from '../dictionary/browsers';
 import { SELECTOR } from '../dictionary/identifiers';
 import { RULE } from '../dictionary/postcss';
 
-export default plugin([IE_5_5, IE_6, IE_7], [RULE], function (rule) {
-  if (isMixin(rule)) {
-    return;
+export default class TrailingSlashComma extends BasePlugin {
+  constructor(result) {
+    super([IE_5_5, IE_6, IE_7], [RULE], result);
   }
 
-  const { selector } = rule;
-  const trim = selector.trim();
+  detect(rule) {
+    if (isMixin(rule)) {
+      return;
+    }
 
-  if (
-    trim.lastIndexOf(',') === selector.length - 1 ||
-    trim.lastIndexOf('\\') === selector.length - 1
-  ) {
-    this.push(rule, {
-      identifier: SELECTOR,
-      hack: selector,
-    });
+    const { selector } = rule;
+    const trim = selector.trim();
+
+    if (
+      trim.lastIndexOf(',') === selector.length - 1 ||
+      trim.lastIndexOf('\\') === selector.length - 1
+    ) {
+      this.push(rule, {
+        identifier: SELECTOR,
+        hack: selector,
+      });
+    }
   }
-});
+}


### PR DESCRIPTION
- replace the mix of closures and `.apply()` with `extends`
- replace rest parameters with single arguments because
  plugin methods are only called with one node as argument