### PR TITLE
refactor: replace bad types

### DIFF
--- a/packages/postcss-ordered-values/src/lib/getValue.js
+++ b/packages/postcss-ordered-values/src/lib/getValue.js
@@ -5,9 +5,7 @@ import { stringify } from 'postcss-value-parser';
  * @return {string}
  */
 export default function getValue(values) {
-  return stringify({
-    nodes: flatten(values),
-  });
+  return stringify(flatten(values));
 }
 /**
  * @param {import('postcss-value-parser').Node[][]} values

--- a/packages/stylehacks/src/plugins/leadingStar.js
+++ b/packages/stylehacks/src/plugins/leadingStar.js
@@ -14,26 +14,24 @@ export default class LeadingStar extends BasePlugin {
     if (node.type === DECL) {
       // some values are not picked up by before, so ensure they are
       // at the beginning of the value
-      hacks.some((hack) => {
+      hacks.forEach((hack) => {
         if (!node.prop.indexOf(hack)) {
           this.push(node, {
             identifier: PROPERTY,
             hack: node.prop,
           });
-          return true;
         }
       });
       let { before } = node.raws;
       if (!before) {
         return;
       }
-      hacks.some((hack) => {
+      hacks.forEach((hack) => {
         if (before.includes(hack)) {
           this.push(node, {
             identifier: PROPERTY,
             hack: `${before.trim()}${node.prop}`,
           });
-          return true;
         }
       });
     } else {


### PR DESCRIPTION
- replace some with forEach when return value is ignored
- pass a Node array instead of a fake Node to stringify