### PR TITLE
fix(postcss-colormin): don't minify colors in `src` declarations

### DIFF
--- a/packages/postcss-colormin/src/index.js
+++ b/packages/postcss-colormin/src/index.js
@@ -123,7 +123,7 @@ function pluginCreator(config = {}) {
         OnceExit(css) {
           css.walkDecls((decl) => {
             if (
-              /^(composes|font|filter|-webkit-tap-highlight-color)/i.test(
+              /^(composes|font|src$|filter|-webkit-tap-highlight-color)/i.test(
                 decl.prop
               )
             ) {

--- a/packages/postcss-colormin/test/index.js
+++ b/packages/postcss-colormin/test/index.js
@@ -245,4 +245,10 @@ test(
     env: 'chrome62',
   })
 );
+
+test(
+  'should not attempt to convert font names',
+  passthroughCSS('@font-face{src:local(Noto Sans Black)}')
+);
+
 test.run();


### PR DESCRIPTION
I skimmed through all [CSS properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference#index) related to `@font-face` and it looks like only [`src`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src) is impacted by this bug.

Fixes #1463