### PR TITLE
fix(postcss-merge-longhand): preserve hyphenated custom property case

### DIFF
--- a/packages/postcss-merge-longhand/src/lib/parseWsc.js
+++ b/packages/postcss-merge-longhand/src/lib/parseWsc.js
@@ -6,7 +6,7 @@ const none = /^\s*(none|medium)(\s+none(\s+(none|currentcolor))?)?\s*$/i;
 
 /* Approximate https://drafts.csswg.org/css-values-4/#typedef-dashed-ident */
 // eslint-disable-next-line no-control-regex
-const varRE = /--(\w|[^\x00-\x7F])+/g;
+const varRE = /--(\w|-|[^\x00-\x7F])+/g;
 /** @type {(v: string) => string} */
 const toLower = (v) => {
   let match;

--- a/packages/postcss-merge-longhand/test/borders.js
+++ b/packages/postcss-merge-longhand/test/borders.js
@@ -1196,6 +1196,11 @@ test(
 );
 
 test(
+  'Should preserve case of css custom property names with hyphens',
+  passthroughCSS('h1 { border: 1px solid rgba(var(--colors-secondaryColor)); }')
+);
+
+test(
   'Should preserve case of css custom properties example 2',
   processCSS(
     'h1 {border:solid 2px var(--buttonBorderColor, var(--buttonBaseColor, #000));}',


### PR DESCRIPTION
### Summary

Extends the regex that is used to locate custom properties inside a
value so that their case is preserved to also preserve the case of
custom property names that contain hyphen-minus characters.

For example, the case of the custom property in the following rule
should be preserved:

```css
border: 1px solid rgba(var(--colors-secondaryColor));
```

### Motivation

In our projects, we use CSS custom property names with hyphen-minus characters. These custom property names were lowercased via `postcss-merge-longhand` when minifying for production. Since hyphen-minus characters are valid in CSS custom property names, I think they should be allowed in the corresponding regex so that the case of hyphenated custom properties is preserved.

### Does this pull request introduce a breaking change?

- [ ] Yes
- [x] No

### Checklist

- [x] I have followed the [conventional commits](https://www.conventionalcommits.org/) standard for my commit messages
- [x] I have read the [contributing guidelines](https://github.com/cssnano/cssnano/blob/master/CONTRIBUTING.md)
- [x] I have searched/checked for existing issues and PRs

### Documentation
Please check if any of these apply:

- [ ] My proposed change require an update to the documentation
- [ ] I have added or updated the relevant documentation
