### PR TITLE
fix(postcss-convert-values): keep % unit in @property

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -69,3 +69,4 @@ Thanks goes to these wonderful people:
 - Jakka Prihatna
 - James George
 - Jordy D'Hoker
+- Xiaojun Zhou

--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -118,13 +118,24 @@ function shouldKeepZeroUnit(decl, browsers) {
     (decl.value.includes('%') &&
       keepZeroPercent.has(lowerCasedProp) &&
       browsers.includes('ie 11')) ||
-    (parent &&
+    (lowerCasedProp === 'stroke-dasharray' &&
+      parent &&
       parent.parent &&
       parent.parent.type === 'atrule' &&
-      /** @type {import('postcss').AtRule} */ (
-        parent.parent
-      ).name.toLowerCase() === 'keyframes' &&
-      lowerCasedProp === 'stroke-dasharray') ||
+      /** @type {import('postcss').AtRule} */
+      (parent.parent).name.toLowerCase() === 'keyframes') ||
+    (lowerCasedProp === 'initial-value' &&
+      parent &&
+      parent.type === 'atrule' &&
+      /** @type {import('postcss').AtRule} */
+      (parent).name === 'property' &&
+      /** @type {import('postcss').AtRule} */
+      (parent).nodes.some(
+        (node) =>
+          node.type === 'decl' &&
+          node.prop.toLowerCase() === 'syntax' &&
+          node.value === "'<percentage>'"
+      )) ||
     keepWhenZero.has(lowerCasedProp)
   );
 }

--- a/packages/postcss-convert-values/test/index.js
+++ b/packages/postcss-convert-values/test/index.js
@@ -430,5 +430,13 @@ test(
   )
 );
 
+test(
+  `should not strip the percentage from 0 in @property, for initial-value`,
+  processCSS(
+    `@property --percent{syntax:'<percentage>';inherits:false;initial-value:0%;}`,
+    `@property --percent{syntax:'<percentage>';inherits:false;initial-value:0%;}`,
+    )
+);
+
 test('should use the postcss plugin api', usePostCSSPlugin(plugin()));
 test.run();


### PR DESCRIPTION
Fix https://github.com/cssnano/cssnano/issues/1526

In `@property`, when `syntax` is `'<percentage>'`,  `%` is essential.

**Chrome**:
<img width="287" alt="image" src="https://github.com/cssnano/cssnano/assets/24448924/aa927f4e-c88e-42e1-bcdb-99ecdf02487f">
