### PR TITLE
docs: downgrade css-declaration-sorter in playground

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -25,6 +25,9 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
+  "pnpm": {
+    "overrides": {"css-declaration-sorter": "6.1.3" }
+  },
   "devDependencies": {
     "mdast-util-heading-range": "^3.1.0",
     "remark": "^14.0.2",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -1,5 +1,8 @@
 lockfileVersion: 5.3
 
+overrides:
+  css-declaration-sorter: 6.1.3
+
 importers:
 
   .:
@@ -3947,8 +3950,8 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /css-declaration-sorter/6.1.4_postcss@8.4.5:
-    resolution: {integrity: sha512-lpfkqS0fctcmZotJGhnxkIyJWvBXgpyi2wsFd4J8VB7wzyrT6Ch/3Q+FMNJpjK4gu1+GN5khOnpU2ZVKrLbhCw==}
+  /css-declaration-sorter/6.1.3_postcss@8.4.5:
+    resolution: {integrity: sha512-SvjQjNRZgh4ULK1LDJ2AduPKUKxIqmtU7ZAyi47BTV+M90Qvxr9AB6lKlLbDUfXqI9IQeYA8LbAsCZPpJEV3aA==}
     engines: {node: '>= 10'}
     peerDependencies:
       postcss: ^8.0.9
@@ -4068,7 +4071,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      css-declaration-sorter: 6.1.4_postcss@8.4.5
+      css-declaration-sorter: 6.1.3_postcss@8.4.5
       cssnano-utils: 3.0.1_postcss@8.4.5
       postcss: 8.4.5
       postcss-calc: 8.2.2_postcss@8.4.5


### PR DESCRIPTION
Fix #1311

Somehow the last patch release does not run when bundled with webpack.

cc @Siilwyn 