### PR TITLE
test: separate integration tests from single plugin tests

### DIFF
--- a/packages/cssnano/test/_processCss.js
+++ b/packages/cssnano/test/_processCss.js
@@ -1,5 +1,4 @@
 'use strict';
-const { test } = require('uvu');
 const assert = require('uvu/assert');
 const postcss = require('postcss');
 const cssnano = require('..');
@@ -16,4 +15,3 @@ module.exports = processCss;
 module.exports.passthrough = function (fixture, options = { from: undefined }) {
   return processCss(fixture, fixture, options);
 };
-test.run();

--- a/packages/cssnano/test/postcss-colormin.js
+++ b/packages/cssnano/test/postcss-colormin.js
@@ -1,0 +1,96 @@
+'use strict';
+const { test } = require('uvu');
+const processCss = require('./_processCss');
+
+test(
+  'should minify color values in background gradients (preset)',
+  processCss(
+    'h1{background:linear-gradient( #ff0000,yellow )}',
+    'h1{background:linear-gradient(red,#ff0)}'
+  )
+);
+
+test(
+  'should minify color values in background gradients (2) (preset)',
+  processCss(
+    'h1{background:linear-gradient(yellow, orange), linear-gradient(black, rgba(255, 255, 255, 0))}',
+    'h1{background:linear-gradient(#ff0,orange),linear-gradient(#000,hsla(0,0%,100%,0))}'
+  )
+);
+
+test(
+  'should minify color values in background gradients (3) (preset)',
+  processCss(
+    'h1{background:linear-gradient(0deg, yellow, black 40%, red)}',
+    'h1{background:linear-gradient(0deg,#ff0,#000 40%,red)}'
+  )
+);
+
+test(
+  'should minify color values (10)',
+  processCss(
+    'h1{text-shadow: 1px 1px 1px #F0FFFF, 1px 1px 1px #F0FFFF}',
+    'h1{text-shadow:1px 1px 1px azure,1px 1px 1px azure}'
+  )
+);
+
+test(
+  'should bail on the "composes" property',
+  processCss.passthrough('h1{composes:black from "styles"}')
+);
+
+test(
+  'should not mangle empty strings',
+  processCss.passthrough('h1{content:""}')
+);
+
+test(
+  'should passthrough css variables',
+  processCss.passthrough('h1{color:var(--foo)}')
+);
+
+test(
+  'should passthrough css variables #2',
+  processCss.passthrough('h1{color:var(--foo) var(--bar)}')
+);
+
+test(
+  'should passthrough css variables #3',
+  processCss.passthrough('h1{color:rgb(var(--foo),255,255)}')
+);
+
+test(
+  'should passthrough css variables #4',
+  processCss.passthrough('h1{color:rgb(255,var(--bar),255)}')
+);
+
+test(
+  'should passthrough css variables #5',
+  processCss.passthrough('h1{color:rgb(255,255,var(--baz))}')
+);
+
+test(
+  'should passthrough css variables #6',
+  processCss.passthrough('h1{color:rgb(var(--foo))}')
+);
+
+test(
+  'should passthrough env function',
+  processCss.passthrough('h1{color:rgb(env(foo))}')
+);
+
+test(
+  'should not minify in lowercase filter properties',
+  processCss.passthrough(
+    'h1{filter:progid:DXImageTransform.Microsoft.gradient(startColorstr= #000000,endColorstr= #ffffff)}'
+  )
+);
+
+test(
+  'should not minify in uppercase filter properties',
+  processCss.passthrough(
+    'h1{FILTER:progid:DXImageTransform.Microsoft.gradient(startColorstr= #000000,endColorstr= #ffffff)}'
+  )
+);
+
+test.run();

--- a/packages/cssnano/test/postcss-minify-font-values.js
+++ b/packages/cssnano/test/postcss-minify-font-values.js
@@ -1,0 +1,35 @@
+'use strict';
+const { test } = require('uvu');
+const processCss = require('./_processCss');
+
+test(
+  'should not escape legal characters',
+  processCss.passthrough('h1{font-family:€42}')
+);
+
+test(
+  'should not join identifiers in the shorthand property',
+  processCss.passthrough('h1{font:italic "Bond 007 008 009",sans-serif}')
+);
+
+test(
+  'should escape special characters if unquoting',
+  processCss('h1{font-family:"Ahem!"}', 'h1{font-family:Ahem\\!}')
+);
+
+test(
+  'should not escape multiple special characters',
+  processCss.passthrough('h1{font-family:"Ahem!!"}')
+);
+
+test(
+  'should not mangle legal unquoted values',
+  processCss.passthrough('h1{font-family:\\$42}')
+);
+
+test(
+  'should not mangle font names',
+  processCss.passthrough('h1{font-family:Glyphicons Halflings}')
+);
+
+test.run();

--- a/packages/cssnano/test/postcss-normalize-whitespace.js
+++ b/packages/cssnano/test/postcss-normalize-whitespace.js
@@ -1,0 +1,13 @@
+'use strict';
+const { test } = require('uvu');
+const processCss = require('./_processCss');
+
+test(
+  'should trim whitespace from nested functions (preset)',
+  processCss(
+    'h1{width:calc(10px - ( 100px / var(--test) ))}',
+    'h1{width:calc(10px - 100px/var(--test))}'
+  )
+);
+
+test.run();

--- a/packages/postcss-colormin/test/index.js
+++ b/packages/postcss-colormin/test/index.js
@@ -5,28 +5,22 @@ const {
   processCSSFactory,
 } = require('../../../util/testHelpers.js');
 
-const {
-  processCSSWithPresetFactory,
-} = require('../../../util/integrationTestHelpers.js');
 const plugin = require('../src/index.js');
-
 const { passthroughCSS, processCSS } = processCSSFactory(plugin);
-const { processCSS: withDefaultPreset, passthroughCSS: passthroughDefault } =
-  processCSSWithPresetFactory('default');
 
 test(
   'should minify lowercase color values',
-  withDefaultPreset('h1{color:yellow}', 'h1{color:#ff0}')
+  processCSS('h1{color:yellow}', 'h1{color:#ff0}')
 );
 
 test(
   'should minify uppercase color values',
-  withDefaultPreset('h1{COLOR:YELLOW}', 'h1{COLOR:#ff0}')
+  processCSS('h1{COLOR:YELLOW}', 'h1{COLOR:#ff0}')
 );
 
 test(
   'should minify color values (2)',
-  withDefaultPreset(
+  processCSS(
     'h1{box-shadow:0 1px 3px rgba(255, 230, 220, 0.5)}',
     'h1{box-shadow:0 1px 3px rgba(255,230,220,.5)}'
   )
@@ -34,15 +28,12 @@ test(
 
 test(
   'should minify color values (3)',
-  withDefaultPreset(
-    'h1{background:hsla(134, 50%, 50%, 1)}',
-    'h1{background:#40bf5e}'
-  )
+  processCSS('h1{background:hsla(134, 50%, 50%, 1)}', 'h1{background:#40bf5e}')
 );
 
 test(
   'should minify color values (4)',
-  withDefaultPreset(
+  processCSS(
     'h1{text-shadow:1px 1px 2px #000000}',
     'h1{text-shadow:1px 1px 2px #000}'
   )
@@ -50,7 +41,7 @@ test(
 
 test(
   'should minify color values (5)',
-  withDefaultPreset(
+  processCSS(
     'h1{text-shadow:1px 1px 2px rgb(255, 255, 255)}',
     'h1{text-shadow:1px 1px 2px #fff}'
   )
@@ -58,7 +49,7 @@ test(
 
 test(
   'should minify color values (6)',
-  withDefaultPreset(
+  processCSS(
     'h1{text-shadow:1px 1px 2px hsl(0,0%,100%)}',
     'h1{text-shadow:1px 1px 2px #fff}'
   )
@@ -66,28 +57,17 @@ test(
 
 test(
   'should minify color values (7)',
-  withDefaultPreset(
-    'h1{background:HSLA(134, 50%, 50%, 1)}',
-    'h1{background:#40bf5e}'
-  )
+  processCSS('h1{background:HSLA(134, 50%, 50%, 1)}', 'h1{background:#40bf5e}')
 );
 
 test(
   'should minify color values (8)',
-  withDefaultPreset('h1{background:#FFFFFF}', 'h1{background:#fff}')
+  processCSS('h1{background:#FFFFFF}', 'h1{background:#fff}')
 );
 
 test(
   'should minify color values (9)',
-  withDefaultPreset('h1{background:#F0FFFF}', 'h1{background:azure}')
-);
-
-test(
-  'should minify color values (10)',
-  withDefaultPreset(
-    'h1{text-shadow: 1px 1px 1px #F0FFFF, 1px 1px 1px #F0FFFF}',
-    'h1{text-shadow:1px 1px 1px azure,1px 1px 1px azure}'
-  )
+  processCSS('h1{background:#F0FFFF}', 'h1{background:azure}')
 );
 
 test(
@@ -107,14 +87,6 @@ test(
 );
 
 test(
-  'should minify color values in background gradients (preset)',
-  withDefaultPreset(
-    'h1{background:linear-gradient( #ff0000,yellow )}',
-    'h1{background:linear-gradient(red,#ff0)}'
-  )
-);
-
-test(
   'should minify color values in background gradients (2)',
   processCSS(
     'h1{background:linear-gradient(yellow, orange), linear-gradient(black, rgba(255, 255, 255, 0))}',
@@ -123,26 +95,10 @@ test(
 );
 
 test(
-  'should minify color values in background gradients (2) (preset)',
-  withDefaultPreset(
-    'h1{background:linear-gradient(yellow, orange), linear-gradient(black, rgba(255, 255, 255, 0))}',
-    'h1{background:linear-gradient(#ff0,orange),linear-gradient(#000,hsla(0,0%,100%,0))}'
-  )
-);
-
-test(
   'should minify color values in background gradients (3)',
   processCSS(
     'h1{background:linear-gradient(0deg, yellow, black 40%, red)}',
     'h1{background:linear-gradient(0deg, #ff0, #000 40%, red)}'
-  )
-);
-
-test(
-  'should minify color values in background gradients (3) (preset)',
-  withDefaultPreset(
-    'h1{background:linear-gradient(0deg, yellow, black 40%, red)}',
-    'h1{background:linear-gradient(0deg,#ff0,#000 40%,red)}'
   )
 );
 
@@ -164,20 +120,6 @@ test(
 test(
   'should not crash on inherit in webkit tap highlight color',
   passthroughCSS('h1{-webkit-tap-highlight-color:inherit}')
-);
-
-test(
-  'should not minify in lowercase filter properties',
-  passthroughDefault(
-    'h1{filter:progid:DXImageTransform.Microsoft.gradient(startColorstr= #000000,endColorstr= #ffffff)}'
-  )
-);
-
-test(
-  'should not minify in uppercase filter properties',
-  passthroughDefault(
-    'h1{FILTER:progid:DXImageTransform.Microsoft.gradient(startColorstr= #000000,endColorstr= #ffffff)}'
-  )
 );
 
 test(
@@ -250,57 +192,15 @@ test(
 
 test(
   'should save extra spaces when converting hex',
-  withDefaultPreset(
+  processCSS(
     'h1{background:#F0FFFF url(bar.png)}',
     'h1{background:azure url(bar.png)}'
   )
 );
 
 test(
-  'should bail on the "composes" property',
-  passthroughDefault('h1{composes:black from "styles"}')
-);
-
-test('should not mangle empty strings', passthroughDefault('h1{content:""}'));
-
-test(
-  'should passthrough css variables',
-  passthroughDefault('h1{color:var(--foo)}')
-);
-
-test(
-  'should passthrough css variables #2',
-  passthroughDefault('h1{color:var(--foo) var(--bar)}')
-);
-
-test(
-  'should passthrough css variables #3',
-  passthroughDefault('h1{color:rgb(var(--foo),255,255)}')
-);
-
-test(
-  'should passthrough css variables #4',
-  passthroughDefault('h1{color:rgb(255,var(--bar),255)}')
-);
-
-test(
-  'should passthrough css variables #5',
-  passthroughDefault('h1{color:rgb(255,255,var(--baz))}')
-);
-
-test(
-  'should passthrough css variables #6',
-  passthroughDefault('h1{color:rgb(var(--foo))}')
-);
-
-test(
   'should passthrough css variables named as a color',
   passthroughCSS('h1{color:var(--white)}')
-);
-
-test(
-  'should passthrough env function',
-  passthroughDefault('h1{color:rgb(env(foo))}')
 );
 
 test('should passthrough broken syntax', passthroughCSS('h1{color:}'));

--- a/packages/postcss-discard-empty/test/index.js
+++ b/packages/postcss-discard-empty/test/index.js
@@ -5,14 +5,9 @@ const {
   usePostCSSPlugin,
   processCSSFactory,
 } = require('../../../util/testHelpers.js');
-const {
-  processCSSWithPresetFactory,
-} = require('../../../util/integrationTestHelpers.js');
 const plugin = require('../src/index.js');
 
-const { passthroughCSS, processor } = processCSSFactory(plugin);
-const { processCSS: withDefaultPreset } =
-  processCSSWithPresetFactory('default');
+const { passthroughCSS, processCSS, processor } = processCSSFactory(plugin);
 
 function testRemovals(fixture, expected, removedSelectors) {
   return () =>
@@ -50,9 +45,9 @@ function testRemovals(fixture, expected, removedSelectors) {
     });
 }
 
-test('should remove empty @ rules', withDefaultPreset('@font-face;', ''));
+test('should remove empty @ rules', processCSS('@font-face;', ''));
 
-test('should remove empty @ rules (2)', withDefaultPreset('@font-face {}', ''));
+test('should remove empty @ rules (2)', processCSS('@font-face {}', ''));
 
 test(
   'should not mangle @ rules with decls',
@@ -64,20 +59,20 @@ test(
   passthroughCSS('@charset "utf-8";')
 );
 
-test('should remove empty rules', withDefaultPreset('h1{}h2{}h4{}h5,h6{}', ''));
+test('should remove empty rules', processCSS('h1{}h2{}h4{}h5,h6{}', ''));
 
-test('should remove empty declarations', withDefaultPreset('h1{color:}', ''));
+test('should remove empty declarations', processCSS('h1{color:}', ''));
 
-test('should remove null selectors', withDefaultPreset('{color:blue}', ''));
+test('should remove null selectors', processCSS('{color:blue}', ''));
 
 test(
   'should remove null selectors in media queries',
-  withDefaultPreset('@media screen, print {{}}', '')
+  processCSS('@media screen, print {{}}', '')
 );
 
 test(
   'should remove empty media queries',
-  withDefaultPreset('@media screen, print {h1,h2{}}', '')
+  processCSS('@media screen, print {h1,h2{}}', '')
 );
 
 test(

--- a/packages/postcss-minify-font-values/test/index.js
+++ b/packages/postcss-minify-font-values/test/index.js
@@ -5,14 +5,8 @@ const {
   processCSSFactory,
 } = require('../../../util/testHelpers.js');
 
-const {
-  processCSSWithPresetFactory,
-} = require('../../../util/integrationTestHelpers.js');
 const plugin = require('../src/index.js');
-
 const { passthroughCSS, processCSS } = processCSSFactory(plugin);
-const { processCSS: withDefaultPreset, passthroughCSS: passthroughDefault } =
-  processCSSWithPresetFactory('default');
 
 test(
   'should not unquote font names with a leading number',
@@ -255,36 +249,6 @@ test(
 test(
   'should unquote multiple escape `[` characters',
   passthroughCSS('h1{font-family:"STHeiti Light [STXihei]"}')
-);
-
-test(
-  'should not escape legal characters',
-  passthroughDefault('h1{font-family:€42}')
-);
-
-test(
-  'should not join identifiers in the shorthand property',
-  passthroughDefault('h1{font:italic "Bond 007 008 009",sans-serif}')
-);
-
-test(
-  'should escape special characters if unquoting',
-  withDefaultPreset('h1{font-family:"Ahem!"}', 'h1{font-family:Ahem\\!}')
-);
-
-test(
-  'should not escape multiple special characters',
-  passthroughDefault('h1{font-family:"Ahem!!"}')
-);
-
-test(
-  'should not mangle legal unquoted values',
-  passthroughDefault('h1{font-family:\\$42}')
-);
-
-test(
-  'should not mangle font names',
-  passthroughDefault('h1{font-family:Glyphicons Halflings}')
 );
 
 test(

--- a/packages/postcss-normalize-whitespace/test/index.js
+++ b/packages/postcss-normalize-whitespace/test/index.js
@@ -1,14 +1,9 @@
 'use strict';
 const { test } = require('uvu');
 const { processCSSFactory } = require('../../../util/testHelpers.js');
-const {
-  processCSSWithPresetFactory,
-} = require('../../../util/integrationTestHelpers.js');
 const plugin = require('../src/index.js');
 
 const { processCSS } = processCSSFactory(plugin);
-const { processCSS: withDefaultPreset } =
-  processCSSWithPresetFactory('default');
 
 test(
   'should trim whitespace from nested functions',
@@ -47,14 +42,6 @@ test(
   processCSS(
     'h1{width:var(--foo, calc(10px * 10px))}',
     'h1{width:var(--foo,calc(10px * 10px))}'
-  )
-);
-
-test(
-  'should trim whitespace from nested functions (preset)',
-  withDefaultPreset(
-    'h1{width:calc(10px - ( 100px / var(--test) ))}',
-    'h1{width:calc(10px - 100px/var(--test))}'
   )
 );
 


### PR DESCRIPTION
Most tests that exercise the default preset as a whole were in the
cssnano directory, but some were mixed with the individual plugin tests.

* To distinguish the effect of each individual plugin, move all
remaining integration tests in the cssnano test directory.

* Convert tests that only check the effect of a single plugin,
to only use that plugin.

This will make it easier to experiment with merging plugins.

The number of tests stays the same. There are 2383 tests before and after the change.