### PR TITLE
test: fix api options for node v20.10.0

### DIFF
--- a/packages/css-size/test/index.js
+++ b/packages/css-size/test/index.js
@@ -133,7 +133,7 @@ test('api options', () => {
     discardUnused: false,
     from: undefined,
   }).then((result) => {
-    assert.is(result.gzip.processed, '67 B');
+    assert.is(parseInt(result.gzip.difference, 10) > 0, true);
   });
 });
 test.run();


### PR DESCRIPTION
This is the proposed solution for your comment at:

* https://github.com/cssnano/cssnano/pull/1533#issuecomment-1841395155

The result of css-size changes depending on the Node.js version, so rather than testing for a specific number of bytes, this instead asserts that after processing, the result is fewer bytes.

In this scenario, on all Node.js versions except Node.js v20.10.0 (latest LTS release) it returns 67 B, but on v20.10.0 it returns 68 B instead. The new assertion instead asserts what, I assume, was the intent of the test, while passing on all Node.js versions.