### PR TITLE
chore: replace Node.js 19 with Node.js 20 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.2
       - name: Install pnpm
         uses: pnpm/action-setup@v2.2.4
         with:
-          version: 7.29.1
-      - name: Install Node.js 16.x
+          version: 7.32.2
+      - name: Install Node.js 18.x
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -32,15 +32,15 @@ jobs:
   test_helpers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.2
       - name: Install pnpm
         uses: pnpm/action-setup@v2.2.4
         with:
-          version: 7.29.1
-      - name: Install Node.js 16.x
+          version: 7.32.2
+      - name: Install Node.js 18.x
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -55,19 +55,19 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node-version: ['14', '16', '18', '19']
+        node-version: ['14', '16', '18', '20']
 
     steps:
       - name: Setup Git
         if: matrix.os == 'windows-latest'
         run: git config --global core.autocrlf input
 
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.2
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2.2.4
         with:
-          version: 7.29.1
+          version: 7.32.2
 
       - name: Install Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3.6.0


### PR DESCRIPTION
Since Nodee 19 support will stop on June 1. Also update action and npm version.