### PR TITLE
Publish preset TypeScript fixes

### DIFF
--- a/packages/cssnano-preset-advanced/CHANGELOG.md
+++ b/packages/cssnano-preset-advanced/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.2.1
+
+### Patch Changes
+
+- fix: improve type declarations
+
 ## 5.2.0
 
 ### Minor Changes

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-advanced",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "main": "src/index.js",
   "types": "types/index.d.ts",
   "description": "Advanced optimisations for cssnano; may or may not break your CSS!",

--- a/packages/cssnano-preset-lite/CHANGELOG.md
+++ b/packages/cssnano-preset-lite/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.1.1
+
+### Patch Changes
+
+- fix: improve type declarations
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/cssnano-preset-lite/package.json
+++ b/packages/cssnano-preset-lite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cssnano-preset-lite",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "main": "src/index.js",
     "types": "types/index.d.ts",
     "description": "Safe and minimum transformation",


### PR DESCRIPTION
cssano-preset-lite and cssnano-preset-advanced are not cssnano dependencies so I don't think it makes sense to bump cssnano too. 