### PR TITLE
fix: replace lookbehind in regex for safari support

### DIFF
--- a/packages/postcss-normalize-url/src/normalize.js
+++ b/packages/postcss-normalize-url/src/normalize.js
@@ -113,8 +113,10 @@ function normalizeUrl(urlString) {
   // Remove duplicate slashes if not preceded by a protocol
   if (urlObject.pathname) {
     urlObject.pathname = urlObject.pathname.replace(
-      /(?<!\b[a-z][a-z\d+\-.]{1,50}:)\/{2,}/g,
-      '/'
+      /(\b[a-z][a-z\d+\-.]{1,50}:)?\/{2,}/g,
+      function (match, protocol) {
+        return protocol ? match : '/';
+      }
     );
   }
 


### PR DESCRIPTION
Lookbehind assertions are not supported in Safari, so we need to modify the regular expression to achieve the same result without using lookbehind. The alternative approach uses capturing groups and backreferences.

