### PR TITLE
fix(postcss-reduce-idents): fix handling of reserved keywords

### DIFF
--- a/packages/postcss-reduce-idents/src/lib/grid-template.js
+++ b/packages/postcss-reduce-idents/src/lib/grid-template.js
@@ -58,7 +58,10 @@ module.exports = function () {
         declCache.push(node);
       } else if (gridChildProperties.has(node.prop.toLowerCase())) {
         valueParser(node.value).walk((child) => {
-          if (child.type === 'word' && !RESERVED_KEYWORDS.has(child.value)) {
+          if (
+            child.type === 'word' &&
+            !RESERVED_KEYWORDS.has(child.value.toLowerCase())
+          ) {
             addToCache(child.value, encoder, cache);
           }
         });

--- a/packages/postcss-reduce-idents/src/lib/grid-template.js
+++ b/packages/postcss-reduce-idents/src/lib/grid-template.js
@@ -11,6 +11,21 @@ const RESERVED_KEYWORDS = new Set([
   'unset',
 ]);
 
+const gridTemplateProperties = new Set([
+  'grid-template',
+  'grid-template-areas',
+]);
+
+const gridChildProperties = new Set([
+  'grid-area',
+  'grid-column',
+  'grid-row',
+  'grid-column-start',
+  'grid-column-end',
+  'grid-row-start',
+  'grid-row-end',
+]);
+
 /**
  * @return {import('../index.js').Reducer}
  */
@@ -20,23 +35,13 @@ module.exports = function () {
   /** @type {import('postcss').Declaration[]} */
   let declCache = [];
 
-  const gridChildProperties = new Set([
-    'grid-area',
-    'grid-column',
-    'grid-row',
-    'grid-column-start',
-    'grid-column-end',
-    'grid-row-start',
-    'grid-row-end',
-  ]);
-
   return {
     collect(node, encoder) {
       if (node.type !== 'decl') {
         return;
       }
 
-      if (/(grid-template|grid-template-areas)/i.test(node.prop)) {
+      if (gridTemplateProperties.has(node.prop.toLowerCase())) {
         valueParser(node.value).walk((child) => {
           if (child.type === 'string') {
             child.value.split(/\s+/).forEach((word) => {
@@ -66,7 +71,7 @@ module.exports = function () {
       declCache.forEach((decl) => {
         decl.value = valueParser(decl.value)
           .walk((node) => {
-            if (/(grid-template|grid-template-areas)/i.test(decl.prop)) {
+            if (gridTemplateProperties.has(decl.prop.toLowerCase())) {
               node.value.split(/\s+/).forEach((word) => {
                 if (word in cache) {
                   node.value = node.value.replace(word, cache[word].ident);
@@ -75,7 +80,10 @@ module.exports = function () {
               node.value = node.value.replace(/\s+/g, ' '); // merge white-spaces
             }
 
-            if (gridChildProperties.has(decl.prop.toLowerCase()) && !isNum(node)) {
+            if (
+              gridChildProperties.has(decl.prop.toLowerCase()) &&
+              !isNum(node)
+            ) {
               if (node.value in cache) {
                 node.value = cache[node.value].ident;
               }

--- a/packages/postcss-reduce-idents/test/index.js
+++ b/packages/postcss-reduce-idents/test/index.js
@@ -269,6 +269,26 @@ test(
 );
 
 test(
+  'should leave grid-template-rows',
+  processCSS(
+    [
+      'body{grid-template-areas:"head head" \n"nav  main"\n"nav  foot"; grid-template-rows: 1fr 1fr 1fr;}',
+      'header { grid-area: head }',
+      'nav{grid-area:nav}',
+      'main{grid-area:main}',
+      'footer{grid-area:foot}',
+    ].join(''),
+    [
+      'body{grid-template-areas:"a a" "b c" "b d"; grid-template-rows: 1fr 1fr 1fr;}',
+      'header { grid-area: a }',
+      'nav{grid-area:b}',
+      'main{grid-area:c}',
+      'footer{grid-area:d}',
+    ].join('')
+  )
+);
+
+test(
   'should rename grid-template-areas and grid-area (uppercase)',
   processCSS(
     [
@@ -384,6 +404,26 @@ test(
       '.middle{GRID-ROW:b}',
       '.top{GRID-ROW:a/b}',
       '.bottom{GRID-ROW-START:b; GRID-ROW-END: a}',
+    ].join('')
+  )
+);
+
+test(
+  'should not rename uppercase reserved keywords in grid-row, grid-row-start and grid-row-end',
+  processCSS(
+    [
+      'body{grid-template-areas:"full ." \n"full middle" \n"full .";}',
+      '.full { grid-row: AUTO }',
+      '.middle{grid-row:INHERIT}',
+      '.top{grid-row:full/middle}',
+      '.bottom{grid-row-start:middle; grid-row-end: full}',
+    ].join(''),
+    [
+      'body{grid-template-areas:"a ." "a b" "a .";}',
+      '.full { grid-row: AUTO }',
+      '.middle{grid-row:INHERIT}',
+      '.top{grid-row:a/b}',
+      '.bottom{grid-row-start:b; grid-row-end: a}',
     ].join('')
   )
 );


### PR DESCRIPTION
* fix issue where uppercase special values (AUTO) were transformed
* skip useless parsing of `grid-template-rows` and `grid-template-columns` as no substitutions occur there (the code always checks whether the token type is `string` before considering a candidate for replacing, so there was not bug but the intents was confusing)