### PR TITLE
chore: lint code to check old Node.js compatibility

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 2021
+    "ecmaVersion": 2018
   },
   "extends": [
     "eslint:recommended",
@@ -8,8 +8,7 @@
   ],
   "env": {
     "node": true,
-    "es2021": true,
-    "jest": true
+    "es2017": true
   },
   "rules": {
     "curly": "error",
@@ -37,7 +36,8 @@
     {
       "files": ["*.mjs"],
       "parserOptions": {
-        "sourceType": "module"
+        "sourceType": "module",
+        "ecmaVersion": 2021
       }
     }
   ]


### PR DESCRIPTION
Since we're still targeting Node.js 10, set the language level
to a compatible version, except for modules we don not publish.
Also remove the Jest environment.