### PR TITLE
fix(postcss-merge-rules): preserve container queries

### DIFF
--- a/packages/postcss-merge-rules/src/index.js
+++ b/packages/postcss-merge-rules/src/index.js
@@ -84,9 +84,19 @@ function canMerge(ruleA, ruleB, browsers, compatibilityCache) {
   ) {
     return false;
   }
+  if (ruleA.some(isRuleOrAtRule) || ruleB.some(isRuleOrAtRule)) {
+    return false;
+  }
   return parent && (selectors.every(noVendor) || sameVendor(a, b));
 }
 
+/**
+ * @param {import('postcss').ChildNode} node
+ * @return {boolean}
+ */
+function isRuleOrAtRule(node) {
+  return node.type === 'rule' || node.type === 'atrule';
+}
 /**
  * @param {import('postcss').ChildNode} node
  * @return {node is import('postcss').Declaration}

--- a/packages/postcss-merge-rules/test/index.js
+++ b/packages/postcss-merge-rules/test/index.js
@@ -151,6 +151,22 @@ test(
 );
 
 test(
+  'should not merge across container queries',
+  passthroughCSS(
+    `@container (min-width: 200px) {
+  .mobile {
+     display: none;
+  }
+}
+@container (max-width: 100px) {
+  .notMobile {
+     display: none;
+  }
+}`
+  )
+);
+
+test(
   'should perform partial merging of selectors',
   processCSS(
     'h1{color:red}h2{color:red;text-decoration:underline}',
@@ -843,4 +859,5 @@ test(
     'h1{color:#001;color:#002;color:#003}h2{color:#001;color:#002}'
   )
 );
+
 test.run();

--- a/packages/postcss-merge-rules/test/index.js
+++ b/packages/postcss-merge-rules/test/index.js
@@ -860,4 +860,25 @@ test(
   )
 );
 
+test(
+  'should not merge nested rules',
+  passthroughCSS('h1 { .a { color: red; } } h1 { .b { color: red; } }')
+);
+
+test(
+  'should not merge nested container rules',
+  passthroughCSS(
+    `.mobile {
+  @container (min-width: 200px) {
+     display: none;
+  }
+}
+
+.notMobile {
+  @container (max-width: 100px) {
+     display: none;
+  }
+}`
+  )
+);
 test.run();


### PR DESCRIPTION
Add a test for #1489 and ensure container queries do not get merged incorrectly.