### PR TITLE
Fix `cssnanoPlugin` type to return Processor not Plugin

### DIFF
--- a/packages/cssnano/src/index.js
+++ b/packages/cssnano/src/index.js
@@ -125,7 +125,7 @@ function resolveConfig(options) {
 /**
  * @type {import('postcss').PluginCreator<Options>}
  * @param {Options=} options
- * @return {import('postcss').Plugin}
+ * @return {import('postcss').Processor}
  */
 function cssnanoPlugin(options = {}) {
   if (Array.isArray(options.plugins)) {

--- a/packages/cssnano/types/index.d.ts
+++ b/packages/cssnano/types/index.d.ts
@@ -2,9 +2,9 @@ export = cssnanoPlugin;
 /**
  * @type {import('postcss').PluginCreator<Options>}
  * @param {Options=} options
- * @return {import('postcss').Plugin}
+ * @return {import('postcss').Processor}
  */
-declare function cssnanoPlugin(options?: Options | undefined): import('postcss').Plugin;
+declare function cssnanoPlugin(options?: Options | undefined): import('postcss').Processor;
 declare namespace cssnanoPlugin {
     export { postcss, Options };
 }


### PR DESCRIPTION
Invoking `postcss` gives you a Processor, not a Plugin.