### PR TITLE
fix: correct file paths in scripts that fetch external data

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "eslint-config-prettier": "^8.5.0",
     "html-to-text": "^8.1.0",
     "nanospy": "^0.5.0",
-    "node-fetch": "2.6.7",
     "picocolors": "^1.0.0",
     "pleeease-filters": "^4.0.0",
     "postcss": "^8.4.12",

--- a/packages/postcss-ordered-values/package.json
+++ b/packages/postcss-ordered-values/package.json
@@ -33,8 +33,8 @@
     "node": "^10 || ^12 || >=14.0"
   },
   "devDependencies": {
-    "node-fetch": "^2.6.7",
-    "postcss": "^8.2.15"
+    "postcss": "^8.2.15",
+    "undici": "^5.0.0"
   },
   "peerDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-ordered-values/script/buildListStyleType.js
+++ b/packages/postcss-ordered-values/script/buildListStyleType.js
@@ -3,7 +3,7 @@
 
 const { writeFile } = require('fs');
 const { resolve } = require('path');
-const fetch = require('node-fetch');
+const { fetch } = require('undici');
 
 const listTypeURL =
   'https://raw.githubusercontent.com/mdn/browser-compat-data/master/css/properties/list-style-type.json';
@@ -18,17 +18,6 @@ const listTypeURL =
   };
   writeFile(
     resolve(__dirname, '../src/rules/listStyleTypes.json'),
-    JSON.stringify(content, null, 2),
-    (err) => {
-      if (err) {
-        console.log('Error while fetch list style type from GitHub', err);
-        process.exit(1);
-      }
-    }
-  );
-
-  writeFile(
-    resolve(__dirname, '../dist/rules/listStyleTypes.json'),
     JSON.stringify(content, null, 2),
     (err) => {
       if (err) {

--- a/packages/postcss-reduce-initial/package.json
+++ b/packages/postcss-reduce-initial/package.json
@@ -37,7 +37,8 @@
   },
   "devDependencies": {
     "@types/caniuse-api": "^3.0.2",
-    "postcss": "^8.2.15"
+    "postcss": "^8.2.15",
+    "undici": "^5.0.0"
   },
   "peerDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-reduce-initial/script/acquire.mjs
+++ b/packages/postcss-reduce-initial/script/acquire.mjs
@@ -1,13 +1,13 @@
 import { writeFile } from 'fs';
-import fetch from 'node-fetch';
+import { fetch } from 'undici';
 import { generate } from './lib/io.mjs';
 
 const url =
   'https://raw.githubusercontent.com/mdn/data/master/css/properties.json';
 
 const paths = {
-  fromInitial: new URL('../data/fromInitial.json', import.meta.url),
-  toInitial: new URL('../data/toInitial.json', import.meta.url),
+  fromInitial: new URL('../src/data/fromInitial.json', import.meta.url),
+  toInitial: new URL('../src/data/toInitial.json', import.meta.url),
 };
 
 generate(fetch, writeFile, paths, url).catch((error) => {

--- a/packages/postcss-reduce-initial/script/test/io.mjs
+++ b/packages/postcss-reduce-initial/script/test/io.mjs
@@ -2,7 +2,6 @@ import fs from 'fs';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { spy } from 'nanospy';
-import { Response } from 'node-fetch';
 import { handleError, toJSONString, write, generate } from '../lib/io.mjs';
 
 const testData = JSON.parse(
@@ -47,7 +46,7 @@ test('should handle file operation errors', () => {
 test('should make it through promise chain with sample data and write 2 files', async () => {
   const fileFunc = spy();
   const fetchFunc = spy(async () => {
-    return new Response(JSON.stringify(testData));
+    return { json: () => Promise.resolve(testData) };
   });
   await generate(
     fetchFunc,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,6 @@ importers:
       eslint-config-prettier: ^8.5.0
       html-to-text: ^8.1.0
       nanospy: ^0.5.0
-      node-fetch: 2.6.7
       picocolors: ^1.0.0
       pleeease-filters: ^4.0.0
       postcss: ^8.4.12
@@ -32,7 +31,6 @@ importers:
       eslint-config-prettier: 8.5.0_eslint@8.12.0
       html-to-text: 8.1.0
       nanospy: 0.5.0
-      node-fetch: 2.6.7
       picocolors: 1.0.0
       pleeease-filters: 4.0.0
       postcss: 8.4.12
@@ -408,15 +406,15 @@ importers:
   packages/postcss-ordered-values:
     specifiers:
       cssnano-utils: workspace:^
-      node-fetch: ^2.6.7
       postcss: ^8.2.15
       postcss-value-parser: ^4.2.0
+      undici: ^5.0.0
     dependencies:
       cssnano-utils: link:../cssnano-utils
       postcss-value-parser: 4.2.0
     devDependencies:
-      node-fetch: 2.6.7
       postcss: 8.4.12
+      undici: 5.0.0
 
   packages/postcss-reduce-idents:
     specifiers:
@@ -433,12 +431,14 @@ importers:
       browserslist: ^4.16.6
       caniuse-api: ^3.0.0
       postcss: ^8.2.15
+      undici: ^5.0.0
     dependencies:
       browserslist: 4.20.2
       caniuse-api: 3.0.0
     devDependencies:
       '@types/caniuse-api': 3.0.2
       postcss: 8.4.12
+      undici: 5.0.0
 
   packages/postcss-reduce-transforms:
     specifiers:
@@ -2127,18 +2127,6 @@ packages:
       randexp: 0.4.6
     dev: true
 
-  /node-fetch/2.6.7:
-    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-    dependencies:
-      whatwg-url: 5.0.0
-    dev: true
-
   /node-releases/2.0.2:
     resolution: {integrity: sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==}
 
@@ -2801,10 +2789,6 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /tr46/0.0.3:
-    resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
-    dev: true
-
   /trim-newlines/3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
@@ -2854,6 +2838,11 @@ packages:
     resolution: {integrity: sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
+
+  /undici/5.0.0:
+    resolution: {integrity: sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg==}
+    engines: {node: '>=12.18'}
     dev: true
 
   /universalify/0.1.2:
@@ -2906,17 +2895,6 @@ packages:
     resolution: {integrity: sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=}
     dependencies:
       defaults: 1.0.3
-    dev: true
-
-  /webidl-conversions/3.0.1:
-    resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
-    dev: true
-
-  /whatwg-url/5.0.0:
-    resolution: {integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0=}
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
     dev: true
 
   /which-module/2.0.0:


### PR DESCRIPTION
* correct the file paths that changed when transpiling was
removed and TypeScript checks added
* switch fetch library to undici since its got zero dependencies
  and it's going to be the basis for built-in Node.js fetch
* did not commit changes to the data files from running the scripts
  again because they need a separate review for browser compatibility