### PR TITLE
Bump svgo to v2.8.0

### DIFF
--- a/packages/postcss-svgo/package.json
+++ b/packages/postcss-svgo/package.json
@@ -28,7 +28,7 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "postcss-value-parser": "^4.2.0",
-    "svgo": "^2.7.0"
+    "svgo": "^2.8.0"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"


### PR DESCRIPTION
svgo@2.7.0 transitively fetches nth-check@2.0.0 which contains security issue as per npm audit. 
Need to bump svgo@2.8.0 to fetch nth-check@2.1.1.