### PR TITLE
fix: prevent mangling of 'named timeline range names and percentages' in keyframe selectors

### DIFF
--- a/packages/postcss-minify-selectors/src/index.js
+++ b/packages/postcss-minify-selectors/src/index.js
@@ -163,7 +163,7 @@ const tagReplacements = new Map([
 function tag(selector) {
   const value = selector.value.toLowerCase();
 
-  if (tagReplacements.has(value)) {
+  if (tagReplacements.has(value) && selector.parent && selector.parent.nodes.length === 1) {
     selector.value = /** @type {string} */ (tagReplacements.get(value));
   }
 }

--- a/packages/postcss-minify-selectors/src/index.js
+++ b/packages/postcss-minify-selectors/src/index.js
@@ -163,7 +163,14 @@ const tagReplacements = new Map([
 function tag(selector) {
   const value = selector.value.toLowerCase();
 
-  if (tagReplacements.has(value) && selector.parent && selector.parent.nodes.length === 1) {
+  const isSimple = selector.parent && selector.parent.nodes.length === 1;
+  // Avoid simplifying complex selectors (`entry 100% {...}`)
+  if (!isSimple) {
+    return;
+  }
+
+  // Simplify simple selectors that have replacements (`100% {...}`)
+  if (tagReplacements.has(value)) {
     selector.value = /** @type {string} */ (tagReplacements.get(value));
   }
 }

--- a/packages/postcss-minify-selectors/test/index.js
+++ b/packages/postcss-minify-selectors/test/index.js
@@ -208,6 +208,11 @@ test(
 );
 
 test(
+  'should not mangle @keyframe 100% in named timeline range names and percentages',
+  passthroughCSS('@keyframes test{entry 100%{color:red}}')
+);
+
+test(
   'should not be responsible for normalising comments',
   processCSS(
     'h1 /*!test comment*/, h2{color:blue}',


### PR DESCRIPTION
This PR fixes an issue reported in https://github.com/cssnano/cssnano/issues/1460

Keyframe selectors from scroll-driven animations ([named timeline range name and percentage](https://www.w3.org/TR/scroll-animations-1/#named-range-keyframes)) are mangled by replacing `100%` with `to` in keyframe selectors where it is not valid.

```css

@keyframes test {
   entry 100% {
      color: red;
   }
}

/*
The keyframe-selector with a named timeline range name and percentage is mangled to:

@keyframes test {
   entry to {
      color: red;
   }
}
*/
```

This PR fixes the issue by only replacing `100%` with `to` when the parent selector only has one child node.