### PR TITLE
fix: fix TypeScript error when importing lite and advanced presets

### DIFF
--- a/packages/cssnano-preset-advanced/src/index.js
+++ b/packages/cssnano-preset-advanced/src/index.js
@@ -22,7 +22,7 @@ const defaultOpts = {
   },
 };
 
-module.exports = function advancedPreset(opts = {}) {
+function advancedPreset(opts = {}) {
   const options = Object.assign({}, defaultOpts, opts);
 
   /** @type {[import('postcss').PluginCreator<any>, boolean | Record<string, any> | undefined][]} */
@@ -36,4 +36,6 @@ module.exports = function advancedPreset(opts = {}) {
   ];
 
   return { plugins };
-};
+}
+
+module.exports = advancedPreset;

--- a/packages/cssnano-preset-advanced/types/index.d.ts
+++ b/packages/cssnano-preset-advanced/types/index.d.ts
@@ -1,8 +1,11 @@
-declare function _exports(opts?: {}): {
+export = advancedPreset;
+declare function advancedPreset(opts?: {}): {
     plugins: [import("postcss").PluginCreator<any>, boolean | Record<string, any> | undefined][];
 };
-export = _exports;
-export type AdvancedOptions = {
+declare namespace advancedPreset {
+    export { AdvancedOptions, Options };
+}
+type AdvancedOptions = {
     autoprefixer?: autoprefixer.Options;
     discardUnused?: false | import('postcss-discard-unused').Options & {
         exclude?: true;
@@ -17,5 +20,5 @@ export type AdvancedOptions = {
         exclude?: true;
     };
 };
-export type Options = import('cssnano-preset-default').Options & AdvancedOptions;
+type Options = import('cssnano-preset-default').Options & AdvancedOptions;
 import autoprefixer = require("autoprefixer");

--- a/packages/cssnano-preset-lite/src/index.js
+++ b/packages/cssnano-preset-lite/src/index.js
@@ -15,7 +15,7 @@ const defaultOpts = {};
  * @param {Options} opts
  * @return {{plugins: [import('postcss').PluginCreator<any>, false | Record<string, any> | undefined][]}}
  */
-module.exports = function defaultPreset(opts = {}) {
+function defaultPreset(opts = {}) {
   const options = Object.assign({}, defaultOpts, opts);
   /** @type {[import('postcss').PluginCreator<any>, false | Record<string, any> | undefined][]} **/
   const plugins = [
@@ -26,4 +26,6 @@ module.exports = function defaultPreset(opts = {}) {
   ];
 
   return { plugins };
-};
+}
+
+module.exports = defaultPreset;

--- a/packages/cssnano-preset-lite/types/index.d.ts
+++ b/packages/cssnano-preset-lite/types/index.d.ts
@@ -1,16 +1,23 @@
-declare function _exports(opts?: Options): {
+export = defaultPreset;
+/**
+ * @param {Options} opts
+ * @return {{plugins: [import('postcss').PluginCreator<any>, false | Record<string, any> | undefined][]}}
+ */
+declare function defaultPreset(opts?: Options): {
     plugins: [import('postcss').PluginCreator<any>, false | Record<string, any> | undefined][];
 };
-export = _exports;
-export type SimpleOptions = false | {
-    exclude?: true;
-};
-export type Options = {
+declare namespace defaultPreset {
+    export { SimpleOptions, Options };
+}
+type Options = {
     discardComments?: false | import('postcss-discard-comments').Options & {
         exclude?: true;
     };
     normalizeWhitespace?: SimpleOptions;
     discardEmpty?: SimpleOptions;
     rawCache?: SimpleOptions;
+};
+type SimpleOptions = false | {
+    exclude?: true;
 };
 import { rawCache } from "cssnano-utils";


### PR DESCRIPTION
Declare the function before assigning it to an export to fix
`An export assignment cannot be used in a module with other exported elements`