### PR TITLE
chore: update prettier config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   },
   "extends": [
     "eslint:recommended",
-    "plugin:prettier/recommended"
+    "prettier"
   ],
   "env": {
     "node": true,

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+*.html
+*.md
+*.json
+*.css
+*.yml
+*.yaml
+*.d.ts
+site/_site

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "lint": "pnpm types && eslint . --cache --ignore-path .gitignore --ext .js,.mjs",
-    "fixlint": "pnpm lint -- --fix",
+    "fixlint": "prettier --write . && pnpm lint -- --fix",
     "build:integration": "node ./util/buildFrameworks.mjs",
     "pretest": "pnpm lint",
     "test:only": "uvu packages \"test.*\\.js$\"",
@@ -26,7 +26,6 @@
     "diff": "^5.0.0",
     "eslint": "^8.11.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-prettier": "^4.0.0",
     "html-to-text": "^8.1.0",
     "nanospy": "^0.5.0",
     "node-fetch": "2.6.7",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "postcss-scss": "^3.0.4",
     "postcss-simple-vars": "^6.0.1",
     "postcss-value-parser": "^4.2.0",
-    "prettier": "^2.5.1",
+    "prettier": "^2.6.0",
     "typescript": "^4.6.2",
     "uvu": "^0.5.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,6 @@ importers:
       diff: ^5.0.0
       eslint: ^8.11.0
       eslint-config-prettier: ^8.5.0
-      eslint-plugin-prettier: ^4.0.0
       html-to-text: ^8.1.0
       nanospy: ^0.5.0
       node-fetch: 2.6.7
@@ -31,7 +30,6 @@ importers:
       diff: 5.0.0
       eslint: 8.11.0
       eslint-config-prettier: 8.5.0_eslint@8.11.0
-      eslint-plugin-prettier: 4.0.0_c9d5adccfd1d43a8805a302169f6a967
       html-to-text: 8.1.0
       nanospy: 0.5.0
       node-fetch: 2.6.7
@@ -1382,23 +1380,6 @@ packages:
       eslint: 8.11.0
     dev: true
 
-  /eslint-plugin-prettier/4.0.0_c9d5adccfd1d43a8805a302169f6a967:
-    resolution: {integrity: sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==}
-    engines: {node: '>=6.0.0'}
-    peerDependencies:
-      eslint: '>=7.28.0'
-      eslint-config-prettier: '*'
-      prettier: '>=2.0.0'
-    peerDependenciesMeta:
-      eslint-config-prettier:
-        optional: true
-    dependencies:
-      eslint: 8.11.0
-      eslint-config-prettier: 8.5.0_eslint@8.11.0
-      prettier: 2.5.1
-      prettier-linter-helpers: 1.0.0
-    dev: true
-
   /eslint-scope/7.1.1:
     resolution: {integrity: sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1525,10 +1506,6 @@ packages:
 
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
-
-  /fast-diff/1.2.0:
-    resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
     dev: true
 
   /fast-glob/3.2.11:
@@ -2445,13 +2422,6 @@ packages:
   /prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-    dev: true
-
-  /prettier-linter-helpers/1.0.0:
-    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      fast-diff: 1.2.0
     dev: true
 
   /prettier/1.19.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
       postcss-scss: ^3.0.4
       postcss-simple-vars: ^6.0.1
       postcss-value-parser: ^4.2.0
-      prettier: ^2.5.1
+      prettier: ^2.6.0
       typescript: ^4.6.2
       uvu: ^0.5.3
     devDependencies:
@@ -40,7 +40,7 @@ importers:
       postcss-scss: 3.0.5
       postcss-simple-vars: 6.0.3_postcss@8.4.10
       postcss-value-parser: 4.2.0
-      prettier: 2.5.1
+      prettier: 2.6.0
       typescript: 4.6.2
       uvu: 0.5.3
 
@@ -2430,8 +2430,8 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier/2.5.1:
-    resolution: {integrity: sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==}
+  /prettier/2.6.0:
+    resolution: {integrity: sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Don't mix formatting with other errors when the editor has prettier integration. The Prettier documentation also recommends against running Prettier as ESlint plugin for the same reason
https://prettier.io/docs/en/integrating-with-linters.html#notes

* use eslint-config-prettier directly instead of plugin-prettier
* ignore all file types except JS
 We can't format some of the markdown because it's generated, the same goes for YAML files and *d.ts. Most of the CSS is also from third-party libraries.