### PR TITLE
Update lilconfig

### DIFF
--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -20,7 +20,7 @@
     "license": "MIT",
     "dependencies": {
         "cssnano-preset-default": "workspace:^",
-        "lilconfig": "^2.1.0"
+        "lilconfig": "^3.0.0"
     },
     "homepage": "https://github.com/cssnano/cssnano",
     "author": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -58,8 +58,8 @@ importers:
         specifier: workspace:^
         version: link:../cssnano-preset-default
       lilconfig:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^3.0.0
+        version: 3.0.0
     devDependencies:
       autoprefixer:
         specifier: ^10.4.12
@@ -2394,9 +2394,9 @@ packages:
       type-check: 0.4.0
     dev: true
 
-  /lilconfig@2.1.0:
-    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
-    engines: {node: '>=10'}
+  /lilconfig@3.0.0:
+    resolution: {integrity: sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==}
+    engines: {node: '>=14'}
     dev: false
 
   /lines-and-columns@1.2.4:


### PR DESCRIPTION
Hi, lilconfig maintainer here 👋

I have recently [released a new major version](https://github.com/antonk52/lilconfig/releases/tag/v3.0.0) that is fully compatible with how it is currently used.

Hope this helps!

PS: not sure why the pnpm lock file version changed. I used pnpm v8.10.3 and node v20.9.0