### PR TITLE
chore: really publish the postcss-merge-longhand changes

### DIFF
--- a/packages/cssnano-preset-advanced/CHANGELOG.md
+++ b/packages/cssnano-preset-advanced/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- fix: preserve border color when mergin border properties
+- fix: preserve border color when merging border properties
 - Updated dependencies
   - cssnano-preset-default@5.2.6
 

--- a/packages/cssnano-preset-advanced/CHANGELOG.md
+++ b/packages/cssnano-preset-advanced/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 5.3.3
+
+### Patch Changes
+
+- fix: update postcss-merge-longhand. It was skipped by mistake in the previous release.
+- Updated dependencies
+  - cssnano-preset-default@5.2.7
+
 ## 5.3.2
 
 ### Patch Changes

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-advanced",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "main": "src/index.js",
   "types": "types/index.d.ts",
   "description": "Advanced optimisations for cssnano; may or may not break your CSS!",

--- a/packages/cssnano-preset-default/CHANGELOG.md
+++ b/packages/cssnano-preset-default/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 5.2.7
+
+### Patch Changes
+
+- fix: update postcss-merge-longhand. It was skipped by mistake in the previous release.
+- Updated dependencies
+  - postcss-merge-longhand@5.1.4
+
 ## 5.2.6
 
 ### Patch Changes

--- a/packages/cssnano-preset-default/CHANGELOG.md
+++ b/packages/cssnano-preset-default/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- fix: preserve border color when mergin border properties
+- fix: preserve border color when merging border properties
 
 ## 5.2.5
 

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-default",
-  "version": "5.2.6",
+  "version": "5.2.7",
   "main": "src/index.js",
   "types": "types/index.d.ts",
   "description": "Safe defaults for cssnano which require minimal configuration.",

--- a/packages/cssnano/CHANGELOG.md
+++ b/packages/cssnano/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 5.1.7
+
+### Patch Changes
+
+- fix: update postcss-merge-longhand. It was skipped by mistake in the previous release.
+- Updated dependencies
+  - cssnano-preset-default@5.2.7
+
 ## 5.1.6
 
 ### Patch Changes

--- a/packages/cssnano/CHANGELOG.md
+++ b/packages/cssnano/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- fix: preserve border color when mergin border properties
+- fix: preserve border color when merging border properties
 - Updated dependencies
   - cssnano-preset-default@5.2.6
 

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cssnano",
-    "version": "5.1.6",
+    "version": "5.1.7",
     "description": "A modular minifier, built on top of the PostCSS ecosystem.",
     "main": "src/index.js",
     "types": "types/index.d.ts",

--- a/packages/postcss-merge-longhand/CHANGELOG.md
+++ b/packages/postcss-merge-longhand/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.1.4
+
+### Patch Changes
+
+- fix: update postcss-merge-longhand. It was skipped by mistake in the previous release.
+
 ## 5.1.3
 
 ### Patch Changes

--- a/packages/postcss-merge-longhand/package.json
+++ b/packages/postcss-merge-longhand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-merge-longhand",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "Merge longhand properties into shorthand with PostCSS.",
   "main": "src/index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
The previous release (5.1.6) did not update `postcss-merge-longhand` version and publish a  new `postcss-merge-longhand` with the fixes but only updated the presets version number.