### PR TITLE
refactor: extract CSS variable indentifiers

### DIFF
--- a/packages/postcss-normalize-positions/src/index.js
+++ b/packages/postcss-normalize-positions/src/index.js
@@ -13,7 +13,7 @@ const verticalValue = new Map([
   ['top', '0'],
 ]);
 const mathFunctions = new Set(['calc', 'min', 'max', 'clamp']);
-
+const variableFunctions = new Set(['var', 'env', 'constant']);
 /**
  * @param {valueParser.Node} node
  * @return {boolean}
@@ -31,7 +31,7 @@ function isVariableFunctionNode(node) {
     return false;
   }
 
-  return ['var', 'env'].includes(node.value.toLowerCase());
+  return variableFunctions.has(node.value.toLowerCase());
 }
 
 /**

--- a/packages/postcss-normalize-positions/test/index.js
+++ b/packages/postcss-normalize-positions/test/index.js
@@ -231,6 +231,11 @@ test(
 );
 
 test(
+  'should pass through with constant',
+  passthroughCSS('background-position: constant(--foo)')
+);
+
+test(
   'should normalize when property in uppercase',
   processCSS('BACKGROUND-POSITION: center', 'BACKGROUND-POSITION: 50%')
 );

--- a/packages/postcss-normalize-repeat-style/src/index.js
+++ b/packages/postcss-normalize-repeat-style/src/index.js
@@ -21,6 +21,7 @@ function isCommaNode(node) {
   return node.type === 'div' && node.value === ',';
 }
 
+const variableFunctions = new Set(['var', 'env', 'constant']);
 /**
  * @param {valueParser.Node} node
  * @return {boolean}
@@ -30,7 +31,7 @@ function isVariableFunctionNode(node) {
     return false;
   }
 
-  return ['var', 'env'].includes(node.value.toLowerCase());
+  return variableFunctions.has(node.value.toLowerCase());
 }
 
 /**

--- a/packages/postcss-normalize-repeat-style/test/index.js
+++ b/packages/postcss-normalize-repeat-style/test/index.js
@@ -106,6 +106,11 @@ test(
 );
 
 test(
+  'should pass through with constant',
+  passthroughCSS('background-position: constant(--foo)')
+);
+
+test(
   'should normalize background position with var and multiple background',
   processCSS(
     'background: url("/media/examples/lizard.png") repeat no-repeat, url("/media/examples/lizard.png") var(--foo)',

--- a/packages/postcss-ordered-values/src/index.js
+++ b/packages/postcss-ordered-values/src/index.js
@@ -63,6 +63,8 @@ const rules = new Map([
   ...columnRules,
 ]);
 
+const variableFunctions = new Set(['var', 'env', 'constant']);
+
 /**
  * @param {valueParser.Node} node
  * @return {boolean}
@@ -72,7 +74,7 @@ function isVariableFunctionNode(node) {
     return false;
   }
 
-  return ['var', 'env', 'constant'].includes(node.value.toLowerCase());
+  return variableFunctions.has(node.value.toLowerCase());
 }
 
 /**


### PR DESCRIPTION
* refactor: use the same variable functions definition everywhere
* refactor(postcss-ordered-values): extract variable functions set