### PR TITLE
chore: fix license of of Mozilla data

### DIFF
--- a/packages/postcss-reduce-initial/README.md
+++ b/packages/postcss-reduce-initial/README.md
@@ -85,10 +85,7 @@ See [CONTRIBUTORS.md](https://github.com/cssnano/cssnano/blob/master/CONTRIBUTOR
 
 ## License
 
-[Template:CSSData] by Mozilla Contributors is licensed under [CC-BY-SA 2.5].
-
-[template:cssdata]: https://developer.mozilla.org/en-US/docs/Template:CSSData
-[cc-by-sa 2.5]: http://creativecommons.org/licenses/by-sa/2.5/
+This program uses a list of CSS properties derived from data maintained my the MDN team at Mozilla and licensed under the [CC0 1.0 Universal Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 
 MIT © [Ben Briggs](http://beneb.info)
 


### PR DESCRIPTION
They switched to Creatice Commons Zero in 2018 https://github.com/mdn/data/blob/main/LICENSE

I cannot find that the CSSDATA template mentioned in the original README
is used anywhere in the code right now and the template does not exist
on MDN any more either.