### PR TITLE
Fix at-rule children

### DIFF
--- a/.changeset/neat-houses-trade.md
+++ b/.changeset/neat-houses-trade.md
@@ -1,0 +1,5 @@
+---
+"postcss-discard-empty": patch
+---
+
+fix(postcss-discard-empty): preserve empty layer declarations

--- a/.changeset/pretty-rats-laugh.md
+++ b/.changeset/pretty-rats-laugh.md
@@ -1,0 +1,5 @@
+---
+"postcss-discard-duplicates": patch
+---
+
+fix(postcss-discard-duplicates): avoid crash with empty layers

--- a/.changeset/tasty-terms-flow.md
+++ b/.changeset/tasty-terms-flow.md
@@ -1,0 +1,7 @@
+---
+"postcss-convert-values": patch
+"postcss-discard-unused": patch
+"postcss-merge-idents": patch
+---
+
+fix: handle cases where AtRules might not have any children nodes

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "globals": "^14.0.0",
-    "postcss": "^8.4.33",
+    "postcss": "^8.4.35",
     "postcss-font-magician": "^3.0.0",
     "prettier": "^3.2.5",
     "typescript": "~5.3.3",

--- a/packages/css-size/package.json
+++ b/packages/css-size/package.json
@@ -35,7 +35,7 @@
     "postcss": "^8.4.31"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -32,7 +32,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -55,7 +55,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/cssnano-preset-lite/package.json
+++ b/packages/cssnano-preset-lite/package.json
@@ -26,7 +26,7 @@
         "node": "^14 || ^16 || >=18.0"
     },
     "devDependencies": {
-        "postcss": "^8.4.33"
+        "postcss": "^8.4.35"
     },
     "peerDependencies": {
         "postcss": "^8.4.31"

--- a/packages/cssnano-utils/package.json
+++ b/packages/cssnano-utils/package.json
@@ -19,7 +19,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "postcss": "^8.4.33",
+    "postcss": "^8.4.35",
     "postcss-value-parser": "^4.2.0"
   },
   "peerDependencies": {

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -44,7 +44,7 @@
         "autoprefixer": "^10.4.16",
         "cssnano-preset-advanced": "workspace:^",
         "cssnano-preset-lite": "workspace:^",
-        "postcss": "^8.4.33"
+        "postcss": "^8.4.35"
     },
     "peerDependencies": {
         "postcss": "^8.4.31"

--- a/packages/postcss-colormin/package.json
+++ b/packages/postcss-colormin/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/caniuse-api": "^3.0.6",
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-convert-values/package.json
+++ b/packages/postcss-convert-values/package.json
@@ -34,7 +34,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -130,6 +130,8 @@ function shouldKeepZeroUnit(decl, browsers) {
       /** @type {import('postcss').AtRule} */
       (parent).name === 'property' &&
       /** @type {import('postcss').AtRule} */
+      (parent).nodes !== undefined &&
+      /** @type {import('postcss').AtRule} */
       (parent).nodes.some(
         (node) =>
           node.type === 'decl' &&

--- a/packages/postcss-convert-values/test/index.js
+++ b/packages/postcss-convert-values/test/index.js
@@ -434,8 +434,8 @@ test(
   `should not strip the percentage from 0 in @property, for initial-value`,
   processCSS(
     `@property --percent{syntax:'<percentage>';inherits:false;initial-value:0%;}`,
-    `@property --percent{syntax:'<percentage>';inherits:false;initial-value:0%;}`,
-    )
+    `@property --percent{syntax:'<percentage>';inherits:false;initial-value:0%;}`
+  )
 );
 
 test('should use the postcss plugin api', usePostCSSPlugin(plugin()));

--- a/packages/postcss-discard-comments/package.json
+++ b/packages/postcss-discard-comments/package.json
@@ -30,7 +30,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33",
+    "postcss": "^8.4.35",
     "postcss-scss": "^4.0.9",
     "postcss-simple-vars": "^7.0.1"
   },

--- a/packages/postcss-discard-duplicates/package.json
+++ b/packages/postcss-discard-duplicates/package.json
@@ -31,7 +31,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-discard-duplicates/src/index.js
+++ b/packages/postcss-discard-duplicates/src/index.js
@@ -68,7 +68,7 @@ function equals(nodeA, nodeB) {
       break;
   }
 
-  if (a.nodes) {
+  if (a.nodes && b.nodes) {
     if (a.nodes.length !== b.nodes.length) {
       return false;
     }

--- a/packages/postcss-discard-duplicates/test/index.js
+++ b/packages/postcss-discard-duplicates/test/index.js
@@ -107,6 +107,14 @@ test(
 );
 
 test(
+  'should not crash on @layer syntax',
+  processCSS(
+    '@layer ui-components { } @layer ui-components',
+    '@layer ui-components'
+  )
+);
+
+test(
   'should not remove declarations when selectors are different',
   passthroughCSS('h1{font-weight:bold}h2{font-weight:bold}')
 );

--- a/packages/postcss-discard-empty/package.json
+++ b/packages/postcss-discard-empty/package.json
@@ -33,7 +33,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-discard-empty/src/index.js
+++ b/packages/postcss-discard-empty/src/index.js
@@ -21,7 +21,7 @@ function discardAndReport(css, result) {
     if (
       (type === 'decl' && !node.value && !node.prop.startsWith('--')) ||
       (type === 'rule' && !node.selector) ||
-      (sub && !sub.length) ||
+      (sub && !sub.length && !(type === 'atrule' && node.name === 'layer')) ||
       (type === 'atrule' &&
         ((!sub && !node.params) ||
           (!node.params &&

--- a/packages/postcss-discard-empty/test/index.js
+++ b/packages/postcss-discard-empty/test/index.js
@@ -86,6 +86,24 @@ test(
 );
 
 test(
+  'should preserve empty layers',
+  passthroughCSS(`@layer a {}
+@layer b {}
+
+@layer b {
+  foo {
+    color: red;
+  }
+}
+
+@layer a {
+  bar {
+    color: green;
+  }
+}`)
+);
+
+test(
   'should report removed selectors',
   testRemovals('h1{}.hot{}.a.b{}{}@media screen, print{h1,h2{}}', '', [
     'h1',

--- a/packages/postcss-discard-overridden/package.json
+++ b/packages/postcss-discard-overridden/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "diff": "^5.1.0",
     "picocolors": "^1.0.0",
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-discard-unused/package.json
+++ b/packages/postcss-discard-unused/package.json
@@ -35,7 +35,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-discard-unused/src/index.js
+++ b/packages/postcss-discard-unused/src/index.js
@@ -40,7 +40,7 @@ function filterAtRule({ atRules, values }) {
  */
 function filterNamespace({ atRules, rules }) {
   const uniqueRules = new Set(rules);
-  atRules.forEach((atRule) => {
+  for (const atRule of atRules) {
     const { 0: param, length: len } = atRule.params.split(' ').filter(Boolean);
 
     if (len === 1) {
@@ -52,7 +52,7 @@ function filterNamespace({ atRules, rules }) {
     if (!hasRule) {
       atRule.remove();
     }
-  });
+  }
 }
 
 /**
@@ -74,25 +74,27 @@ function hasFont(fontFamily, cache, comma) {
  */
 function filterFont({ atRules, values }, comma) {
   values = [...new Set(values)];
-  atRules.forEach((r) => {
-    /** @type {import('postcss').Declaration[]} */
-    const families = /** @type {import('postcss').Declaration[]} */ (
-      r.nodes.filter(
-        (node) => node.type === 'decl' && node.prop === 'font-family'
-      )
-    );
+  for (const r of atRules) {
+    if (r.nodes !== undefined) {
+      /** @type {import('postcss').Declaration[]} */
+      const families = /** @type {import('postcss').Declaration[]} */ (
+        r.nodes.filter(
+          (node) => node.type === 'decl' && node.prop === 'font-family'
+        )
+      );
 
-    // Discard the @font-face if it has no font-family
-    if (!families.length) {
-      return r.remove();
-    }
-
-    families.forEach((family) => {
-      if (!hasFont(family.value.toLowerCase(), values, comma)) {
+      // Discard the @font-face if it has no font-family
+      if (families.length === 0) {
         r.remove();
       }
-    });
-  });
+
+      for (const family of families) {
+        if (!hasFont(family.value.toLowerCase(), values, comma)) {
+          r.remove();
+        }
+      }
+    }
+  }
 }
 
 /**@typedef {{fontFace?: boolean, counterStyle?: boolean, keyframes?: boolean, namespace?: boolean}} Options */

--- a/packages/postcss-discard-unused/test/index.js
+++ b/packages/postcss-discard-unused/test/index.js
@@ -152,5 +152,10 @@ test(
   )
 );
 
+test(
+  'should not crash with empty layers',
+  processCSS('@layer a;', '@layer a;')
+);
+
 test('should use the postcss plugin api', usePostCSSPlugin(plugin()));
 test.run();

--- a/packages/postcss-merge-idents/package.json
+++ b/packages/postcss-merge-idents/package.json
@@ -34,7 +34,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-merge-idents/src/index.js
+++ b/packages/postcss-merge-idents/src/index.js
@@ -77,16 +77,19 @@ function mergeAtRules(css) {
         relevant.cache.push(node);
         return;
       } else {
-        let toString = node.nodes.toString();
+        const toString = node.nodes ? node.nodes.toString() : '';
 
         relevant.cache.forEach((cached) => {
+          const cachedStringContent = cached.nodes
+            ? cached.nodes.toString()
+            : '';
           if (
             cached.name.toLowerCase() === node.name.toLowerCase() &&
             sameParent(
               /** @type {any} */ (cached),
               /** @type {any} */ (node)
             ) &&
-            cached.nodes.toString() === toString
+            cachedStringContent === toString
           ) {
             relevant.removals.push(cached);
             relevant.replacements[cached.params] = node.params;

--- a/packages/postcss-merge-longhand/package.json
+++ b/packages/postcss-merge-longhand/package.json
@@ -35,7 +35,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-merge-rules/package.json
+++ b/packages/postcss-merge-rules/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@types/caniuse-api": "^3.0.6",
-    "postcss": "^8.4.33",
+    "postcss": "^8.4.35",
     "postcss-discard-comments": "workspace:^",
     "postcss-simple-vars": "^7.0.1"
   },

--- a/packages/postcss-minify-font-values/package.json
+++ b/packages/postcss-minify-font-values/package.json
@@ -31,7 +31,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-minify-gradients/package.json
+++ b/packages/postcss-minify-gradients/package.json
@@ -34,7 +34,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-minify-params/package.json
+++ b/packages/postcss-minify-params/package.json
@@ -33,7 +33,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-minify-selectors/package.json
+++ b/packages/postcss-minify-selectors/package.json
@@ -35,7 +35,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-normalize-charset/package.json
+++ b/packages/postcss-normalize-charset/package.json
@@ -26,7 +26,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-normalize-display-values/package.json
+++ b/packages/postcss-normalize-display-values/package.json
@@ -27,7 +27,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-normalize-positions/package.json
+++ b/packages/postcss-normalize-positions/package.json
@@ -32,7 +32,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-normalize-repeat-style/package.json
+++ b/packages/postcss-normalize-repeat-style/package.json
@@ -27,7 +27,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-normalize-string/package.json
+++ b/packages/postcss-normalize-string/package.json
@@ -32,7 +32,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-normalize-timing-functions/package.json
+++ b/packages/postcss-normalize-timing-functions/package.json
@@ -27,7 +27,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-normalize-unicode/package.json
+++ b/packages/postcss-normalize-unicode/package.json
@@ -33,7 +33,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-normalize-url/package.json
+++ b/packages/postcss-normalize-url/package.json
@@ -36,7 +36,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-normalize-whitespace/package.json
+++ b/packages/postcss-normalize-whitespace/package.json
@@ -32,7 +32,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-ordered-values/package.json
+++ b/packages/postcss-ordered-values/package.json
@@ -33,7 +33,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-reduce-idents/package.json
+++ b/packages/postcss-reduce-idents/package.json
@@ -32,7 +32,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-reduce-initial/package.json
+++ b/packages/postcss-reduce-initial/package.json
@@ -39,7 +39,7 @@
     "@types/caniuse-api": "^3.0.6",
     "html-to-text": "^9.0.5",
     "nanospy": "^1.0.0",
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-reduce-transforms/package.json
+++ b/packages/postcss-reduce-transforms/package.json
@@ -27,7 +27,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-svgo/package.json
+++ b/packages/postcss-svgo/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "pleeease-filters": "^4.0.0",
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-unique-selectors/package.json
+++ b/packages/postcss-unique-selectors/package.json
@@ -32,7 +32,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/postcss-zindex/package.json
+++ b/packages/postcss-zindex/package.json
@@ -33,7 +33,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/packages/stylehacks/package.json
+++ b/packages/stylehacks/package.json
@@ -38,7 +38,7 @@
     "node": "^14 || ^16 || >=18.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.33"
+    "postcss": "^8.4.35"
   },
   "peerDependencies": {
     "postcss": "^8.4.31"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,11 +27,11 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
       postcss-font-magician:
         specifier: ^3.0.0
-        version: 3.0.0(postcss@8.4.33)
+        version: 3.0.0(postcss@8.4.35)
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -52,8 +52,8 @@ importers:
         version: 1.2.8
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/cssnano:
     dependencies:
@@ -66,7 +66,7 @@ importers:
     devDependencies:
       autoprefixer:
         specifier: ^10.4.16
-        version: 10.4.16(postcss@8.4.33)
+        version: 10.4.16(postcss@8.4.35)
       cssnano-preset-advanced:
         specifier: workspace:^
         version: link:../cssnano-preset-advanced
@@ -74,14 +74,14 @@ importers:
         specifier: workspace:^
         version: link:../cssnano-preset-lite
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/cssnano-preset-advanced:
     dependencies:
       autoprefixer:
         specifier: ^10.4.16
-        version: 10.4.16(postcss@8.4.33)
+        version: 10.4.16(postcss@8.4.35)
       cssnano-preset-default:
         specifier: workspace:^
         version: link:../cssnano-preset-default
@@ -99,20 +99,20 @@ importers:
         version: link:../postcss-zindex
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/cssnano-preset-default:
     dependencies:
       css-declaration-sorter:
         specifier: ^7.1.1
-        version: 7.1.1(postcss@8.4.33)
+        version: 7.1.1(postcss@8.4.35)
       cssnano-utils:
         specifier: workspace:^
         version: link:../cssnano-utils
       postcss-calc:
         specifier: ^9.0.1
-        version: 9.0.1(postcss@8.4.33)
+        version: 9.0.1(postcss@8.4.35)
       postcss-colormin:
         specifier: workspace:^
         version: link:../postcss-colormin
@@ -193,8 +193,8 @@ importers:
         version: link:../postcss-unique-selectors
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/cssnano-preset-lite:
     dependencies:
@@ -212,14 +212,14 @@ importers:
         version: link:../postcss-normalize-whitespace
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/cssnano-utils:
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
       postcss-value-parser:
         specifier: ^4.2.0
         version: 4.2.0
@@ -243,8 +243,8 @@ importers:
         specifier: ^3.0.6
         version: 3.0.6
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-convert-values:
     dependencies:
@@ -256,32 +256,32 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-discard-comments:
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
       postcss-scss:
         specifier: ^4.0.9
-        version: 4.0.9(postcss@8.4.33)
+        version: 4.0.9(postcss@8.4.35)
       postcss-simple-vars:
         specifier: ^7.0.1
-        version: 7.0.1(postcss@8.4.33)
+        version: 7.0.1(postcss@8.4.35)
 
   packages/postcss-discard-duplicates:
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-discard-empty:
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-discard-overridden:
     devDependencies:
@@ -292,8 +292,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-discard-unused:
     dependencies:
@@ -302,8 +302,8 @@ importers:
         version: 6.0.15
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-merge-idents:
     dependencies:
@@ -315,8 +315,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-merge-longhand:
     dependencies:
@@ -328,8 +328,8 @@ importers:
         version: link:../stylehacks
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-merge-rules:
     dependencies:
@@ -350,14 +350,14 @@ importers:
         specifier: ^3.0.6
         version: 3.0.6
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
       postcss-discard-comments:
         specifier: workspace:^
         version: link:../postcss-discard-comments
       postcss-simple-vars:
         specifier: ^7.0.1
-        version: 7.0.1(postcss@8.4.33)
+        version: 7.0.1(postcss@8.4.35)
 
   packages/postcss-minify-font-values:
     dependencies:
@@ -366,8 +366,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-minify-gradients:
     dependencies:
@@ -382,8 +382,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-minify-params:
     dependencies:
@@ -398,8 +398,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-minify-selectors:
     dependencies:
@@ -408,14 +408,14 @@ importers:
         version: 6.0.15
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-normalize-charset:
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-normalize-display-values:
     dependencies:
@@ -424,8 +424,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-normalize-positions:
     dependencies:
@@ -434,8 +434,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-normalize-repeat-style:
     dependencies:
@@ -444,8 +444,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-normalize-string:
     dependencies:
@@ -454,8 +454,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-normalize-timing-functions:
     dependencies:
@@ -464,8 +464,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-normalize-unicode:
     dependencies:
@@ -477,8 +477,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-normalize-url:
     dependencies:
@@ -487,8 +487,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-normalize-whitespace:
     dependencies:
@@ -497,8 +497,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-ordered-values:
     dependencies:
@@ -510,8 +510,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-reduce-idents:
     dependencies:
@@ -520,8 +520,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-reduce-initial:
     dependencies:
@@ -542,8 +542,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-reduce-transforms:
     dependencies:
@@ -552,8 +552,8 @@ importers:
         version: 4.2.0
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-svgo:
     dependencies:
@@ -568,8 +568,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-unique-selectors:
     dependencies:
@@ -578,14 +578,14 @@ importers:
         version: 6.0.15
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/postcss-zindex:
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
   packages/stylehacks:
     dependencies:
@@ -597,8 +597,8 @@ importers:
         version: 6.0.15
     devDependencies:
       postcss:
-        specifier: ^8.4.33
-        version: 8.4.33
+        specifier: ^8.4.35
+        version: 8.4.35
 
 packages:
 
@@ -1090,7 +1090,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /autoprefixer@10.4.16(postcss@8.4.33):
+  /autoprefixer@10.4.16(postcss@8.4.35):
     resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
@@ -1102,7 +1102,7 @@ packages:
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.0.0
-      postcss: 8.4.33
+      postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
   /available-typed-arrays@1.0.5:
@@ -1335,13 +1335,13 @@ packages:
       which: 2.0.2
     dev: true
 
-  /css-declaration-sorter@7.1.1(postcss@8.4.33):
+  /css-declaration-sorter@7.1.1(postcss@8.4.35):
     resolution: {integrity: sha512-dZ3bVTEEc1vxr3Bek9vGwfB5Z6ESPULhcRvO472mfjVnj8jRcTnKO8/JTczlvxM10Myb+wBM++1MtdO76eWcaQ==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.4.35
     dev: false
 
   /css-select@5.1.0:
@@ -1978,12 +1978,12 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /google-fonts-complete@2.2.3(postcss@8.4.33):
+  /google-fonts-complete@2.2.3(postcss@8.4.35):
     resolution: {integrity: sha512-/0EkrmRkh4qdNmlcM55LU6fRp2pdF2tvWA908wqx0cWxzAP3FSNKAZg8SxjynGhkhiPQeM7UxH659cGYbFz3EQ==}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.4.35
     dev: true
 
   /gopd@1.0.1:
@@ -2775,18 +2775,18 @@ packages:
       postcss: 6.0.23
     dev: true
 
-  /postcss-calc@9.0.1(postcss@8.4.33):
+  /postcss-calc@9.0.1(postcss@8.4.35):
     resolution: {integrity: sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.2
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.4.35
       postcss-selector-parser: 6.0.15
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-font-magician@3.0.0(postcss@8.4.33):
+  /postcss-font-magician@3.0.0(postcss@8.4.35):
     resolution: {integrity: sha512-PqGk9TeIoWzytZeLW6AtgzuL1sJb0bO0xPr4daI6MEhidqyCMECJmwXIlAS6ypf18y6tR04cDFbLqlQruXQiIA==}
     engines: {node: ^10 || ^12 || >=14}
     peerDependencies:
@@ -2794,17 +2794,17 @@ packages:
     dependencies:
       bootstrap-fonts-complete: 1.0.0
       directory-fonts-complete: 1.2.0
-      google-fonts-complete: 2.2.3(postcss@8.4.33)
-      postcss: 8.4.33
+      google-fonts-complete: 2.2.3(postcss@8.4.35)
+      postcss: 8.4.35
     dev: true
 
-  /postcss-scss@4.0.9(postcss@8.4.33):
+  /postcss-scss@4.0.9(postcss@8.4.35):
     resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.4.29
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.4.35
     dev: true
 
   /postcss-selector-parser@6.0.15:
@@ -2815,13 +2815,13 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /postcss-simple-vars@7.0.1(postcss@8.4.33):
+  /postcss-simple-vars@7.0.1(postcss@8.4.35):
     resolution: {integrity: sha512-5GLLXaS8qmzHMOjVxqkk1TZPf1jMqesiI7qLhnlyERalG0sMbHIbJqrcnrpmZdKCLglHnRHoEBB61RtGTsj++A==}
     engines: {node: '>=14.0'}
     peerDependencies:
       postcss: ^8.2.1
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.4.35
     dev: true
 
   /postcss-value-parser@4.2.0:
@@ -2844,8 +2844,8 @@ packages:
       supports-color: 5.5.0
     dev: true
 
-  /postcss@8.4.33:
-    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
+  /postcss@8.4.35:
+    resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7


### PR DESCRIPTION
Fix some issues related to `@layer` rules. For example, a [crash in css-minimizer-webpack-plugin](https://github.com/webpack-contrib/css-minimizer-webpack-plugin/issues/239), type checking failures because now children might not exist on an AtRule  (since PostCSS 8.35.0). 