### PR TITLE
chore: add workflow to publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish Package to npmjs
+permissions:
+  contents: read
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4.0.1
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: pnpm test:only
+      - run: pnpm all-publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+


### PR DESCRIPTION
Allow to trace an npm tag to a commit in the repo