### PR TITLE
chore: update GitHub action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.0.0
+      - uses: actions/checkout@v3.0.2
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.1
+        uses: pnpm/action-setup@v2.2.2
         with:
-          version: 6.32.2
+          version: 6.32.18
       - name: Install Node.js 16.x
         uses: actions/setup-node@v3.1.1
         with:
@@ -32,11 +32,11 @@ jobs:
   test_helpers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.0.0
+      - uses: actions/checkout@v3.0.2
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.1
+        uses: pnpm/action-setup@v2.2.2
         with:
-          version: 6.32.2
+          version: 6.32.18
       - name: Install Node.js 16.x
         uses: actions/setup-node@v3.1.1
         with:
@@ -62,13 +62,13 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: git config --global core.autocrlf input
 
-      - uses: actions/checkout@v3.0.0
+      - uses: actions/checkout@v3.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.1
+        uses: pnpm/action-setup@v2.2.2
         if: matrix.node-version != '10'
         with:
-          version: 6.32.2
+          version: 6.32.18
 
       - name: Install Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3.1.1
@@ -78,14 +78,14 @@ jobs:
           cache: 'pnpm'
 
       - name: Install old pnpm
-        uses: pnpm/action-setup@v2.2.1
+        uses: pnpm/action-setup@v2.2.2
         if: matrix.node-version == '10'
         with:
           version: 5.18.4
 
       # No cache support on GH actions for old pnpm
       - name: Install Node.js without cache ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3.1.1
         if: matrix.node-version == '10'
         with:
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
Unblock the pipeline by updating the @pnpm/action-setup. We need this commit: https://github.com/pnpm/action-setup/pull/46 to stop CI from failing when trying to install pnpm on MacOS