### PR TITLE
fix(postcss-reduce-initial): ensure options are always read

### DIFF
--- a/packages/cssnano/test/presets.js
+++ b/packages/cssnano/test/presets.js
@@ -106,6 +106,20 @@ test('should be able to exclude plugins (exclude syntax)', () => {
     });
 });
 
+test('should be able to exclude pointer-events plugin', () => {
+  return cssnano({
+    preset: [
+      'default',
+      {
+        reduceInitial: { ignore: ['pointer-events'] },
+      },
+    ],
+  })
+    .process('.selector { pointer-events: initial; }', { from: undefined })
+    .then((result) => {
+      assert.is(result.css, '.selector{pointer-events:initial}');
+    });
+});
 test('should error on a bad preset', async () => {
   try {
     await postcss([cssnano({ preset: 'avanced' })])

--- a/packages/postcss-reduce-initial/src/index.js
+++ b/packages/postcss-reduce-initial/src/index.js
@@ -8,12 +8,14 @@ const initial = 'initial';
 
 // In most of the browser including chrome the initial for `writing-mode` is not `horizontal-tb`. Ref https://github.com/cssnano/cssnano/pull/905
 const defaultIgnoreProps = ['writing-mode', 'transform-box'];
+/** @typedef {{ignore?: string[]}} Options */
 
 /**
- * @type {import('postcss').PluginCreator<void>}
+ * @type {import('postcss').PluginCreator<Options>}
+ * @param {Options} options
  * @return {import('postcss').Plugin}
  */
-function pluginCreator() {
+function pluginCreator(options = {}) {
   return {
     postcssPlugin: 'postcss-reduce-initial',
     /** @param {import('postcss').Result & {opts: browserslist.Options & {ignore?: string[]}}} result */
@@ -31,7 +33,7 @@ function pluginCreator() {
           css.walkDecls((decl) => {
             const lowerCasedProp = decl.prop.toLowerCase();
             const ignoreProp = new Set(
-              defaultIgnoreProps.concat(resultOpts.ignore || [])
+              defaultIgnoreProps.concat(options.ignore || [])
             );
 
             if (ignoreProp.has(lowerCasedProp)) {

--- a/packages/postcss-reduce-initial/types/index.d.ts
+++ b/packages/postcss-reduce-initial/types/index.d.ts
@@ -1,9 +1,15 @@
 export = pluginCreator;
+/** @typedef {{ignore?: string[]}} Options */
 /**
- * @type {import('postcss').PluginCreator<void>}
+ * @type {import('postcss').PluginCreator<Options>}
+ * @param {Options} options
  * @return {import('postcss').Plugin}
  */
-declare function pluginCreator(): import('postcss').Plugin;
+declare function pluginCreator(options?: Options): import('postcss').Plugin;
 declare namespace pluginCreator {
-    const postcss: true;
+    export { postcss, Options };
 }
+type Options = {
+    ignore?: string[];
+};
+declare var postcss: true;


### PR DESCRIPTION
Fix #1436

Ensure options are read also when the plugin is configured in cssnano instead as a standalone PostCSS plugin.