### PR TITLE
feat(postcss-convert-values): preserve min-width percent on IE 11 only

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@changesets/cli": "^2.22.0",
     "@types/node": "^17.0.31",
-    "browserslist": "^4.20.3",
     "c8": "^7.11.2",
     "diff": "^5.0.0",
     "eslint": "^8.13.0",

--- a/packages/postcss-convert-values/package.json
+++ b/packages/postcss-convert-values/package.json
@@ -24,6 +24,7 @@
   },
   "repository": "cssnano/cssnano",
   "dependencies": {
+    "browserslist": "^4.20.3",
     "postcss-value-parser": "^4.2.0"
   },
   "bugs": {

--- a/packages/postcss-convert-values/types/index.d.ts
+++ b/packages/postcss-convert-values/types/index.d.ts
@@ -1,6 +1,6 @@
 export = pluginCreator;
 /**
- * @typedef {{precision: boolean | number, angle?: boolean, time?: boolean, length?: boolean}} Options */
+ * @typedef {{precision: boolean | number, angle?: boolean, time?: boolean, length?: boolean} & browserslist.Options} Options */
 /**
  * @type {import('postcss').PluginCreator<Options>}
  * @param {Options} opts
@@ -15,5 +15,6 @@ type Options = {
     angle?: boolean;
     time?: boolean;
     length?: boolean;
-};
+} & browserslist.Options;
 declare var postcss: true;
+import browserslist = require("browserslist");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,9 +194,11 @@ importers:
 
   packages/postcss-convert-values:
     specifiers:
+      browserslist: ^4.20.3
       postcss: ^8.2.15
       postcss-value-parser: ^4.2.0
     dependencies:
+      browserslist: 4.20.3
       postcss-value-parser: 4.2.0
     devDependencies:
       postcss: 8.4.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ importers:
     specifiers:
       '@changesets/cli': ^2.22.0
       '@types/node': ^17.0.31
-      browserslist: ^4.20.3
       c8: ^7.11.2
       diff: ^5.0.0
       eslint: ^8.13.0
@@ -25,7 +24,6 @@ importers:
     devDependencies:
       '@changesets/cli': 2.22.0
       '@types/node': 17.0.31
-      browserslist: 4.20.3
       c8: 7.11.2
       diff: 5.0.0
       eslint: 8.15.0


### PR DESCRIPTION
Follow-up to #1385

Use browserslist to determine whether browsers include IE 11 as discussed in https://github.com/cssnano/cssnano/pull/1385#issuecomment-1094909660