### PR TITLE
Fix minify font space case

### DIFF
--- a/.changeset/cyan-squids-own.md
+++ b/.changeset/cyan-squids-own.md
@@ -1,0 +1,5 @@
+---
+"postcss-minify-font-values": patch
+---
+
+fix(postcss-minify-font-values): emit correct output when spaces are missing between the font family and other values

--- a/packages/postcss-minify-font-values/src/index.js
+++ b/packages/postcss-minify-font-values/src/index.js
@@ -32,11 +32,7 @@ function transform(prop, value, opts) {
 
     return tree.toString();
   } else if (lowerCasedProp === 'font') {
-    const tree = valueParser(value);
-
-    tree.nodes = minifyFont(tree.nodes, opts);
-
-    return tree.toString();
+    return minifyFont(value, opts);
   }
 
   return value;

--- a/packages/postcss-minify-font-values/src/lib/minify-font.js
+++ b/packages/postcss-minify-font-values/src/lib/minify-font.js
@@ -56,9 +56,31 @@ module.exports = function (nodes, opts) {
     }
   }
 
-  familyStart += 2;
+  let needAdditionalSpace = false;
 
-  family = minifyFamily(nodes.slice(familyStart), opts);
+  // handle case .8em"Times New Roman"
+  if (nodes[familyStart + 1].type === 'space') {
+    familyStart += 2;
+  } else {
+    // @ts-ignore
+    if (nodes[familyStart + 1].quote) {
+      needAdditionalSpace = true
+    }
+    familyStart += 1;
+  }
+
+  const familyNodes = nodes.slice(familyStart);
+
+  family = minifyFamily(familyNodes, opts);
+
+  if (needAdditionalSpace) {
+    return nodes.slice(0, familyStart).concat([
+      /** @type {import('postcss-value-parser').SpaceNode} */ ({
+        type: 'space',
+        value: ' ',
+      }),
+    ], family);
+  }
 
   return nodes.slice(0, familyStart).concat(family);
 };

--- a/packages/postcss-minify-font-values/src/lib/minify-font.js
+++ b/packages/postcss-minify-font-values/src/lib/minify-font.js
@@ -1,21 +1,46 @@
 'use strict';
-const { unit } = require('postcss-value-parser');
+const valueParser = require('postcss-value-parser');
 const keywords = require('./keywords');
 const minifyFamily = require('./minify-family');
 const minifyWeight = require('./minify-weight');
 
 /**
+ * Adds missing spaces before strings.
+ *
+ * @param toBeSpliced {Set<number>}
  * @param {import('postcss-value-parser').Node[]} nodes
- * @param {import('../index').Options} opts
- * @return {import('postcss-value-parser').Node[]}
+ * @return {void}
  */
-module.exports = function (nodes, opts) {
-  let i, max, node, family;
+function normalizeNodes(nodes, toBeSpliced) {
+  for (const index of toBeSpliced) {
+    nodes.splice(
+      index,
+      0,
+      /** @type {import('postcss-value-parser').SpaceNode} */ ({
+        type: 'space',
+        value: ' ',
+      })
+    );
+  }
+}
+
+/**
+ * @param {string} unminified
+ * @param {import('../index').Options} opts
+ * @return {string}
+ */
+module.exports = function (unminified, opts) {
+  const tree = valueParser(unminified);
+  const nodes = tree.nodes;
+
   let familyStart = NaN;
   let hasSize = false;
+  const toBeSpliced = new Set();
 
-  for (i = 0, max = nodes.length; i < max; i += 1) {
-    node = nodes[i];
+  for (const [i, node] of nodes.entries()) {
+    if (node.type === 'string' && i > 0 && nodes[i - 1].type !== 'space') {
+      toBeSpliced.add(i);
+    }
 
     if (node.type === 'word') {
       if (hasSize) {
@@ -23,7 +48,6 @@ module.exports = function (nodes, opts) {
       }
 
       const value = node.value.toLowerCase();
-
       if (
         value === 'normal' ||
         value === 'inherit' ||
@@ -31,7 +55,7 @@ module.exports = function (nodes, opts) {
         value === 'unset'
       ) {
         familyStart = i;
-      } else if (keywords.style.has(value) || unit(value)) {
+      } else if (keywords.style.has(value) || valueParser.unit(value)) {
         familyStart = i;
       } else if (keywords.variant.has(value)) {
         familyStart = i;
@@ -40,7 +64,7 @@ module.exports = function (nodes, opts) {
         familyStart = i;
       } else if (keywords.stretch.has(value)) {
         familyStart = i;
-      } else if (keywords.size.has(value) || unit(value)) {
+      } else if (keywords.size.has(value) || valueParser.unit(value)) {
         familyStart = i;
         hasSize = true;
       }
@@ -56,31 +80,11 @@ module.exports = function (nodes, opts) {
     }
   }
 
-  let needAdditionalSpace = false;
+  normalizeNodes(nodes, toBeSpliced);
+  familyStart += 2;
 
-  // handle case .8em"Times New Roman"
-  if (nodes[familyStart + 1].type === 'space') {
-    familyStart += 2;
-  } else {
-    // @ts-ignore
-    if (nodes[familyStart + 1].quote) {
-      needAdditionalSpace = true
-    }
-    familyStart += 1;
-  }
+  const family = minifyFamily(nodes.slice(familyStart), opts);
 
-  const familyNodes = nodes.slice(familyStart);
-
-  family = minifyFamily(familyNodes, opts);
-
-  if (needAdditionalSpace) {
-    return nodes.slice(0, familyStart).concat([
-      /** @type {import('postcss-value-parser').SpaceNode} */ ({
-        type: 'space',
-        value: ' ',
-      }),
-    ], family);
-  }
-
-  return nodes.slice(0, familyStart).concat(family);
+  tree.nodes = nodes.slice(0, familyStart).concat(family);
+  return tree.toString();
 };

--- a/packages/postcss-minify-font-values/test/minify-font.js
+++ b/packages/postcss-minify-font-values/test/minify-font.js
@@ -3,78 +3,49 @@ const { test } = require('uvu');
 const assert = require('uvu/assert');
 const minifyFont = require('../src/lib/minify-font.js');
 
-const tests = [
-  {
-    // .8em "Times New Roman", Arial, Helvetica, sans-serif
-    options: { removeQuotes: true },
-    fixture: [
-      { type: 'word', value: '.8em' },
-      { type: "space", value: " " },
-      { type: 'string', quote: '"', value: 'Times New Roman' },
-      { type: 'div', value: ',', before: '', after: ' ' },
-      { type: 'word', value: 'Arial' },
-      { type: 'div', value: ',', before: '', after: ' ' },
-      { type: 'word', value: 'Helvetica' },
-      { type: 'div', value: ',', before: '', after: ' ' },
-      { type: 'word', value: 'sans-serif' }
-    ],
-    expected: [
-      { type: 'word', value: '.8em' },
-      { type: "space", value: " " },
-      { type: 'word', value: 'Times New Roman,Arial,Helvetica,sans-serif' }
-    ],
-  },
-  {
-    // .8em"Times New Roman", Arial, Helvetica, sans-serif
-    options: { removeQuotes: true },
-    fixture: [
-      { type: 'word', value: '.8em' },
-      { type: 'string', quote: '"', value: 'Times New Roman' },
-      { type: 'div', value: ',', before: '', after: ' ' },
-      { type: 'word', value: 'Arial' },
-      { type: 'div', value: ',', before: '', after: ' ' },
-      { type: 'word', value: 'Helvetica' },
-      { type: 'div', value: ',', before: '', after: ' ' },
-      { type: 'word', value: 'sans-serif' }
-    ],
-    expected: [
-      { type: 'word', value: '.8em' },
-      { type: "space", value: " " },
-      { type: 'word', value: 'Times New Roman,Arial,Helvetica,sans-serif' }
-    ],
-  },
-  {
-    options: {},
-    fixture: [
-      { type: 'word', value: 'bold' },
-      { type: 'space', value: '  ' },
-      { type: 'word', value: 'italic' },
-      { type: 'space', value: ' \t ' },
-      { type: 'word', value: '20px' },
-      { type: 'space', value: ' \n ' },
-      { type: 'word', value: 'Times' },
-      { type: 'space', value: ' ' },
-      { type: 'word', value: 'New' },
-      { type: 'space', value: ' \t ' },
-      { type: 'word', value: 'Roman' },
-      { type: 'div', value: ',', before: '', after: ' ' },
-      { type: 'word', value: 'serif' },
-    ],
-    expected: [
-      { type: 'word', value: '700' },
-      { type: 'space', value: '  ' },
-      { type: 'word', value: 'italic' },
-      { type: 'space', value: ' \t ' },
-      { type: 'word', value: '20px' },
-      { type: 'space', value: ' \n ' },
-      { type: 'word', value: 'Times New Roman,serif' },
-    ],
-  },
-];
+test('.8em "Times New Roman", Arial, Helvetica, sans-serif', () => {
+  assert.equal(
+    minifyFont(
+      '.8em "Times New Roman", Arial, Helvetica, sans-serif',
 
-test('minify-font', () => {
-  tests.forEach(({ fixture, options, expected }) => {
-    assert.equal(minifyFont(fixture, options), expected);
-  });
+      { removeQuotes: true }
+    ),
+    '.8em Times New Roman,Arial,Helvetica,sans-serif'
+  );
 });
+
+test('.8em"Times New Roman", Arial, Helvetica, sans-serif', () => {
+  assert.equal(
+    minifyFont('.8em"Times New Roman", Arial, Helvetica, sans-serif', {
+      removeQuotes: true,
+    }),
+    '.8em Times New Roman,Arial,Helvetica,sans-serif'
+  );
+});
+
+test('ultra-condensed small-caps 1.2em "Fira Sans", sans-serif;', () => {
+  assert.equal(
+    minifyFont('ultra-condensed small-caps 1.2em "Fira Sans", sans-serif;', {
+      removeQuotes: true,
+    }),
+    'ultra-condensed small-caps 1.2em Fira Sans,sans-serif;'
+  );
+});
+
+test('ultra-condensed small-caps 1.2em"Fira Sans", sans-serif;', () => {
+  assert.equal(
+    minifyFont('ultra-condensed small-caps 1.2em"Fira Sans", sans-serif;', {
+      removeQuotes: true,
+    }),
+    'ultra-condensed small-caps 1.2em Fira Sans,sans-serif;'
+  );
+});
+
+test('tabs and newlines', () => {
+  assert.equal(
+    minifyFont('bold italic \t 20px \n Times New\tRoman, serif', {}),
+    '700 italic \t 20px \n Times New Roman,serif'
+  );
+});
+
 test.run();

--- a/packages/postcss-minify-font-values/test/minify-font.js
+++ b/packages/postcss-minify-font-values/test/minify-font.js
@@ -5,6 +5,45 @@ const minifyFont = require('../src/lib/minify-font.js');
 
 const tests = [
   {
+    // .8em "Times New Roman", Arial, Helvetica, sans-serif
+    options: { removeQuotes: true },
+    fixture: [
+      { type: 'word', value: '.8em' },
+      { type: "space", value: " " },
+      { type: 'string', quote: '"', value: 'Times New Roman' },
+      { type: 'div', value: ',', before: '', after: ' ' },
+      { type: 'word', value: 'Arial' },
+      { type: 'div', value: ',', before: '', after: ' ' },
+      { type: 'word', value: 'Helvetica' },
+      { type: 'div', value: ',', before: '', after: ' ' },
+      { type: 'word', value: 'sans-serif' }
+    ],
+    expected: [
+      { type: 'word', value: '.8em' },
+      { type: "space", value: " " },
+      { type: 'word', value: 'Times New Roman,Arial,Helvetica,sans-serif' }
+    ],
+  },
+  {
+    // .8em"Times New Roman", Arial, Helvetica, sans-serif
+    options: { removeQuotes: true },
+    fixture: [
+      { type: 'word', value: '.8em' },
+      { type: 'string', quote: '"', value: 'Times New Roman' },
+      { type: 'div', value: ',', before: '', after: ' ' },
+      { type: 'word', value: 'Arial' },
+      { type: 'div', value: ',', before: '', after: ' ' },
+      { type: 'word', value: 'Helvetica' },
+      { type: 'div', value: ',', before: '', after: ' ' },
+      { type: 'word', value: 'sans-serif' }
+    ],
+    expected: [
+      { type: 'word', value: '.8em' },
+      { type: "space", value: " " },
+      { type: 'word', value: 'Times New Roman,Arial,Helvetica,sans-serif' }
+    ],
+  },
+  {
     options: {},
     fixture: [
       { type: 'word', value: 'bold' },

--- a/packages/postcss-minify-font-values/types/lib/minify-font.d.ts
+++ b/packages/postcss-minify-font-values/types/lib/minify-font.d.ts
@@ -1,2 +1,2 @@
-declare function _exports(nodes: import('postcss-value-parser').Node[], opts: import('../index').Options): import('postcss-value-parser').Node[];
+declare function _exports(unminified: string, opts: import('../index').Options): string;
 export = _exports;


### PR DESCRIPTION
When trying to process font value strings with unusual space usage (quoted strings glued to other values), add missing spaces to font property values before minifying so the minification logic does not become too complex.

Also refactor the internal method to take and return a string, so when testing if the transformation work we have readable input and output.

Fix #1519 close #1520

