### PR TITLE
chore: replace do-while and other refactors to simplify types

### DIFF
--- a/packages/postcss-discard-overridden/src/index.js
+++ b/packages/postcss-discard-overridden/src/index.js
@@ -19,12 +19,12 @@ function getScope(node) {
 
   const chain = [node.name.toLowerCase(), node.params];
 
-  do {
+  while (current) {
     if (current.type === 'atrule' && isScope(current.name)) {
       chain.unshift(current.name + ' ' + current.params);
     }
     current = current.parent;
-  } while (current);
+  }
 
   return chain.join('|');
 }

--- a/packages/postcss-merge-longhand/src/lib/decl/borders.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/borders.js
@@ -54,7 +54,7 @@ function getLevel(prop) {
 }
 
 const isValueCustomProp = (value) =>
-  value && value.search(/var\s*\(\s*--/i) !== -1;
+  value !== undefined && value.search(/var\s*\(\s*--/i) !== -1;
 
 function canMergeValues(values) {
   return !values.some(isValueCustomProp);
@@ -160,7 +160,7 @@ function explode(rule) {
           insertCloned(decl.parent, decl, { prop: direction });
         });
 
-        return decl.remove();
+        decl.remove();
       }
     }
 
@@ -176,7 +176,7 @@ function explode(rule) {
           });
         });
 
-        return decl.remove();
+        decl.remove();
       }
     }
 
@@ -339,6 +339,7 @@ function merge(rule) {
 
       return true;
     }
+    return false;
   });
 
   // border-wsc -> border + border-trbl
@@ -437,6 +438,7 @@ function merge(rule) {
 
       return true;
     }
+    return false;
   });
 
   // border-trbl-wsc + border-trbl (custom prop) -> border-trbl + border-trbl-wsc (custom prop)
@@ -476,6 +478,7 @@ function merge(rule) {
 
           return true;
         }
+        return false;
       });
     });
   });

--- a/packages/postcss-merge-longhand/src/lib/decl/columns.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/columns.js
@@ -128,6 +128,7 @@ function merge(rule) {
 
       return true;
     }
+    return false;
   });
 
   cleanup(rule);

--- a/packages/postcss-minify-font-values/src/lib/minify-family.js
+++ b/packages/postcss-minify-font-values/src/lib/minify-family.js
@@ -33,9 +33,9 @@ const regexSimpleEscapeCharacters = /[ !"#$%&'()*+,.\/;<=>?@\[\\\]^`{|}~]/;
 
 function escape(string, escapeForString) {
   let counter = 0;
-  let character = null;
-  let charCode = null;
-  let value = null;
+  let character;
+  let charCode;
+  let value;
   let output = '';
 
   while (counter < string.length) {

--- a/packages/postcss-minify-gradients/src/index.js
+++ b/packages/postcss-minify-gradients/src/index.js
@@ -58,7 +58,7 @@ function optimise(decl) {
           node.nodes[0].value = angles[node.nodes[0].value.toLowerCase()];
         }
 
-        let lastStop = null;
+        let lastStop;
 
         args.forEach((arg, index) => {
           if (arg.length !== 3) {
@@ -68,7 +68,7 @@ function optimise(decl) {
           let isFinalStop = index === args.length - 1;
           let thisStop = valueParser.unit(arg[2].value);
 
-          if (lastStop === null) {
+          if (lastStop === undefined) {
             lastStop = thisStop;
 
             if (

--- a/packages/postcss-normalize-url/src/index.js
+++ b/packages/postcss-normalize-url/src/index.js
@@ -27,7 +27,7 @@ function isAbsolute(url) {
 
 function convert(url, options) {
   if (isAbsolute(url) || url.startsWith('//')) {
-    let normalizedURL = null;
+    let normalizedURL;
 
     try {
       normalizedURL = normalize(url, options);

--- a/packages/stylehacks/src/plugins/leadingStar.js
+++ b/packages/stylehacks/src/plugins/leadingStar.js
@@ -23,7 +23,7 @@ module.exports = class LeadingStar extends BasePlugin {
           });
         }
       });
-      let { before } = node.raws;
+      const { before } = node.raws;
       if (!before) {
         return;
       }
@@ -37,8 +37,8 @@ module.exports = class LeadingStar extends BasePlugin {
       });
     } else {
       // test for the @property: value; hack
-      let { name } = node;
-      let len = name.length - 1;
+      const { name } = node;
+      const len = name.length - 1;
       if (name.lastIndexOf(':') === len) {
         this.push(node, {
           identifier: PROPERTY,


### PR DESCRIPTION
chore: replace do-while with while

The first loop execution would crash if the while condition was false.

chore: fix bollean return type

chore: remove redundant null initializations

chore: make variables const

chore: correct return types