### PR TITLE
chore(postcss-merge-longhand): fix stylehacks import

### DIFF
--- a/packages/postcss-merge-longhand/src/lib/decl/borders.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/borders.js
@@ -1,5 +1,5 @@
 import { list } from 'postcss';
-import { detect } from 'stylehacks';
+import stylehacks from 'stylehacks';
 import insertCloned from '../insertCloned';
 import parseTrbl from '../parseTrbl';
 import hasAllProps from '../hasAllProps';
@@ -81,7 +81,7 @@ function mergeRedundant({ values, nextValues, decl, nextDecl, index }) {
     return;
   }
 
-  if (detect(decl) || detect(nextDecl)) {
+  if (stylehacks.detect(decl) || stylehacks.detect(nextDecl)) {
     return;
   }
 
@@ -149,7 +149,7 @@ function explode(rule) {
       return;
     }
 
-    if (detect(decl)) {
+    if (stylehacks.detect(decl)) {
       return;
     }
 
@@ -209,7 +209,7 @@ function merge(rule) {
       rule,
       wsc.map((style) => borderProperty(direction, style)),
       (rules, lastNode) => {
-        if (canMerge(rules, false) && !rules.some(detect)) {
+        if (canMerge(rules, false) && !rules.some(stylehacks.detect)) {
           insertCloned(lastNode.parent, lastNode, {
             prop,
             value: rules.map(getValue).join(' '),
@@ -231,7 +231,7 @@ function merge(rule) {
       rule,
       trbl.map((direction) => borderProperty(direction, style)),
       (rules, lastNode) => {
-        if (canMerge(rules) && !rules.some(detect)) {
+        if (canMerge(rules) && !rules.some(stylehacks.detect)) {
           insertCloned(lastNode.parent, lastNode, {
             prop,
             value: minifyTrbl(rules.map(getValue).join(' ')),
@@ -247,7 +247,7 @@ function merge(rule) {
 
   // border-trbl -> border-wsc
   mergeRules(rule, directions, (rules, lastNode) => {
-    if (rules.some(detect)) {
+    if (rules.some(stylehacks.detect)) {
       return;
     }
 
@@ -285,7 +285,7 @@ function merge(rule) {
   // border-wsc -> border + border-color
   // border-wsc -> border + border-dir
   mergeRules(rule, properties, (rules, lastNode) => {
-    if (rules.some(detect)) {
+    if (rules.some(stylehacks.detect)) {
       return;
     }
 
@@ -343,7 +343,7 @@ function merge(rule) {
 
   // border-wsc -> border + border-trbl
   mergeRules(rule, properties, (rules, lastNode) => {
-    if (rules.some(detect)) {
+    if (rules.some(stylehacks.detect)) {
       return;
     }
 
@@ -392,7 +392,7 @@ function merge(rule) {
   // border-trbl -> border
   // border-trbl -> border + border-trbl
   mergeRules(rule, directions, (rules, lastNode) => {
-    if (rules.some(detect)) {
+    if (rules.some(stylehacks.detect)) {
       return;
     }
 
@@ -464,7 +464,7 @@ function merge(rule) {
 
         values[i] = wscProp.value;
 
-        if (canMerge(rules, false) && !rules.some(detect)) {
+        if (canMerge(rules, false) && !rules.some(stylehacks.detect)) {
           insertCloned(lastNode.parent, lastNode, {
             prop,
             value: wscValue,
@@ -503,7 +503,7 @@ function merge(rule) {
 
       values[i] = wscProp.value;
 
-      if (canMerge(rules, false) && !rules.some(detect)) {
+      if (canMerge(rules, false) && !rules.some(stylehacks.detect)) {
         insertCloned(lastNode.parent, lastNode, {
           prop,
           value: wscValue,
@@ -543,7 +543,7 @@ function merge(rule) {
       );
       const rules = getRules(props, names);
 
-      if (hasAllProps(rules, ...names) && !rules.some(detect)) {
+      if (hasAllProps(rules, ...names) && !rules.some(stylehacks.detect)) {
         const values = rules.map((node) => (node ? node.value : null));
         const filteredValues = values.filter(Boolean);
         const lastNodeValue = list.space(lastNode.value)[i];
@@ -687,8 +687,8 @@ function merge(rule) {
     // remove properties of lower precedence
     const lesser = decls.filter(
       (node) =>
-        !detect(lastNode) &&
-        !detect(node) &&
+        !stylehacks.detect(lastNode) &&
+        !stylehacks.detect(node) &&
         !isCustomProp(lastNode) &&
         node !== lastNode &&
         node.important === lastNode.important &&
@@ -703,8 +703,8 @@ function merge(rule) {
     // get duplicate properties
     let duplicates = decls.filter(
       (node) =>
-        !detect(lastNode) &&
-        !detect(node) &&
+        !stylehacks.detect(lastNode) &&
+        !stylehacks.detect(node) &&
         node !== lastNode &&
         node.important === lastNode.important &&
         node.prop === lastNode.prop &&

--- a/packages/postcss-merge-longhand/src/lib/decl/boxBase.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/boxBase.js
@@ -1,4 +1,4 @@
-import { detect } from 'stylehacks';
+import stylehacks from 'stylehacks';
 import canMerge from '../canMerge';
 import getDecls from '../getDecls';
 import minifyTrbl from '../minifyTrbl';
@@ -23,8 +23,8 @@ export default (prop) => {
       // remove properties of lower precedence
       const lesser = decls.filter(
         (node) =>
-          !detect(lastNode) &&
-          !detect(node) &&
+          !stylehacks.detect(lastNode) &&
+          !stylehacks.detect(node) &&
           node !== lastNode &&
           node.important === lastNode.important &&
           lastNode.prop === prop &&
@@ -37,8 +37,8 @@ export default (prop) => {
       // get duplicate properties
       let duplicates = decls.filter(
         (node) =>
-          !detect(lastNode) &&
-          !detect(node) &&
+          !stylehacks.detect(lastNode) &&
+          !stylehacks.detect(node) &&
           node !== lastNode &&
           node.important === lastNode.important &&
           node.prop === lastNode.prop &&
@@ -59,7 +59,7 @@ export default (prop) => {
           return;
         }
 
-        if (detect(decl)) {
+        if (stylehacks.detect(decl)) {
           return;
         }
 
@@ -77,7 +77,7 @@ export default (prop) => {
     },
     merge: (rule) => {
       mergeRules(rule, properties, (rules, lastNode) => {
-        if (canMerge(rules) && !rules.some(detect)) {
+        if (canMerge(rules) && !rules.some(stylehacks.detect)) {
           insertCloned(lastNode.parent, lastNode, {
             prop,
             value: minifyTrbl(mergeValues(...rules)),

--- a/packages/postcss-merge-longhand/src/lib/decl/columns.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/columns.js
@@ -1,6 +1,6 @@
 import { list } from 'postcss';
 import { unit } from 'postcss-value-parser';
-import { detect } from 'stylehacks';
+import stylehacks from 'stylehacks';
 import canMerge from '../canMerge';
 import getDecls from '../getDecls';
 import getValue from '../getValue';
@@ -48,7 +48,7 @@ function explode(rule) {
       return;
     }
 
-    if (detect(decl)) {
+    if (stylehacks.detect(decl)) {
       return;
     }
 
@@ -86,8 +86,8 @@ function cleanup(rule) {
     // remove properties of lower precedence
     const lesser = decls.filter(
       (node) =>
-        !detect(lastNode) &&
-        !detect(node) &&
+        !stylehacks.detect(lastNode) &&
+        !stylehacks.detect(node) &&
         node !== lastNode &&
         node.important === lastNode.important &&
         lastNode.prop === 'columns' &&
@@ -100,8 +100,8 @@ function cleanup(rule) {
     // get duplicate properties
     let duplicates = decls.filter(
       (node) =>
-        !detect(lastNode) &&
-        !detect(node) &&
+        !stylehacks.detect(lastNode) &&
+        !stylehacks.detect(node) &&
         node !== lastNode &&
         node.important === lastNode.important &&
         node.prop === lastNode.prop &&
@@ -117,7 +117,7 @@ function cleanup(rule) {
 
 function merge(rule) {
   mergeRules(rule, properties, (rules, lastNode) => {
-    if (canMerge(rules) && !rules.some(detect)) {
+    if (canMerge(rules) && !rules.some(stylehacks.detect)) {
       insertCloned(lastNode.parent, lastNode, {
         prop: 'columns',
         value: normalize(rules.map(getValue)),


### PR DESCRIPTION
There is no named export from the stylehacks package, so the named import
only works when both all packages are transpiled to CJS.