### PR TITLE
Publish cssnano 5.1.9

### DIFF
--- a/packages/cssnano-preset-advanced/CHANGELOG.md
+++ b/packages/cssnano-preset-advanced/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 5.3.5
+
+### Patch Changes
+
+- fix: preserve more color function fallbacks
+- Updated dependencies
+  - cssnano-preset-default@5.2.9
+
 ## 5.3.4
 
 ### Patch Changes

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-advanced",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "main": "src/index.js",
   "types": "types/index.d.ts",
   "description": "Advanced optimisations for cssnano; may or may not break your CSS!",

--- a/packages/cssnano-preset-default/CHANGELOG.md
+++ b/packages/cssnano-preset-default/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 5.2.9
+
+### Patch Changes
+
+- fix: preserve more color function fallbacks
+- Updated dependencies
+  - postcss-merge-longhand@5.1.5
+
 ## 5.2.8
 
 ### Patch Changes

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-default",
-  "version": "5.2.8",
+  "version": "5.2.9",
   "main": "src/index.js",
   "types": "types/index.d.ts",
   "description": "Safe defaults for cssnano which require minimal configuration.",

--- a/packages/cssnano/CHANGELOG.md
+++ b/packages/cssnano/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 5.1.9
+
+### Patch Changes
+
+- fix: preserve more color function fallbacks
+- Updated dependencies
+  - cssnano-preset-default@5.2.9
+
 ## 5.1.8
 
 ### Patch Changes

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cssnano",
-    "version": "5.1.8",
+    "version": "5.1.9",
     "description": "A modular minifier, built on top of the PostCSS ecosystem.",
     "main": "src/index.js",
     "types": "types/index.d.ts",

--- a/packages/postcss-merge-longhand/CHANGELOG.md
+++ b/packages/postcss-merge-longhand/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.1.5
+
+### Patch Changes
+
+- fix: preserve more color function fallbacks
+
 ## 5.1.4
 
 ### Patch Changes

--- a/packages/postcss-merge-longhand/package.json
+++ b/packages/postcss-merge-longhand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-merge-longhand",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "Merge longhand properties into shorthand with PostCSS.",
   "main": "src/index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
I would release this to avoid other issues similar to https://github.com/cssnano/cssnano/issues/1396 because it's going to take some time to properly refactor color handling as it's duplicated multiple times across the codebase. In fact, before working on any more issues, I am thinking to start a branch to merge plugins and reduce the number of traversals like we said many times in the past. That should a give a clearer picture of how many times the same properties are parsed and analysed in separate places. 