### PR TITLE
fix: conflict detection needs to consider border-left-color vs border-color

### DIFF
--- a/packages/postcss-merge-longhand/src/lib/mergeRules.js
+++ b/packages/postcss-merge-longhand/src/lib/mergeRules.js
@@ -9,17 +9,23 @@ const getRules = require('./getRules.js');
  * @return {boolean}
  */
 function isConflictingProp(propA, propB) {
-  if (!propB.prop || propB.important !== propA.important) {
+  if (!propB.prop || propB.important !== propA.important ||
+      propA.prop === propB.prop) {
     return false;
   }
 
-  const parts = propA.prop.split('-');
+  const partsA = propA.prop.split('-');
+  const partsB = propB.prop.split('-');
 
-  return parts.some(() => {
-    parts.pop();
+  /* Be safe: check that the first part matches. So we don't try to
+   * combine e.g. border-color and color.
+   */
+  if (partsA[0] !== partsB[0]) {
+    return false;
+  }
 
-    return parts.join('-') === propB.prop;
-  });
+  const partsASet = new Set(partsA);
+  return partsB.every((partB) => partsASet.has(partB));
 }
 
 /**

--- a/packages/postcss-merge-longhand/test/borders.js
+++ b/packages/postcss-merge-longhand/test/borders.js
@@ -1279,5 +1279,12 @@ test(
   )
 );
 
+test(
+  'avoid dropping custom property when merging expansions',
+  passthroughCSS(
+    'h1{border:1px solid;border-color:var(--BORDER);border-left-style:none;}'
+  )
+);
+
 test('should handle empty border', processCSS('h1{border:;}', 'h1{border:;}'));
 test.run();


### PR DESCRIPTION
The previous algorithm was to pop values off the end and comparing to
the other given property. Change the detection to instead check that all
the components of the second value are in the first value.

Fixes #1375

Please note that I'm new to this codebase, so I may very well have missed something. The existing tests do pass though.