### PR TITLE
fix: prevent crash where first preset is already invoked

### DIFF
--- a/packages/cssnano/src/index.js
+++ b/packages/cssnano/src/index.js
@@ -42,8 +42,8 @@ function resolvePreset(preset) {
   }
 
   // For JS setups where we invoked the preset already
-  if (preset.plugins) {
-    return preset.plugins;
+  if (fn.plugins) {
+    return fn.plugins;
   }
 
   // Provide an alias for the default preset, as it is built-in.

--- a/packages/cssnano/test/plugins_config.js
+++ b/packages/cssnano/test/plugins_config.js
@@ -28,6 +28,28 @@ test('should run the plugins in the preset', () => {
     });
 });
 
+test('should run the plugins in the first preset in an array', () => {
+  const preset = litePreset();
+
+  return postcss([cssnano({ preset: [preset] })])
+    .process(
+      `.example {
+    display: grid;
+    transition: all .5s;
+    user-select: none;
+    background: linear-gradient(to bottom, white, black);
+}
+`,
+      { from: undefined }
+    )
+    .then((result) => {
+      assert.is(
+        result.css,
+        `.example{display:grid;transition:all .5s;user-select:none;background:linear-gradient(to bottom,white,black)}`
+      );
+    });
+});
+
 test('should run the plugin passed through the cssnano config.plugins', () => {
   const preset = litePreset({ discardComments: false });
 


### PR DESCRIPTION
Thanks for such a brilliant utility 😊

I've fixed a couple of lines in [**packages/cssnano/src/index.js**](https://github.com/cssnano/cssnano/blob/a352df203eebff22f8b3b2ac458fe296474e9bf1/packages/cssnano/src/index.js#L36-L42) where arrays of presets are handled

See how the first preset in an array is assigned to `fn` and `options`?

https://github.com/cssnano/cssnano/blob/a352df203eebff22f8b3b2ac458fe296474e9bf1/packages/cssnano/src/index.js#L36-L42

The lines that follow use `preset` by mistake, rather than `fn`

```patch
+  if (preset.plugins) {
+    return preset.plugins;
-  if (fn.plugins) {
-    return fn.plugins;
   }
```

This affects the third example below but is fixed by this PR

## Single preset, already invoked

```js
cssnano({ // Works ✅
  preset: cssnanoPresetDefault({
    cssDeclarationSorter: false
  })
})
```

## Preset in array, separate config

```js
cssnano({ // Works ✅
  preset: [cssnanoPresetDefault, {
    cssDeclarationSorter: false
  }]
})
```

## Preset in array, already invoked

```js
cssnano({ // Error: Cannot load preset ❌
  preset: [
    cssnanoPresetDefault({
      cssDeclarationSorter: false
    })
  ]
})
```