### PR TITLE
chore: disable most permissions for the CI job runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: git config --global core.autocrlf input
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2.2.1
@@ -71,7 +71,7 @@ jobs:
           version: 6.32.2
 
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3.0.0
         if: matrix.node-version != '10'
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: test
+permissions: {}
 
 on:
   push:


### PR DESCRIPTION
The jobs complete fine without any extra permission, so we can improve security by disabling them (as the [Open Source Security Foundation scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) recommends). Someone with administrative access can also change the default permissions for all workflows in the repository, in that case the individual workflows need to opt-in. Also see the [GitHub docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions).