### PR TITLE
refactor: conform to type signatures

### DIFF
--- a/packages/postcss-merge-longhand/src/lib/decl/columns.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/columns.js
@@ -60,10 +60,10 @@ function explode(rule) {
 
     values.forEach((value, i) => {
       let prop = properties[1];
-
+      const dimension = unit(value);
       if (value.toLowerCase() === auto) {
         prop = properties[i];
-      } else if (unit(value).unit) {
+      } else if (dimension && dimension.unit !== '') {
         prop = properties[0];
       }
 

--- a/packages/postcss-minify-gradients/src/isColorStop.js
+++ b/packages/postcss-minify-gradients/src/isColorStop.js
@@ -29,9 +29,8 @@ function isCSSLengthUnit(input) {
 }
 
 function isStop(str) {
-  let stop = !str;
-
-  if (!stop) {
+  if (str) {
+    let stop = false;
     const node = unit(str);
     if (node) {
       const number = Number(node.number);
@@ -41,8 +40,9 @@ function isStop(str) {
     } else {
       stop = /^calc\(\S+\)$/g.test(str);
     }
+    return stop;
   }
-  return stop;
+  return true;
 }
 
 export default function isColorStop(color, stop) {

--- a/packages/postcss-svgo/src/index.js
+++ b/packages/postcss-svgo/src/index.js
@@ -52,7 +52,7 @@ function minifySVG(input, opts) {
 function minify(decl, opts, postcssResult) {
   const parsed = valueParser(decl.value);
 
-  decl.value = parsed.walk((node) => {
+  const minified = parsed.walk((node) => {
     if (
       node.type !== 'function' ||
       node.value.toLowerCase() !== 'url' ||
@@ -103,7 +103,7 @@ function minify(decl, opts, postcssResult) {
     return false;
   });
 
-  decl.value = decl.value.toString();
+  decl.value = minified.toString();
 }
 
 function pluginCreator(opts = {}) {

--- a/packages/postcss-unique-selectors/src/index.js
+++ b/packages/postcss-unique-selectors/src/index.js
@@ -23,7 +23,7 @@ function pluginCreator() {
               sel.remove();
               return;
             } else {
-              return sel;
+              return;
             }
           });
         });


### PR DESCRIPTION
 - selector parser callback is not expected to return a node
 - unit() returns false if it cannot parse
 - don't assign an array of nodes to a string