### PR TITLE
Publish cssnano 5.1.13

### DIFF
--- a/packages/cssnano/CHANGELOG.md
+++ b/packages/cssnano/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.1.13
+
+### Patch Changes
+
+- fix(cssnano): correct return type of cssnano() call
+
 ## 5.1.12
 
 ### Patch Changes

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cssnano",
-    "version": "5.1.12",
+    "version": "5.1.13",
     "description": "A modular minifier, built on top of the PostCSS ecosystem.",
     "main": "src/index.js",
     "types": "types/index.d.ts",


### PR DESCRIPTION
Release the fix for https://github.com/cssnano/cssnano/pull/1425 to make it possible to call `cssnano.process()` in TypeScript. 