### PR TITLE
Publish cssnano 5.1.5

### DIFF
--- a/packages/cssnano-preset-advanced/CHANGELOG.md
+++ b/packages/cssnano-preset-advanced/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 5.3.1
+
+### Patch Changes
+
+- fix: correct package.json dependency version specifier
+- Updated dependencies
+  - cssnano-preset-default@5.2.5
+  - postcss-merge-idents@5.1.1
+
 ## 5.3.0
 
 ### Minor Changes

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-advanced",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "main": "src/index.js",
   "types": "types/index.d.ts",
   "description": "Advanced optimisations for cssnano; may or may not break your CSS!",

--- a/packages/cssnano-preset-default/CHANGELOG.md
+++ b/packages/cssnano-preset-default/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 5.2.5
+
+### Patch Changes
+
+- fix: correct package.json dependency version specifier
+- Updated dependencies
+  - postcss-merge-longhand@5.1.3
+  - postcss-merge-rules@5.1.1
+  - postcss-minify-gradients@5.1.1
+  - postcss-minify-params@5.1.2
+  - postcss-ordered-values@5.1.1
+
 ## 5.2.4
 
 ### Patch Changes

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-default",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "main": "src/index.js",
   "types": "types/index.d.ts",
   "description": "Safe defaults for cssnano which require minimal configuration.",

--- a/packages/cssnano-preset-lite/CHANGELOG.md
+++ b/packages/cssnano-preset-lite/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.1.2
+
+### Patch Changes
+
+- fix: correct package.json dependency version specifier
+
 ## 2.1.1
 
 ### Patch Changes

--- a/packages/cssnano-preset-lite/package.json
+++ b/packages/cssnano-preset-lite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cssnano-preset-lite",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "main": "src/index.js",
     "types": "types/index.d.ts",
     "description": "Safe and minimum transformation",

--- a/packages/cssnano/CHANGELOG.md
+++ b/packages/cssnano/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 5.1.5
+
+### Patch Changes
+
+- fix: correct package.json dependency version specifier
+- Updated dependencies
+  - cssnano-preset-default@5.2.5
+
 ## 5.1.4
 
 ### Patch Changes

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cssnano",
-    "version": "5.1.4",
+    "version": "5.1.5",
     "description": "A modular minifier, built on top of the PostCSS ecosystem.",
     "main": "src/index.js",
     "types": "types/index.d.ts",

--- a/packages/postcss-merge-idents/CHANGELOG.md
+++ b/packages/postcss-merge-idents/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.1.1
+
+### Patch Changes
+
+- fix: correct package.json dependency version specifier
+
 ## 5.1.0
 
 ### Minor Changes

--- a/packages/postcss-merge-idents/package.json
+++ b/packages/postcss-merge-idents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-merge-idents",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Merge keyframe and counter style identifiers.",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/packages/postcss-merge-longhand/CHANGELOG.md
+++ b/packages/postcss-merge-longhand/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.1.3
+
+### Patch Changes
+
+- fix: correct package.json dependency version specifier
+
 ## 5.1.2
 
 ### Patch Changes

--- a/packages/postcss-merge-longhand/package.json
+++ b/packages/postcss-merge-longhand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-merge-longhand",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Merge longhand properties into shorthand with PostCSS.",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/packages/postcss-merge-rules/CHANGELOG.md
+++ b/packages/postcss-merge-rules/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.1.1
+
+### Patch Changes
+
+- fix: correct package.json dependency version specifier
+
 ## 5.1.0
 
 ### Minor Changes

--- a/packages/postcss-merge-rules/package.json
+++ b/packages/postcss-merge-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-merge-rules",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Merge CSS rules with PostCSS.",
   "types": "types/index.d.ts",
   "main": "src/index.js",

--- a/packages/postcss-minify-gradients/CHANGELOG.md
+++ b/packages/postcss-minify-gradients/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.1.1
+
+### Patch Changes
+
+- fix: correct package.json dependency version specifier
+
 ## 5.1.0
 
 ### Minor Changes

--- a/packages/postcss-minify-gradients/package.json
+++ b/packages/postcss-minify-gradients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-minify-gradients",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Minify gradient parameters with PostCSS.",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/packages/postcss-minify-params/CHANGELOG.md
+++ b/packages/postcss-minify-params/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.1.2
+
+### Patch Changes
+
+- fix: correct package.json dependency version specifier
+
 ## 5.1.1
 
 ### Patch Changes

--- a/packages/postcss-minify-params/package.json
+++ b/packages/postcss-minify-params/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-minify-params",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Minify at-rule params with PostCSS",
   "keywords": [
     "postcss",

--- a/packages/postcss-ordered-values/CHANGELOG.md
+++ b/packages/postcss-ordered-values/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.1.1
+
+### Patch Changes
+
+- fix: correct package.json dependency version specifier
+
 ## 5.1.0
 
 ### Minor Changes

--- a/packages/postcss-ordered-values/package.json
+++ b/packages/postcss-ordered-values/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-ordered-values",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Ensure values are ordered consistently in your CSS.",
   "main": "src/index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
Re-release all packages that depend on at least another workspace package, to fix https://github.com/cssnano/cssnano/pull/1372 (besides cssnano and the presets, it includes all packages that depend on cssnano-utils or stylehacks).