### PR TITLE
test: remove Node.js 10 and 12 from CI

### DIFF
--- a/.changeset/forty-hornets-lie.md
+++ b/.changeset/forty-hornets-lie.md
@@ -1,0 +1,6 @@
+---
+'cssnano-preset-advanced': major
+'cssnano-preset-default': major
+---
+
+chore: bump node versions for packages depending on svgo

--- a/.changeset/red-bottles-rhyme.md
+++ b/.changeset/red-bottles-rhyme.md
@@ -1,0 +1,40 @@
+---
+'postcss-normalize-timing-functions': major
+'postcss-normalize-display-values': major
+'postcss-normalize-repeat-style': major
+'postcss-normalize-whitespace': major
+'postcss-normalize-positions': major
+'postcss-discard-duplicates': major
+'postcss-discard-overridden': major
+'postcss-minify-font-values': major
+'postcss-normalize-charset': major
+'postcss-normalize-unicode': major
+'postcss-reduce-transforms': major
+'postcss-discard-comments': major
+'postcss-minify-gradients': major
+'postcss-minify-selectors': major
+'postcss-normalize-string': major
+'postcss-unique-selectors': major
+'cssnano-preset-advanced': major
+'cssnano-preset-default': major
+'postcss-convert-values': major
+'postcss-discard-unused': major
+'postcss-merge-longhand': major
+'postcss-ordered-values': major
+'postcss-reduce-initial': major
+'postcss-discard-empty': major
+'postcss-minify-params': major
+'postcss-normalize-url': major
+'postcss-reduce-idents': major
+'postcss-merge-idents': major
+'cssnano-preset-lite': major
+'postcss-merge-rules': major
+'postcss-colormin': major
+'postcss-zindex': major
+'cssnano-utils': major
+'stylehacks': major
+'css-size': major
+'cssnano': major
+---
+
+Switch minimum supported Node version to 14 for all packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3.3.0
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.3
+        uses: pnpm/action-setup@v2.2.4
         with:
-          version: 6.32.18
+          version: 7.29.1
       - name: Install Node.js 16.x
-        uses: actions/setup-node@v3.5.0
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: '16'
           cache: 'pnpm'
@@ -32,13 +32,13 @@ jobs:
   test_helpers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3.3.0
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.3
+        uses: pnpm/action-setup@v2.2.4
         with:
-          version: 6.32.18
+          version: 7.29.1
       - name: Install Node.js 16.x
-        uses: actions/setup-node@v3.5.0
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: '16'
           cache: 'pnpm'
@@ -55,40 +55,25 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node-version: ['10', '12', '14', '16', '18']
+        node-version: ['14', '16', '18', '19']
 
     steps:
       - name: Setup Git
         if: matrix.os == 'windows-latest'
         run: git config --global core.autocrlf input
 
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3.3.0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.3
-        if: matrix.node-version != '10'
+        uses: pnpm/action-setup@v2.2.4
         with:
-          version: 6.32.18
+          version: 7.29.1
 
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3.5.0
-        if: matrix.node-version != '10'
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
-
-      - name: Install old pnpm
-        uses: pnpm/action-setup@v2.2.3
-        if: matrix.node-version == '10'
-        with:
-          version: 5.18.4
-
-      # No cache support on GH actions for old pnpm
-      - name: Install Node.js without cache ${{ matrix.node-version }}
-        uses: actions/setup-node@v3.5.0
-        if: matrix.node-version == '10'
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/packages/css-size/package.json
+++ b/packages/css-size/package.json
@@ -41,6 +41,6 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   }
 }

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -52,7 +52,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/cssnano-preset-lite/package.json
+++ b/packages/cssnano-preset-lite/package.json
@@ -23,7 +23,7 @@
         "url": "https://github.com/cssnano/cssnano/issues"
     },
     "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
     },
     "devDependencies": {
         "postcss": "^8.2.15"

--- a/packages/cssnano-utils/package.json
+++ b/packages/cssnano-utils/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "files": [
     "src",

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -38,7 +38,7 @@
         "url": "https://github.com/cssnano/cssnano/issues"
     },
     "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
     },
     "devDependencies": {
         "autoprefixer": "^10.4.12",

--- a/packages/postcss-colormin/package.json
+++ b/packages/postcss-colormin/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "@types/caniuse-api": "^3.0.2",

--- a/packages/postcss-convert-values/package.json
+++ b/packages/postcss-convert-values/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-discard-comments/package.json
+++ b/packages/postcss-discard-comments/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-discard-duplicates/package.json
+++ b/packages/postcss-discard-duplicates/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-discard-empty/package.json
+++ b/packages/postcss-discard-empty/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-discard-overridden/package.json
+++ b/packages/postcss-discard-overridden/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-discard-unused/package.json
+++ b/packages/postcss-discard-unused/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-merge-idents/package.json
+++ b/packages/postcss-merge-idents/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-merge-longhand/package.json
+++ b/packages/postcss-merge-longhand/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-merge-rules/package.json
+++ b/packages/postcss-merge-rules/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "@types/caniuse-api": "^3.0.2",

--- a/packages/postcss-minify-font-values/package.json
+++ b/packages/postcss-minify-font-values/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-minify-gradients/package.json
+++ b/packages/postcss-minify-gradients/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-minify-params/package.json
+++ b/packages/postcss-minify-params/package.json
@@ -30,7 +30,7 @@
     "postcss-value-parser": "^4.2.0"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-minify-selectors/package.json
+++ b/packages/postcss-minify-selectors/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-normalize-charset/package.json
+++ b/packages/postcss-normalize-charset/package.json
@@ -23,7 +23,7 @@
   "main": "src/index.js",
   "types": "types/index.d.ts",
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-normalize-display-values/package.json
+++ b/packages/postcss-normalize-display-values/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-normalize-positions/package.json
+++ b/packages/postcss-normalize-positions/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-normalize-repeat-style/package.json
+++ b/packages/postcss-normalize-repeat-style/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-normalize-string/package.json
+++ b/packages/postcss-normalize-string/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-normalize-timing-functions/package.json
+++ b/packages/postcss-normalize-timing-functions/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/cssnano/cssnano",
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-normalize-unicode/package.json
+++ b/packages/postcss-normalize-unicode/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-normalize-url/package.json
+++ b/packages/postcss-normalize-url/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-normalize-whitespace/package.json
+++ b/packages/postcss-normalize-whitespace/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-ordered-values/package.json
+++ b/packages/postcss-ordered-values/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-reduce-idents/package.json
+++ b/packages/postcss-reduce-idents/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-reduce-initial/package.json
+++ b/packages/postcss-reduce-initial/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "@types/caniuse-api": "^3.0.2",

--- a/packages/postcss-reduce-transforms/package.json
+++ b/packages/postcss-reduce-transforms/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-unique-selectors/package.json
+++ b/packages/postcss-unique-selectors/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-zindex/package.json
+++ b/packages/postcss-zindex/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"

--- a/packages/stylehacks/package.json
+++ b/packages/stylehacks/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
     "postcss": "^8.2.15"


### PR DESCRIPTION
Remove unmaintained Node.js from CI. As we're not testing against Node.js 10 and 12 I think we need to bump the minimal supported Node version on all packages, because we cannot guarantee that we won't introduce an incompatibility in the future.