### PR TITLE
Add additional space before font-family if needed

### DIFF
--- a/packages/postcss-minify-font-values/src/lib/minify-font.js
+++ b/packages/postcss-minify-font-values/src/lib/minify-font.js
@@ -56,9 +56,31 @@ module.exports = function (nodes, opts) {
     }
   }
 
-  familyStart += 2;
+  let needAdditionalSpace = false;
 
-  family = minifyFamily(nodes.slice(familyStart), opts);
+  // handle case .8em"Times New Roman"
+  if (nodes[familyStart + 1].type === 'space') {
+    familyStart += 2;
+  } else {
+    // @ts-ignore
+    if (nodes[familyStart + 1].quote) {
+      needAdditionalSpace = true
+    }
+    familyStart += 1;
+  }
+
+  const familyNodes = nodes.slice(familyStart);
+
+  family = minifyFamily(familyNodes, opts);
+
+  if (needAdditionalSpace) {
+    return nodes.slice(0, familyStart).concat([
+      /** @type {import('postcss-value-parser').SpaceNode} */ ({
+        type: 'space',
+        value: ' ',
+      }),
+    ], family);
+  }
 
   return nodes.slice(0, familyStart).concat(family);
 };

--- a/packages/postcss-minify-font-values/test/minify-font.js
+++ b/packages/postcss-minify-font-values/test/minify-font.js
@@ -5,6 +5,45 @@ const minifyFont = require('../src/lib/minify-font.js');
 
 const tests = [
   {
+    // .8em "Times New Roman", Arial, Helvetica, sans-serif
+    options: { removeQuotes: true },
+    fixture: [
+      { type: 'word', value: '.8em' },
+      { type: "space", value: " " },
+      { type: 'string', quote: '"', value: 'Times New Roman' },
+      { type: 'div', value: ',', before: '', after: ' ' },
+      { type: 'word', value: 'Arial' },
+      { type: 'div', value: ',', before: '', after: ' ' },
+      { type: 'word', value: 'Helvetica' },
+      { type: 'div', value: ',', before: '', after: ' ' },
+      { type: 'word', value: 'sans-serif' }
+    ],
+    expected: [
+      { type: 'word', value: '.8em' },
+      { type: "space", value: " " },
+      { type: 'word', value: 'Times New Roman,Arial,Helvetica,sans-serif' }
+    ],
+  },
+  {
+    // .8em"Times New Roman", Arial, Helvetica, sans-serif
+    options: { removeQuotes: true },
+    fixture: [
+      { type: 'word', value: '.8em' },
+      { type: 'string', quote: '"', value: 'Times New Roman' },
+      { type: 'div', value: ',', before: '', after: ' ' },
+      { type: 'word', value: 'Arial' },
+      { type: 'div', value: ',', before: '', after: ' ' },
+      { type: 'word', value: 'Helvetica' },
+      { type: 'div', value: ',', before: '', after: ' ' },
+      { type: 'word', value: 'sans-serif' }
+    ],
+    expected: [
+      { type: 'word', value: '.8em' },
+      { type: "space", value: " " },
+      { type: 'word', value: 'Times New Roman,Arial,Helvetica,sans-serif' }
+    ],
+  },
+  {
     options: {},
     fixture: [
       { type: 'word', value: 'bold' },


### PR DESCRIPTION
`.8em"YS Text", Arial, Helvetica, sans-serif` => `.8em YS Text, Arial, Helvetica, sans-serif`

See #1519