### PR TITLE
test(css-size): fix cli path

### DIFF
--- a/packages/css-size/src/__tests__/index.js
+++ b/packages/css-size/src/__tests__/index.js
@@ -14,7 +14,7 @@ function setup(args) {
 
     let ps = spawn(
       process.execPath,
-      [path.resolve(__dirname, '../src/cli.js')].concat(args)
+      [path.resolve(__dirname, '../cli.js')].concat(args)
     );
 
     let out = '';


### PR DESCRIPTION
After moving from dist to src, the path to the 'cli' file was not adjusted properly in the test.
I find a bit discomforting that the tests were exiting without result instead of failing.