### PR TITLE
fix(cssnano-preset-default): update css-declaration-sorter

### DIFF
--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "css-declaration-sorter": "^6.3.1",
+    "css-declaration-sorter": "^7.0.0",
     "cssnano-utils": "workspace:^",
     "postcss-calc": "^9.0.1",
     "postcss-colormin": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,8 @@ importers:
   packages/cssnano-preset-default:
     dependencies:
       css-declaration-sorter:
-        specifier: ^6.3.1
-        version: 6.3.1(postcss@8.4.21)
+        specifier: ^7.0.0
+        version: 7.0.0(postcss@8.4.21)
       cssnano-utils:
         specifier: workspace:^
         version: link:../cssnano-utils
@@ -1315,9 +1315,9 @@ packages:
       which: 2.0.2
     dev: true
 
-  /css-declaration-sorter@6.3.1(postcss@8.4.21):
-    resolution: {integrity: sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==}
-    engines: {node: ^10 || ^12 || >=14}
+  /css-declaration-sorter@7.0.0(postcss@8.4.21):
+    resolution: {integrity: sha512-jV48Uxg3jWGLthtZhYAH3JFWMjdurJrSQAgWCc/t2ZE0UUFAIWlgcXcLJNutZT8GXrLAr36Kp+O1w3yBdxCr/A==}
+    engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
     dependencies:


### PR DESCRIPTION
The major bump in css-declaration-sorter is because of dropping support for Node < 14, so it non-breaking for cssnano.

Fix #1502