### PR TITLE
chore: use Node.js 18 instead of 17 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node-version: ['10', '12', '14', '16', '17']
+        node-version: ['10', '12', '14', '16', '18']
 
     steps:
       - name: Setup Git


### PR DESCRIPTION
Node.js 18 will become the next LTS but 17
reaches end-of-life at the end of May.