### PR TITLE
refactor(postcss-merge-longhand): delete remove() function

### DIFF
--- a/packages/postcss-merge-longhand/src/lib/decl/borders.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/borders.js
@@ -11,7 +11,6 @@ const mergeRules = require('../mergeRules.js');
 const minifyTrbl = require('../minifyTrbl.js');
 const minifyWsc = require('../minifyWsc.js');
 const canMerge = require('../canMerge.js');
-const remove = require('../remove.js');
 const trbl = require('../trbl.js');
 const isCustomProp = require('../isCustomProp.js');
 const canExplode = require('../canExplode.js');
@@ -273,8 +272,9 @@ function merge(rule) {
               value: rules.map(getValue).join(' '),
             }
           );
-
-          rules.forEach(remove);
+          for (const node of rules) {
+            node.remove();
+          }
 
           return true;
         }
@@ -301,7 +301,9 @@ function merge(rule) {
             }
           );
 
-          rules.forEach(remove);
+          for (const node of rules) {
+            node.remove();
+          }
 
           return true;
         }
@@ -350,7 +352,9 @@ function merge(rule) {
       }
     });
 
-    rules.forEach(remove);
+    for (const node of rules) {
+      node.remove();
+    }
 
     return true;
   });
@@ -400,7 +404,9 @@ function merge(rule) {
           })
         );
       }
-      rules.forEach(remove);
+      for (const node of rules) {
+        node.remove();
+      }
 
       return true;
     } else if (reduced.length === 1) {
@@ -413,7 +419,7 @@ function merge(rule) {
       );
       rules
         .filter((node) => node.prop.toLowerCase() !== properties[2])
-        .forEach(remove);
+        .forEach((node) => node.remove());
 
       return true;
     }
@@ -462,7 +468,9 @@ function merge(rule) {
         }
       });
 
-      rules.forEach(remove);
+      for (const node of rules) {
+        node.remove();
+      }
 
       return true;
     }
@@ -512,7 +520,9 @@ function merge(rule) {
         );
       }
 
-      rules.forEach(remove);
+      for (const node of rules) {
+        node.remove();
+      }
 
       return true;
     }
@@ -672,7 +682,9 @@ function merge(rule) {
         );
 
         decls = decls.filter((node) => !rules.includes(node));
-        rules.forEach(remove);
+        for (const node of rules) {
+          node.remove();
+        }
       }
     });
 
@@ -739,7 +751,9 @@ function merge(rule) {
           values[i] !== undefined &&
           longhands[0].value.toLowerCase() === values[i].toLowerCase()
         ) {
-          longhands.forEach(remove);
+          for (const node of longhands) {
+            node.remove();
+          }
 
           insertCloned(
             /** @type {import('postcss').Rule} */ (decl.parent),
@@ -801,7 +815,9 @@ function merge(rule) {
           node.prop.toLowerCase().endsWith(/** @type {string} */ (lastPart)))
     );
 
-    lesser.forEach(remove);
+    for (const node of lesser) {
+      node.remove();
+    }
     decls = decls.filter((node) => !lesser.includes(node));
 
     // get duplicate properties
@@ -823,8 +839,9 @@ function merge(rule) {
 
         duplicates = duplicates.filter((node) => node !== preserve);
       }
-
-      duplicates.forEach(remove);
+      for (const node of duplicates) {
+        node.remove();
+      }
     }
 
     decls = decls.filter(

--- a/packages/postcss-merge-longhand/src/lib/decl/boxBase.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/boxBase.js
@@ -7,7 +7,6 @@ const parseTrbl = require('../parseTrbl.js');
 const insertCloned = require('../insertCloned.js');
 const mergeRules = require('../mergeRules.js');
 const mergeValues = require('../mergeValues.js');
-const remove = require('../remove.js');
 const trbl = require('../trbl.js');
 const isCustomProp = require('../isCustomProp.js');
 const canExplode = require('../canExplode.js');
@@ -36,7 +35,9 @@ module.exports = (prop) => {
           node.prop !== lastNode.prop
       );
 
-      lesser.forEach(remove);
+      for (const node of lesser) {
+        node.remove();
+      }
       decls = decls.filter((node) => !lesser.includes(node));
 
       // get duplicate properties
@@ -50,7 +51,9 @@ module.exports = (prop) => {
           !(!isCustomProp(node) && isCustomProp(lastNode))
       );
 
-      duplicates.forEach(remove);
+      for (const node of duplicates) {
+        node.remove();
+      }
       decls = decls.filter(
         (node) => node !== lastNode && !duplicates.includes(node)
       );
@@ -97,7 +100,9 @@ module.exports = (prop) => {
               value: minifyTrbl(mergeValues(...rules)),
             }
           );
-          rules.forEach(remove);
+          for (const node of rules) {
+            node.remove();
+          }
 
           return true;
         }

--- a/packages/postcss-merge-longhand/src/lib/decl/columns.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/columns.js
@@ -7,7 +7,6 @@ const getDecls = require('../getDecls.js');
 const getValue = require('../getValue.js');
 const mergeRules = require('../mergeRules.js');
 const insertCloned = require('../insertCloned.js');
-const remove = require('../remove.js');
 const isCustomProp = require('../isCustomProp.js');
 const canExplode = require('../canExplode.js');
 
@@ -104,7 +103,9 @@ function cleanup(rule) {
         node.prop !== lastNode.prop
     );
 
-    lesser.forEach(remove);
+    for (const node of lesser) {
+      node.remove();
+    }
     decls = decls.filter((node) => !lesser.includes(node));
 
     // get duplicate properties
@@ -118,7 +119,9 @@ function cleanup(rule) {
         !(!isCustomProp(node) && isCustomProp(lastNode))
     );
 
-    duplicates.forEach(remove);
+    for (const node of duplicates) {
+      node.remove();
+    }
     decls = decls.filter(
       (node) => node !== lastNode && !duplicates.includes(node)
     );
@@ -141,7 +144,9 @@ function merge(rule) {
         }
       );
 
-      rules.forEach(remove);
+      for (const node of rules) {
+        node.remove();
+      }
 
       return true;
     }

--- a/packages/postcss-merge-longhand/src/lib/remove.js
+++ b/packages/postcss-merge-longhand/src/lib/remove.js
@@ -1,8 +1,0 @@
-'use strict';
-/**
- * @param {import('postcss').Node} node
- * @return {import('postcss').Node}
- */
-module.exports = function remove(node) {
-  return node.remove();
-};


### PR DESCRIPTION
I find this function makes the code harder to read, because it just
calls `remove()` on the PostCSS node, but the fact that it's a separate
function makes you believe that it's performing a more complex operation. It also returns the node, but nothing uses the return value.