### PR TITLE
chore: update TypeScript and regenerate types

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "postcss-simple-vars": "^6.0.1",
     "postcss-value-parser": "^4.2.0",
     "prettier": "^2.6.0",
-    "typescript": "^4.6.2",
+    "typescript": "^4.6.3",
     "uvu": "^0.5.3"
   },
   "browserslist": {

--- a/packages/postcss-merge-longhand/types/lib/decl/index.d.ts
+++ b/packages/postcss-merge-longhand/types/lib/decl/index.d.ts
@@ -39,6 +39,8 @@ declare const _exports: {
     keys(): IterableIterator<number>;
     values(): IterableIterator<typeof borders>;
     includes(searchElement: typeof borders, fromIndex?: number | undefined): boolean;
+    flatMap<U_3, This = undefined>(callback: (this: This, value: typeof borders, index: number, array: (typeof borders)[]) => U_3 | readonly U_3[], thisArg?: This | undefined): U_3[];
+    flat<A, D extends number = 1>(this: A, depth?: D | undefined): FlatArray<A, D>[];
     [Symbol.iterator](): IterableIterator<typeof borders>;
     [Symbol.unscopables](): {
         copyWithin: boolean;
@@ -49,5 +51,6 @@ declare const _exports: {
         keys: boolean;
         values: boolean;
     };
+    at(index: number): typeof borders | undefined;
 };
 export = _exports;

--- a/packages/postcss-merge-longhand/types/lib/trbl.d.ts
+++ b/packages/postcss-merge-longhand/types/lib/trbl.d.ts
@@ -39,6 +39,8 @@ declare const _exports: {
     keys(): IterableIterator<number>;
     values(): IterableIterator<string>;
     includes(searchElement: string, fromIndex?: number | undefined): boolean;
+    flatMap<U_3, This = undefined>(callback: (this: This, value: string, index: number, array: string[]) => U_3 | readonly U_3[], thisArg?: This | undefined): U_3[];
+    flat<A, D extends number = 1>(this: A, depth?: D | undefined): FlatArray<A, D>[];
     [Symbol.iterator](): IterableIterator<string>;
     [Symbol.unscopables](): {
         copyWithin: boolean;
@@ -49,5 +51,6 @@ declare const _exports: {
         keys: boolean;
         values: boolean;
     };
+    at(index: number): string | undefined;
 };
 export = _exports;

--- a/packages/stylehacks/types/plugins/index.d.ts
+++ b/packages/stylehacks/types/plugins/index.d.ts
@@ -347,6 +347,16 @@ declare const _exports: {
     } | {
         new (result?: import("postcss").Result | undefined): trailingSlashComma;
     }, fromIndex?: number | undefined): boolean;
+    flatMap<U_3, This = undefined>(callback: (this: This, value: {
+        new (result?: import("postcss").Result | undefined): important;
+    } | {
+        new (result?: import("postcss").Result | undefined): trailingSlashComma;
+    }, index: number, array: ({
+        new (result?: import("postcss").Result | undefined): important;
+    } | {
+        new (result?: import("postcss").Result | undefined): trailingSlashComma;
+    })[]) => U_3 | readonly U_3[], thisArg?: This | undefined): U_3[];
+    flat<A, D extends number = 1>(this: A, depth?: D | undefined): FlatArray<A, D>[];
     [Symbol.iterator](): IterableIterator<{
         new (result?: import("postcss").Result | undefined): important;
     } | {
@@ -361,5 +371,10 @@ declare const _exports: {
         keys: boolean;
         values: boolean;
     };
+    at(index: number): {
+        new (result?: import("postcss").Result | undefined): important;
+    } | {
+        new (result?: import("postcss").Result | undefined): trailingSlashComma;
+    } | undefined;
 };
 export = _exports;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
       postcss-simple-vars: ^6.0.1
       postcss-value-parser: ^4.2.0
       prettier: ^2.6.0
-      typescript: ^4.6.2
+      typescript: ^4.6.3
       uvu: ^0.5.3
     devDependencies:
       '@changesets/cli': 2.21.1
@@ -41,7 +41,7 @@ importers:
       postcss-simple-vars: 6.0.3_postcss@8.4.10
       postcss-value-parser: 4.2.0
       prettier: 2.6.0
-      typescript: 4.6.2
+      typescript: 4.6.3
       uvu: 0.5.3
 
   packages/css-size:
@@ -2858,8 +2858,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /typescript/4.6.2:
-    resolution: {integrity: sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==}
+  /typescript/4.6.3:
+    resolution: {integrity: sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
TypeScript adds `flat()`, `flatMap()` and `flat()` to type definitions
for modules that export an array.
These only exist in Node since Node 11, butI don't think that's a problem
because they're in internal modules.