### PR TITLE
chore: fix some type issues in the advanced presets plugins

### DIFF
--- a/packages/postcss-merge-idents/src/index.js
+++ b/packages/postcss-merge-idents/src/index.js
@@ -22,14 +22,32 @@ function canonical(obj) {
     return key;
   };
 }
-
-function mergeAtRules(css, pairs) {
-  pairs.forEach((pair) => {
-    pair.cache = [];
-    pair.replacements = [];
-    pair.decls = [];
-    pair.removals = [];
-  });
+/**
+ * @param {import('postcss').Root} css
+ * @return {void}
+ */
+function mergeAtRules(css) {
+  const pairs = [
+    {
+      atrule: /keyframes/i,
+      decl: /animation/i,
+      /** @type {import('postcss').AtRule[]} */
+      cache: [],
+      replacements: {},
+      /** @type {import('postcss').Declaration[]} */
+      decls: [],
+      /** @type {import('postcss').AtRule[]} */
+      removals: [],
+    },
+    {
+      atrule: /counter-style/i,
+      decl: /(list-style|system)/i,
+      cache: [],
+      replacements: {},
+      decls: [],
+      removals: [],
+    },
+  ];
 
   let relevant;
 
@@ -100,16 +118,7 @@ function pluginCreator() {
     postcssPlugin: 'postcss-merge-idents',
 
     OnceExit(css) {
-      mergeAtRules(css, [
-        {
-          atrule: /keyframes/i,
-          decl: /animation/i,
-        },
-        {
-          atrule: /counter-style/i,
-          decl: /(list-style|system)/i,
-        },
-      ]);
+      mergeAtRules(css);
     },
   };
 }

--- a/packages/postcss-reduce-idents/src/lib/counter-style.js
+++ b/packages/postcss-reduce-idents/src/lib/counter-style.js
@@ -2,7 +2,7 @@
 const valueParser = require('postcss-value-parser');
 const addToCache = require('./cache');
 
-const RESERVED_KEYWORDS = [
+const RESERVED_KEYWORDS = new Set([
   'unset',
   'initial',
   'inherit',
@@ -64,7 +64,7 @@ const RESERVED_KEYWORDS = [
   'upper-armenian',
   'disclosure-open',
   'disclosure-close',
-];
+]);
 
 module.exports = function () {
   let cache = {};
@@ -78,7 +78,7 @@ module.exports = function () {
       if (
         type === 'atrule' &&
         /counter-style/i.test(node.name) &&
-        RESERVED_KEYWORDS.indexOf(node.params.toLowerCase()) === -1
+        !RESERVED_KEYWORDS.has(node.params.toLowerCase())
       ) {
         addToCache(node.params, encoder, cache);
 

--- a/packages/postcss-reduce-idents/src/lib/counter-style.js
+++ b/packages/postcss-reduce-idents/src/lib/counter-style.js
@@ -73,11 +73,11 @@ module.exports = function () {
 
   return {
     collect(node, encoder) {
-      const { name, prop, type } = node;
+      const { type } = node;
 
       if (
         type === 'atrule' &&
-        /counter-style/i.test(name) &&
+        /counter-style/i.test(node.name) &&
         RESERVED_KEYWORDS.indexOf(node.params.toLowerCase()) === -1
       ) {
         addToCache(node.params, encoder, cache);
@@ -85,7 +85,7 @@ module.exports = function () {
         atRules.push(node);
       }
 
-      if (type === 'decl' && /(list-style|system)/i.test(prop)) {
+      if (type === 'decl' && /(list-style|system)/i.test(node.prop)) {
         decls.push(node);
       }
     },

--- a/packages/postcss-reduce-idents/src/lib/counter.js
+++ b/packages/postcss-reduce-idents/src/lib/counter.js
@@ -12,11 +12,12 @@ module.exports = function () {
 
   return {
     collect(node, encoder) {
-      const { prop, type } = node;
+      const { type } = node;
 
       if (type !== 'decl') {
         return;
       }
+      const { prop } = node;
 
       if (/counter-(reset|increment)/i.test(prop)) {
         node.value = valueParser(node.value).walk((child) => {

--- a/packages/postcss-reduce-idents/src/lib/counter.js
+++ b/packages/postcss-reduce-idents/src/lib/counter.js
@@ -3,7 +3,7 @@ const valueParser = require('postcss-value-parser');
 const addToCache = require('./cache');
 const isNum = require('./isNum');
 
-const RESERVED_KEYWORDS = ['unset', 'initial', 'inherit', 'none'];
+const RESERVED_KEYWORDS = new Set(['unset', 'initial', 'inherit', 'none']);
 
 module.exports = function () {
   let cache = {};
@@ -24,7 +24,7 @@ module.exports = function () {
           if (
             child.type === 'word' &&
             !isNum(child) &&
-            RESERVED_KEYWORDS.indexOf(child.value.toLowerCase()) === -1
+            !RESERVED_KEYWORDS.has(child.value.toLowerCase())
           ) {
             addToCache(child.value, encoder, cache);
 

--- a/packages/postcss-reduce-idents/src/lib/grid-template.js
+++ b/packages/postcss-reduce-idents/src/lib/grid-template.js
@@ -3,7 +3,13 @@ const valueParser = require('postcss-value-parser');
 const addToCache = require('./cache');
 const isNum = require('./isNum');
 
-const RESERVED_KEYWORDS = ['auto', 'span', 'inherit', 'initial', 'unset'];
+const RESERVED_KEYWORDS = new Set([
+  'auto',
+  'span',
+  'inherit',
+  'initial',
+  'unset',
+]);
 
 module.exports = function () {
   let cache = {};
@@ -22,10 +28,7 @@ module.exports = function () {
               if (/\.+/.test(word)) {
                 // reduce empty zones to a single `.`
                 node.value = node.value.replace(word, '.');
-              } else if (
-                word &&
-                RESERVED_KEYWORDS.indexOf(word.toLowerCase()) === -1
-              ) {
+              } else if (word && !RESERVED_KEYWORDS.has(word.toLowerCase())) {
                 addToCache(word, encoder, cache);
               }
             });
@@ -35,10 +38,7 @@ module.exports = function () {
         declCache.push(node);
       } else if (node.prop.toLowerCase() === 'grid-area') {
         valueParser(node.value).walk((child) => {
-          if (
-            child.type === 'word' &&
-            RESERVED_KEYWORDS.indexOf(child.value) === -1
-          ) {
+          if (child.type === 'word' && !RESERVED_KEYWORDS.has(child.value)) {
             addToCache(child.value, encoder, cache);
           }
         });

--- a/packages/postcss-reduce-idents/src/lib/keyframes.js
+++ b/packages/postcss-reduce-idents/src/lib/keyframes.js
@@ -2,7 +2,7 @@
 const valueParser = require('postcss-value-parser');
 const addToCache = require('./cache');
 
-const RESERVED_KEYWORDS = ['none', 'inherit', 'initial', 'unset'];
+const RESERVED_KEYWORDS = new Set(['none', 'inherit', 'initial', 'unset']);
 
 module.exports = function () {
   let cache = {};
@@ -16,7 +16,7 @@ module.exports = function () {
       if (
         type === 'atrule' &&
         /keyframes/i.test(node.name) &&
-        RESERVED_KEYWORDS.indexOf(node.params.toLowerCase()) === -1
+        !RESERVED_KEYWORDS.has(node.params.toLowerCase())
       ) {
         addToCache(node.params, encoder, cache);
         atRules.push(node);

--- a/packages/postcss-reduce-idents/src/lib/keyframes.js
+++ b/packages/postcss-reduce-idents/src/lib/keyframes.js
@@ -11,18 +11,18 @@ module.exports = function () {
 
   return {
     collect(node, encoder) {
-      const { name, prop, type } = node;
+      const { type } = node;
 
       if (
         type === 'atrule' &&
-        /keyframes/i.test(name) &&
+        /keyframes/i.test(node.name) &&
         RESERVED_KEYWORDS.indexOf(node.params.toLowerCase()) === -1
       ) {
         addToCache(node.params, encoder, cache);
         atRules.push(node);
       }
 
-      if (type === 'decl' && /animation/i.test(prop)) {
+      if (type === 'decl' && /animation/i.test(node.prop)) {
         decls.push(node);
       }
     },

--- a/packages/stylehacks/src/plugins/important.js
+++ b/packages/stylehacks/src/plugins/important.js
@@ -10,7 +10,7 @@ module.exports = class Important extends BasePlugin {
 
   detect(decl) {
     const match = decl.value.match(/!\w/);
-    if (match) {
+    if (match && match.index) {
       const hack = decl.value.substr(match.index, decl.value.length - 1);
       this.push(decl, {
         identifier: '!important',


### PR DESCRIPTION
-  chore(postcs-reduce-idents): replace array with Set
-  chore(postcss-reduce-idents): don't access node properties before narrowing node type
-  chore(postcss-merge-idents): turn parameter into constant
-  fix(stylehacks): check if match index exists

