### PR TITLE
chore: update GitHub action versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.4.0
+        uses: pnpm/action-setup@v3.0.0
         with:
           version: 7.33.6
           
       - name: Setup .npmrc file to publish to npm
-        uses: actions/setup-node@v4.0.1
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.4.0
+        uses: pnpm/action-setup@v3.0.0
         with:
           version: 7.33.6
       - name: Install Node.js 20.x
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -34,11 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.4.0
+        uses: pnpm/action-setup@v3.0.0
         with:
           version: 7.33.6
       - name: Install Node.js 20.x
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -65,12 +65,12 @@ jobs:
       - uses: actions/checkout@v4.1.1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.4.0
+        uses: pnpm/action-setup@v3.0.0
         with:
           version: 7.33.6
 
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -82,7 +82,7 @@ jobs:
         run: pnpm test:coverage
 
       - name: Publish code coverage report
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '16'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20'
         uses: codecov/codecov-action@v3.1.4
         with:
           name: codecov


### PR DESCRIPTION
pnpm/action-setup needs the update to be able to run on Node.js 20 when [GitHub removes Node.js 16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).