### PR TITLE
fix(postcss-reduce-initial): fix mask-repeat conversion

### DIFF
--- a/packages/postcss-reduce-initial/src/data/toInitial.json
+++ b/packages/postcss-reduce-initial/src/data/toInitial.json
@@ -22,7 +22,6 @@
   "mask-clip": "border-box",
   "mask-mode": "match-source",
   "mask-origin": "border-box",
-  "mask-repeat": "no-repeat",
   "mask-type": "luminance",
   "ruby-align": "space-around",
   "ruby-merge": "separate",

--- a/packages/postcss-reduce-initial/test/index.js
+++ b/packages/postcss-reduce-initial/test/index.js
@@ -104,7 +104,7 @@ test(
    but MDN has the wrong data so  */
 test(
   'preserve no-repeat mask-repeat',
-  passthroughCSS('div{mask-repeat:no-repeat}')
+  passthroughCSS('div{mask-repeat:no-repeat}', { env: 'chrome58' })
 );
 
 test(


### PR DESCRIPTION
Fix mask-repeat initial value and fix test that did not catch the issue because the default browserslist query includes opera mini which does not support initial.

Fix #1452