### PR TITLE
test: update integration test deps

### DIFF
--- a/example-cli-usage/package.json
+++ b/example-cli-usage/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "cssnano": "^5.0.3",
     "postcss": "^8.4.4",
-    "postcss-cli": "^8.3.0"
+    "postcss-cli": "^10.1.0"
   },
   "scripts": {
     "minify": "postcss input.css > output.css"
@@ -15,7 +15,7 @@
     "url": "https://github.com/cssnano/cssnano/issues"
   },
   "engines": {
-    "node": "^10 || ^12 || >=14.0"
+    "node": "^14 || ^16 || >=18.0"
   },
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "postcss-value-parser": "^4.2.0",
     "prettier": "^2.8.4",
     "typescript": "^4.8.4",
-    "uvu": "0.5.5"
+    "uvu": "^0.5.6"
   },
   "browserslist": {
     "production": ["IE 11 and last 2 versions"],

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "./packages/*"
   ],
   "engines": {
-    "node": "^10 || ^12 || >=14"
+    "node": "^14 || ^16 || >=18"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.0",
@@ -31,8 +31,6 @@
     "pleeease-filters": "^4.0.0",
     "postcss": "^8.4.21",
     "postcss-font-magician": "^3.0.0",
-    "postcss-scss": "^3.0.4",
-    "postcss-simple-vars": "^6.0.1",
     "postcss-value-parser": "^4.2.0",
     "prettier": "^2.8.4",
     "typescript": "^4.8.4",

--- a/packages/postcss-discard-comments/package.json
+++ b/packages/postcss-discard-comments/package.json
@@ -30,7 +30,9 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.2.15"
+    "postcss": "^8.2.15",
+    "postcss-simple-vars": "^7.0.1",
+    "postcss-scss": "^4.0.6"
   },
   "peerDependencies": {
     "postcss": "^8.2.15"

--- a/packages/postcss-merge-rules/package.json
+++ b/packages/postcss-merge-rules/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@types/caniuse-api": "^3.0.2",
     "postcss": "^8.2.15",
+    "postcss-simple-vars": "^7.0.1",
     "postcss-discard-comments": "workspace:^"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
       postcss-value-parser: ^4.2.0
       prettier: ^2.8.4
       typescript: ^4.8.4
-      uvu: 0.5.5
+      uvu: ^0.5.6
     devDependencies:
       '@changesets/cli': 2.26.0
       '@types/node': 18.15.0
@@ -34,7 +34,7 @@ importers:
       postcss-value-parser: 4.2.0
       prettier: 2.8.4
       typescript: 4.8.4
-      uvu: 0.5.5
+      uvu: 0.5.6
 
   packages/css-size:
     specifiers:
@@ -3247,8 +3247,8 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: false
 
-  /uvu/0.5.5:
-    resolution: {integrity: sha512-J3SlxDp1MnHkqYvxnz4geS4jYWd2dXcNMltFWYmuiMpe+q1XOyXXaZb0qiO90o1xEhMWNuvnzqoXrDxbYYQjDQ==}
+  /uvu/0.5.6:
+    resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
     engines: {node: '>=8'}
     hasBin: true
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,6 @@ importers:
       pleeease-filters: ^4.0.0
       postcss: ^8.4.21
       postcss-font-magician: ^3.0.0
-      postcss-scss: ^3.0.4
-      postcss-simple-vars: ^6.0.1
       postcss-value-parser: ^4.2.0
       prettier: ^2.8.4
       typescript: ^4.8.4
@@ -33,8 +31,6 @@ importers:
       pleeease-filters: 4.0.0
       postcss: 8.4.21
       postcss-font-magician: 3.0.0_postcss@8.4.21
-      postcss-scss: 3.0.5
-      postcss-simple-vars: 6.0.3_postcss@8.4.21
       postcss-value-parser: 4.2.0
       prettier: 2.8.4
       typescript: 4.8.4
@@ -204,8 +200,12 @@ importers:
   packages/postcss-discard-comments:
     specifiers:
       postcss: ^8.2.15
+      postcss-scss: ^4.0.6
+      postcss-simple-vars: ^7.0.1
     devDependencies:
       postcss: 8.4.21
+      postcss-scss: 4.0.6_postcss@8.4.21
+      postcss-simple-vars: 7.0.1_postcss@8.4.21
 
   packages/postcss-discard-duplicates:
     specifiers:
@@ -265,6 +265,7 @@ importers:
       postcss: ^8.2.15
       postcss-discard-comments: workspace:^
       postcss-selector-parser: ^6.0.5
+      postcss-simple-vars: ^7.0.1
     dependencies:
       browserslist: 4.21.5
       caniuse-api: 3.0.0
@@ -274,6 +275,7 @@ importers:
       '@types/caniuse-api': 3.0.2
       postcss: 8.4.21
       postcss-discard-comments: link:../postcss-discard-comments
+      postcss-simple-vars: 7.0.1_postcss@8.4.21
 
   packages/postcss-minify-font-values:
     specifiers:
@@ -2676,9 +2678,11 @@ packages:
       postcss: 8.4.21
     dev: true
 
-  /postcss-scss/3.0.5:
-    resolution: {integrity: sha512-3e0qYk87eczfzg5P73ZVuuxEGCBfatRhPze6KrSaIbEKVtmnFI1RYp1Fv+AyZi+w8kcNRSPeNX6ap4b65zEkiA==}
-    engines: {node: '>=10.0'}
+  /postcss-scss/4.0.6_postcss@8.4.21:
+    resolution: {integrity: sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.4.19
     dependencies:
       postcss: 8.4.21
     dev: true
@@ -2691,9 +2695,9 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /postcss-simple-vars/6.0.3_postcss@8.4.21:
-    resolution: {integrity: sha512-fkNn4Zio8vN4vIig9IFdb8lVlxWnYR769RgvxCM6YWlFKie/nQaOcaMMMFz/s4gsfHW4/5bJW+i57zD67mQU7g==}
-    engines: {node: '>=10.0'}
+  /postcss-simple-vars/7.0.1_postcss@8.4.21:
+    resolution: {integrity: sha512-5GLLXaS8qmzHMOjVxqkk1TZPf1jMqesiI7qLhnlyERalG0sMbHIbJqrcnrpmZdKCLglHnRHoEBB61RtGTsj++A==}
+    engines: {node: '>=14.0'}
     peerDependencies:
       postcss: ^8.2.1
     dependencies:


### PR DESCRIPTION
Update the dependencies used in the integration tests to the latest version which do not support Node.js 10 and 12.
Update the example CLI project to the latest postcss-cli version.