### PR TITLE
fix: add missing type declarations to plugins with options

### DIFF
--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "autoprefixer": "^10.4.17",
+    "browserslist": "^4.23.0",
     "cssnano-preset-default": "workspace:^",
     "postcss-discard-unused": "workspace:^",
     "postcss-merge-idents": "workspace:^",

--- a/packages/cssnano-preset-advanced/src/index.js
+++ b/packages/cssnano-preset-advanced/src/index.js
@@ -6,26 +6,41 @@ const postcssReduceIdents = require('postcss-reduce-idents');
 const postcssZindex = require('postcss-zindex');
 const autoprefixer = require('autoprefixer');
 
-/** @typedef {
-{autoprefixer?: autoprefixer.Options,
- discardUnused?: false | import('postcss-discard-unused').Options & { exclude?: true},
- mergeIdents?: false | { exclude?: true},
- reduceIdents?:false | import('postcss-reduce-idents').Options & { exclude?: true},
- zindex?: false | import('postcss-zindex').Options & { exclude?: true},
-}} AdvancedOptions */
-/** @typedef {import('cssnano-preset-default').Options & AdvancedOptions} Options */
+/**
+ * @template {object | void} [OptionsExtends=void]
+ * @typedef {false | OptionsExtends & {exclude?: true}} SimpleOptions
+ */
 
-/** @type {Options} */
+/**
+ * @typedef {object} AdvancedOptions
+ * @property {autoprefixer.Options} [autoprefixer]
+ * @property {SimpleOptions<import('postcss-discard-unused').Options>} [discardUnused]
+ * @property {SimpleOptions} [mergeIdents]
+ * @property {SimpleOptions<import('postcss-reduce-idents').Options>} [reduceIdents]
+ * @property {SimpleOptions<import('postcss-zindex').Options>} [zindex]
+ */
+
+/**
+ * @typedef {defaultPreset.Options & AdvancedOptions} Options
+ */
+
+/** @type {AdvancedOptions} */
 const defaultOpts = {
   autoprefixer: {
     add: false,
   },
 };
 
+/**
+ * Advanced optimisations for cssnano; may or may not break your CSS!
+ *
+ * @param {Options} opts
+ * @returns {{ plugins: [import('postcss').PluginCreator<any>, Options[keyof Options]][] }}
+ */
 function advancedPreset(opts = {}) {
   const options = Object.assign({}, defaultOpts, opts);
 
-  /** @type {[import('postcss').PluginCreator<any>, boolean | Record<string, any> | undefined][]} */
+  /** @type {ReturnType<typeof advancedPreset>["plugins"]} **/
   const plugins = [
     ...defaultPreset(options).plugins,
     [autoprefixer, options.autoprefixer],

--- a/packages/cssnano-preset-advanced/types/index.d.ts
+++ b/packages/cssnano-preset-advanced/types/index.d.ts
@@ -1,24 +1,29 @@
 export = advancedPreset;
-declare function advancedPreset(opts?: {}): {
-    plugins: [import("postcss").PluginCreator<any>, boolean | Record<string, any> | undefined][];
+/**
+ * Advanced optimisations for cssnano; may or may not break your CSS!
+ *
+ * @param {Options} opts
+ * @returns {{ plugins: [import('postcss').PluginCreator<any>, Options[keyof Options]][] }}
+ */
+declare function advancedPreset(opts?: Options): {
+    plugins: [import('postcss').PluginCreator<any>, Options[keyof Options]][];
 };
 declare namespace advancedPreset {
-    export { AdvancedOptions, Options };
+    export { SimpleOptions, AdvancedOptions, Options };
 }
+type Options = defaultPreset.Options & AdvancedOptions;
+type SimpleOptions<OptionsExtends extends void | object = void> = false | (OptionsExtends & {
+    exclude?: true;
+});
 type AdvancedOptions = {
-    autoprefixer?: autoprefixer.Options;
-    discardUnused?: false | import('postcss-discard-unused').Options & {
-        exclude?: true;
-    };
-    mergeIdents?: false | {
-        exclude?: true;
-    };
-    reduceIdents?: false | import('postcss-reduce-idents').Options & {
-        exclude?: true;
-    };
-    zindex?: false | import('postcss-zindex').Options & {
-        exclude?: true;
-    };
+    autoprefixer?: autoprefixer.Options | undefined;
+    discardUnused?: SimpleOptions<postcssDiscardUnused.Options> | undefined;
+    mergeIdents?: SimpleOptions<void> | undefined;
+    reduceIdents?: SimpleOptions<postcssReduceIdents.Options> | undefined;
+    zindex?: SimpleOptions<postcssZindex.Options> | undefined;
 };
-type Options = import('cssnano-preset-default').Options & AdvancedOptions;
+import defaultPreset = require("cssnano-preset-default");
 import autoprefixer = require("autoprefixer");
+import postcssDiscardUnused = require("postcss-discard-unused");
+import postcssReduceIdents = require("postcss-reduce-idents");
+import postcssZindex = require("postcss-zindex");

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -11,6 +11,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "browserslist": "^4.23.0",
     "css-declaration-sorter": "^7.1.1",
     "cssnano-utils": "workspace:^",
     "postcss-calc": "^9.0.1",

--- a/packages/cssnano-preset-default/src/index.js
+++ b/packages/cssnano-preset-default/src/index.js
@@ -61,7 +61,7 @@ const { rawCache } = require('cssnano-utils');
  * @property {SimpleOptions<import('postcss-colormin').Options>} [colormin]
  * @property {SimpleOptions} [orderedValues]
  * @property {SimpleOptions} [minifySelectors]
- * @property {SimpleOptions} [minifyParams]
+ * @property {SimpleOptions<import('postcss-minify-params').Options>} [minifyParams]
  * @property {SimpleOptions<import('postcss-normalize-charset').Options>} [normalizeCharset]
  * @property {SimpleOptions<import('postcss-minify-font-values').Options>} [minifyFontValues]
  * @property {SimpleOptions} [normalizeUrl]

--- a/packages/cssnano-preset-default/src/index.js
+++ b/packages/cssnano-preset-default/src/index.js
@@ -50,6 +50,7 @@ const { rawCache } = require('cssnano-utils');
 
 /**
  * @typedef {object} Options
+ * @property {SimpleOptions<Parameters<typeof cssDeclarationSorter>[0]>} [cssDeclarationSorter]
  * @property {SimpleOptions<import('postcss-discard-comments').Options>} [discardComments]
  * @property {SimpleOptions} [reduceInitial]
  * @property {SimpleOptions} [minifyGradients]

--- a/packages/cssnano-preset-default/src/index.js
+++ b/packages/cssnano-preset-default/src/index.js
@@ -58,7 +58,7 @@ const { rawCache } = require('cssnano-utils');
  * @property {SimpleOptions} [reduceTransforms]
  * @property {SimpleOptions<import('postcss-convert-values').Options>} [convertValues]
  * @property {SimpleOptions<import('postcss-calc').PostCssCalcOptions>} [calc]
- * @property {SimpleOptions<Record<string, any>>} [colormin]
+ * @property {SimpleOptions<import('postcss-colormin').Options>} [colormin]
  * @property {SimpleOptions} [orderedValues]
  * @property {SimpleOptions} [minifySelectors]
  * @property {SimpleOptions} [minifyParams]

--- a/packages/cssnano-preset-default/src/index.js
+++ b/packages/cssnano-preset-default/src/index.js
@@ -43,35 +43,42 @@ const postcssNormalizeDisplayValues = require('postcss-normalize-display-values'
 const postcssNormalizeTimingFunctions = require('postcss-normalize-timing-functions');
 const { rawCache } = require('cssnano-utils');
 
-/** @typedef {{
-discardComments?: false | import('postcss-discard-comments').Options & { exclude?: true},
-reduceInitial?:  false | { exclude?: true}
-minifyGradients?:  false | { exclude?: true}
-svgo?: false | import('postcss-svgo').Options & { exclude?: true},
-reduceTransforms?:  false | { exclude?: true}
-convertValues?: false | import('postcss-convert-values').Options & { exclude?: true},
-calc?: false | import('postcss-calc').PostCssCalcOptions & { exclude?: true},
-colormin?: false | Record<string, any> & { exclude?: true},
-orderedValues?: false | { exclude?: true},
-minifySelectors?: false | { exclude?: true},
-minifyParams?: false | { exclude?: true},
-normalizeCharset?: false | import('postcss-normalize-charset').Options & { exclude?: true},
-minifyFontValues?: false | import('postcss-minify-font-values').Options & { exclude?: true},
-normalizeUrl?: false | { exclude?: true},
-mergeLonghand?: false | { exclude?: true},
-discardDuplicates?: false | { exclude?: true},
-discardOverridden?: false | { exclude?: true},
-normalizeRepeatStyle?: false | { exclude?: true},
-mergeRules?: false | { exclude?: true},
-discardEmpty?: false | { exclude?: true},
-uniqueSelectors?: false | { exclude?: true},
-normalizeString?: false | import('postcss-normalize-string').Options & { exclude?: true},
-normalizePositions?: false | { exclude?: true},
-normalizeWhitespace?: false| { exclude?: true},
-normalizeUnicode?: false | { exclude?: true},
-normalizeDisplayValues?: false | { exclude?: true},
-normalizeTimingFunctions?: false | { exclude?: true},
-rawCache?: false | { exclude?: true}}} Options */
+/**
+ * @template {object | void} [OptionsExtends=void]
+ * @typedef {false | OptionsExtends & {exclude?: true}} SimpleOptions
+ */
+
+/**
+ * @typedef {object} Options
+ * @property {SimpleOptions<import('postcss-discard-comments').Options>} [discardComments]
+ * @property {SimpleOptions} [reduceInitial]
+ * @property {SimpleOptions} [minifyGradients]
+ * @property {SimpleOptions<import('postcss-svgo').Options>} [svgo]
+ * @property {SimpleOptions} [reduceTransforms]
+ * @property {SimpleOptions<import('postcss-convert-values').Options>} [convertValues]
+ * @property {SimpleOptions<import('postcss-calc').PostCssCalcOptions>} [calc]
+ * @property {SimpleOptions<Record<string, any>>} [colormin]
+ * @property {SimpleOptions} [orderedValues]
+ * @property {SimpleOptions} [minifySelectors]
+ * @property {SimpleOptions} [minifyParams]
+ * @property {SimpleOptions<import('postcss-normalize-charset').Options>} [normalizeCharset]
+ * @property {SimpleOptions<import('postcss-minify-font-values').Options>} [minifyFontValues]
+ * @property {SimpleOptions} [normalizeUrl]
+ * @property {SimpleOptions} [mergeLonghand]
+ * @property {SimpleOptions} [discardDuplicates]
+ * @property {SimpleOptions} [discardOverridden]
+ * @property {SimpleOptions} [normalizeRepeatStyle]
+ * @property {SimpleOptions} [mergeRules]
+ * @property {SimpleOptions} [discardEmpty]
+ * @property {SimpleOptions} [uniqueSelectors]
+ * @property {SimpleOptions<import('postcss-normalize-string').Options>} [normalizeString]
+ * @property {SimpleOptions} [normalizePositions]
+ * @property {SimpleOptions} [normalizeWhitespace]
+ * @property {SimpleOptions} [normalizeUnicode]
+ * @property {SimpleOptions} [normalizeDisplayValues]
+ * @property {SimpleOptions} [normalizeTimingFunctions]
+ * @property {SimpleOptions} [rawCache]
+ */
 
 const defaultOpts = {
   convertValues: {
@@ -86,13 +93,15 @@ const defaultOpts = {
 };
 
 /**
+ * Safe defaults for cssnano which require minimal configuration
+ *
  * @param {Options} opts
- * @return {{plugins: [import('postcss').PluginCreator<any>, boolean | Record<string, any> | undefined][]}}
+ * @returns {{ plugins: [import('postcss').PluginCreator<any>, Options[keyof Options]][] }}
  */
 function defaultPreset(opts = {}) {
   const options = Object.assign({}, defaultOpts, opts);
 
-  /** @type {[import('postcss').PluginCreator<any>, boolean | Record<string, any> | undefined][]} **/
+  /** @satisfies {ReturnType<typeof defaultPreset>["plugins"]} */
   const plugins = [
     [postcssDiscardComments, options.discardComments],
     [postcssMinifyGradients, options.minifyGradients],

--- a/packages/cssnano-preset-default/src/index.js
+++ b/packages/cssnano-preset-default/src/index.js
@@ -52,7 +52,7 @@ const { rawCache } = require('cssnano-utils');
  * @typedef {object} Options
  * @property {SimpleOptions<Parameters<typeof cssDeclarationSorter>[0]>} [cssDeclarationSorter]
  * @property {SimpleOptions<import('postcss-discard-comments').Options>} [discardComments]
- * @property {SimpleOptions} [reduceInitial]
+ * @property {SimpleOptions<import('postcss-reduce-initial').Options>} [reduceInitial]
  * @property {SimpleOptions} [minifyGradients]
  * @property {SimpleOptions<import('postcss-svgo').Options>} [svgo]
  * @property {SimpleOptions} [reduceTransforms]

--- a/packages/cssnano-preset-default/types/index.d.ts
+++ b/packages/cssnano-preset-default/types/index.d.ts
@@ -17,7 +17,7 @@ type Options = {
         keepOverrides?: boolean | undefined;
     } | undefined> | undefined;
     discardComments?: SimpleOptions<postcssDiscardComments.Options> | undefined;
-    reduceInitial?: SimpleOptions<void> | undefined;
+    reduceInitial?: SimpleOptions<postcssReduceInitial.Options> | undefined;
     minifyGradients?: SimpleOptions<void> | undefined;
     svgo?: SimpleOptions<postcssSvgo.Options> | undefined;
     reduceTransforms?: SimpleOptions<void> | undefined;
@@ -49,6 +49,7 @@ type SimpleOptions<OptionsExtends extends void | object = void> = false | (Optio
     exclude?: true;
 });
 import postcssDiscardComments = require("postcss-discard-comments");
+import postcssReduceInitial = require("postcss-reduce-initial");
 import postcssSvgo = require("postcss-svgo");
 import postcssConvertValues = require("postcss-convert-values");
 import postcssCalc = require("postcss-calc");

--- a/packages/cssnano-preset-default/types/index.d.ts
+++ b/packages/cssnano-preset-default/types/index.d.ts
@@ -23,7 +23,7 @@ type Options = {
     reduceTransforms?: SimpleOptions<void> | undefined;
     convertValues?: SimpleOptions<postcssConvertValues.Options> | undefined;
     calc?: SimpleOptions<postcssCalc.PostCssCalcOptions> | undefined;
-    colormin?: SimpleOptions<Record<string, any>> | undefined;
+    colormin?: SimpleOptions<postcssColormin.Options> | undefined;
     orderedValues?: SimpleOptions<void> | undefined;
     minifySelectors?: SimpleOptions<void> | undefined;
     minifyParams?: SimpleOptions<void> | undefined;
@@ -52,6 +52,7 @@ import postcssDiscardComments = require("postcss-discard-comments");
 import postcssSvgo = require("postcss-svgo");
 import postcssConvertValues = require("postcss-convert-values");
 import postcssCalc = require("postcss-calc");
+import postcssColormin = require("postcss-colormin");
 import postcssNormalizeCharset = require("postcss-normalize-charset");
 import postcssMinifyFontValues = require("postcss-minify-font-values");
 import postcssNormalizeString = require("postcss-normalize-string");

--- a/packages/cssnano-preset-default/types/index.d.ts
+++ b/packages/cssnano-preset-default/types/index.d.ts
@@ -12,6 +12,10 @@ declare namespace defaultPreset {
     export { SimpleOptions, Options };
 }
 type Options = {
+    cssDeclarationSorter?: SimpleOptions<{
+        order?: ("alphabetical" | "concentric-css" | "smacss") | ((propertyNameA: string, propertyNameB: string) => 0 | 1 | -1) | undefined;
+        keepOverrides?: boolean | undefined;
+    } | undefined> | undefined;
     discardComments?: SimpleOptions<postcssDiscardComments.Options> | undefined;
     reduceInitial?: SimpleOptions<void> | undefined;
     minifyGradients?: SimpleOptions<void> | undefined;

--- a/packages/cssnano-preset-default/types/index.d.ts
+++ b/packages/cssnano-preset-default/types/index.d.ts
@@ -26,7 +26,7 @@ type Options = {
     colormin?: SimpleOptions<postcssColormin.Options> | undefined;
     orderedValues?: SimpleOptions<void> | undefined;
     minifySelectors?: SimpleOptions<void> | undefined;
-    minifyParams?: SimpleOptions<void> | undefined;
+    minifyParams?: SimpleOptions<postcssMinifyParams.BrowserslistOptions> | undefined;
     normalizeCharset?: SimpleOptions<postcssNormalizeCharset.Options> | undefined;
     minifyFontValues?: SimpleOptions<postcssMinifyFontValues.Options> | undefined;
     normalizeUrl?: SimpleOptions<void> | undefined;
@@ -54,6 +54,7 @@ import postcssSvgo = require("postcss-svgo");
 import postcssConvertValues = require("postcss-convert-values");
 import postcssCalc = require("postcss-calc");
 import postcssColormin = require("postcss-colormin");
+import postcssMinifyParams = require("postcss-minify-params");
 import postcssNormalizeCharset = require("postcss-normalize-charset");
 import postcssMinifyFontValues = require("postcss-minify-font-values");
 import postcssNormalizeString = require("postcss-normalize-string");

--- a/packages/cssnano-preset-default/types/index.d.ts
+++ b/packages/cssnano-preset-default/types/index.d.ts
@@ -1,98 +1,53 @@
 export = defaultPreset;
 /**
+ * Safe defaults for cssnano which require minimal configuration
+ *
  * @param {Options} opts
- * @return {{plugins: [import('postcss').PluginCreator<any>, boolean | Record<string, any> | undefined][]}}
+ * @returns {{ plugins: [import('postcss').PluginCreator<any>, Options[keyof Options]][] }}
  */
 declare function defaultPreset(opts?: Options): {
-    plugins: [import('postcss').PluginCreator<any>, boolean | Record<string, any> | undefined][];
+    plugins: [import('postcss').PluginCreator<any>, Options[keyof Options]][];
 };
 declare namespace defaultPreset {
-    export { Options };
+    export { SimpleOptions, Options };
 }
 type Options = {
-    discardComments?: false | import('postcss-discard-comments').Options & {
-        exclude?: true;
-    };
-    reduceInitial?: false | {
-        exclude?: true;
-    };
-    minifyGradients?: false | {
-        exclude?: true;
-    };
-    svgo?: false | import('postcss-svgo').Options & {
-        exclude?: true;
-    };
-    reduceTransforms?: false | {
-        exclude?: true;
-    };
-    convertValues?: false | import('postcss-convert-values').Options & {
-        exclude?: true;
-    };
-    calc?: false | import('postcss-calc').PostCssCalcOptions & {
-        exclude?: true;
-    };
-    colormin?: false | (Record<string, any> & {
-        exclude?: true;
-    });
-    orderedValues?: false | {
-        exclude?: true;
-    };
-    minifySelectors?: false | {
-        exclude?: true;
-    };
-    minifyParams?: false | {
-        exclude?: true;
-    };
-    normalizeCharset?: false | import('postcss-normalize-charset').Options & {
-        exclude?: true;
-    };
-    minifyFontValues?: false | import('postcss-minify-font-values').Options & {
-        exclude?: true;
-    };
-    normalizeUrl?: false | {
-        exclude?: true;
-    };
-    mergeLonghand?: false | {
-        exclude?: true;
-    };
-    discardDuplicates?: false | {
-        exclude?: true;
-    };
-    discardOverridden?: false | {
-        exclude?: true;
-    };
-    normalizeRepeatStyle?: false | {
-        exclude?: true;
-    };
-    mergeRules?: false | {
-        exclude?: true;
-    };
-    discardEmpty?: false | {
-        exclude?: true;
-    };
-    uniqueSelectors?: false | {
-        exclude?: true;
-    };
-    normalizeString?: false | import('postcss-normalize-string').Options & {
-        exclude?: true;
-    };
-    normalizePositions?: false | {
-        exclude?: true;
-    };
-    normalizeWhitespace?: false | {
-        exclude?: true;
-    };
-    normalizeUnicode?: false | {
-        exclude?: true;
-    };
-    normalizeDisplayValues?: false | {
-        exclude?: true;
-    };
-    normalizeTimingFunctions?: false | {
-        exclude?: true;
-    };
-    rawCache?: false | {
-        exclude?: true;
-    };
+    discardComments?: SimpleOptions<postcssDiscardComments.Options> | undefined;
+    reduceInitial?: SimpleOptions<void> | undefined;
+    minifyGradients?: SimpleOptions<void> | undefined;
+    svgo?: SimpleOptions<postcssSvgo.Options> | undefined;
+    reduceTransforms?: SimpleOptions<void> | undefined;
+    convertValues?: SimpleOptions<postcssConvertValues.Options> | undefined;
+    calc?: SimpleOptions<postcssCalc.PostCssCalcOptions> | undefined;
+    colormin?: SimpleOptions<Record<string, any>> | undefined;
+    orderedValues?: SimpleOptions<void> | undefined;
+    minifySelectors?: SimpleOptions<void> | undefined;
+    minifyParams?: SimpleOptions<void> | undefined;
+    normalizeCharset?: SimpleOptions<postcssNormalizeCharset.Options> | undefined;
+    minifyFontValues?: SimpleOptions<postcssMinifyFontValues.Options> | undefined;
+    normalizeUrl?: SimpleOptions<void> | undefined;
+    mergeLonghand?: SimpleOptions<void> | undefined;
+    discardDuplicates?: SimpleOptions<void> | undefined;
+    discardOverridden?: SimpleOptions<void> | undefined;
+    normalizeRepeatStyle?: SimpleOptions<void> | undefined;
+    mergeRules?: SimpleOptions<void> | undefined;
+    discardEmpty?: SimpleOptions<void> | undefined;
+    uniqueSelectors?: SimpleOptions<void> | undefined;
+    normalizeString?: SimpleOptions<postcssNormalizeString.Options> | undefined;
+    normalizePositions?: SimpleOptions<void> | undefined;
+    normalizeWhitespace?: SimpleOptions<void> | undefined;
+    normalizeUnicode?: SimpleOptions<void> | undefined;
+    normalizeDisplayValues?: SimpleOptions<void> | undefined;
+    normalizeTimingFunctions?: SimpleOptions<void> | undefined;
+    rawCache?: SimpleOptions<void> | undefined;
 };
-import { rawCache } from "cssnano-utils";
+type SimpleOptions<OptionsExtends extends void | object = void> = false | (OptionsExtends & {
+    exclude?: true;
+});
+import postcssDiscardComments = require("postcss-discard-comments");
+import postcssSvgo = require("postcss-svgo");
+import postcssConvertValues = require("postcss-convert-values");
+import postcssCalc = require("postcss-calc");
+import postcssNormalizeCharset = require("postcss-normalize-charset");
+import postcssMinifyFontValues = require("postcss-minify-font-values");
+import postcssNormalizeString = require("postcss-normalize-string");

--- a/packages/cssnano-preset-lite/src/index.js
+++ b/packages/cssnano-preset-lite/src/index.js
@@ -4,20 +4,32 @@ const postcssNormalizeWhitespace = require('postcss-normalize-whitespace');
 const postcssDiscardEmpty = require('postcss-discard-empty');
 const { rawCache } = require('cssnano-utils');
 
-/** @typedef {false | { exclude?: true} }SimpleOptions */
-/** @typedef {{discardComments?: false | import('postcss-discard-comments').Options & { exclude?: true},
-normalizeWhitespace?: SimpleOptions, 
-discardEmpty?: SimpleOptions, 
-rawCache?: SimpleOptions}} Options */
-
-const defaultOpts = {};
 /**
- * @param {Options} opts
- * @return {{plugins: [import('postcss').PluginCreator<any>, false | Record<string, any> | undefined][]}}
+ * @template {object | void} [OptionsExtends=void]
+ * @typedef {false | OptionsExtends & {exclude?: true}} SimpleOptions
  */
-function defaultPreset(opts = {}) {
+
+/**
+ * @typedef {object} LiteOptions
+ * @property {SimpleOptions<import('postcss-discard-comments').Options>} [discardComments]
+ * @property {SimpleOptions} [normalizeWhitespace]
+ * @property {SimpleOptions} [discardEmpty]
+ * @property {SimpleOptions} [rawCache]
+ */
+
+/** @satisfies {LiteOptions} */
+const defaultOpts = {};
+
+/**
+ * Safe and minimum transformation with just removing whitespaces, line breaks and comments
+ *
+ * @param {LiteOptions} opts
+ * @returns {{ plugins: [import('postcss').PluginCreator<any>, LiteOptions[keyof LiteOptions]][] }}
+ */
+function litePreset(opts = {}) {
   const options = Object.assign({}, defaultOpts, opts);
-  /** @type {[import('postcss').PluginCreator<any>, false | Record<string, any> | undefined][]} **/
+
+  /** @satisfies {ReturnType<typeof litePreset>["plugins"]} */
   const plugins = [
     [postcssDiscardComments, options.discardComments],
     [postcssNormalizeWhitespace, options.normalizeWhitespace],
@@ -28,4 +40,4 @@ function defaultPreset(opts = {}) {
   return { plugins };
 }
 
-module.exports = defaultPreset;
+module.exports = litePreset;

--- a/packages/cssnano-preset-lite/types/index.d.ts
+++ b/packages/cssnano-preset-lite/types/index.d.ts
@@ -1,23 +1,23 @@
-export = defaultPreset;
+export = litePreset;
 /**
- * @param {Options} opts
- * @return {{plugins: [import('postcss').PluginCreator<any>, false | Record<string, any> | undefined][]}}
+ * Safe and minimum transformation with just removing whitespaces, line breaks and comments
+ *
+ * @param {LiteOptions} opts
+ * @returns {{ plugins: [import('postcss').PluginCreator<any>, LiteOptions[keyof LiteOptions]][] }}
  */
-declare function defaultPreset(opts?: Options): {
-    plugins: [import('postcss').PluginCreator<any>, false | Record<string, any> | undefined][];
+declare function litePreset(opts?: LiteOptions): {
+    plugins: [import('postcss').PluginCreator<any>, LiteOptions[keyof LiteOptions]][];
 };
-declare namespace defaultPreset {
-    export { SimpleOptions, Options };
+declare namespace litePreset {
+    export { SimpleOptions, LiteOptions };
 }
-type Options = {
-    discardComments?: false | import('postcss-discard-comments').Options & {
-        exclude?: true;
-    };
-    normalizeWhitespace?: SimpleOptions;
-    discardEmpty?: SimpleOptions;
-    rawCache?: SimpleOptions;
+type LiteOptions = {
+    discardComments?: SimpleOptions<postcssDiscardComments.Options> | undefined;
+    normalizeWhitespace?: SimpleOptions<void> | undefined;
+    discardEmpty?: SimpleOptions<void> | undefined;
+    rawCache?: SimpleOptions<void> | undefined;
 };
-type SimpleOptions = false | {
+type SimpleOptions<OptionsExtends extends void | object = void> = false | (OptionsExtends & {
     exclude?: true;
-};
-import { rawCache } from "cssnano-utils";
+});
+import postcssDiscardComments = require("postcss-discard-comments");

--- a/packages/postcss-colormin/src/index.js
+++ b/packages/postcss-colormin/src/index.js
@@ -41,7 +41,7 @@ function isMathFunctionNode(node) {
 
 /**
  * @param {string} value
- * @param {Record<string, boolean>} options
+ * @param {Options} options
  * @return {string}
  */
 function transform(value, options) {
@@ -83,9 +83,9 @@ function transform(value, options) {
 }
 
 /**
- * @param {Record<string, boolean>} options
+ * @param {Options} options
  * @param {string[]} browsers
- * @return {Record<string, boolean>}
+ * @return {Options}
  */
 function addPluginDefaults(options, browsers) {
   const defaults = {
@@ -98,9 +98,20 @@ function addPluginDefaults(options, browsers) {
   };
   return { ...defaults, ...options };
 }
+
 /**
- * @type {import('postcss').PluginCreator<Record<string, boolean>>}
- * @param {Record<string, boolean>} config
+ * @typedef {object} Options
+ * @property {boolean} [hex]
+ * @property {boolean} [alphaHex]
+ * @property {boolean} [rgb]
+ * @property {boolean} [hsl]
+ * @property {boolean} [name]
+ * @property {boolean} [transparent]
+ */
+
+/**
+ * @type {import('postcss').PluginCreator<Options>}
+ * @param {Options} config
  * @return {import('postcss').Plugin}
  */
 function pluginCreator(config = {}) {

--- a/packages/postcss-colormin/src/index.js
+++ b/packages/postcss-colormin/src/index.js
@@ -100,13 +100,18 @@ function addPluginDefaults(options, browsers) {
 }
 
 /**
- * @typedef {object} Options
+ * @typedef {object} MinifyColorOptions
  * @property {boolean} [hex]
  * @property {boolean} [alphaHex]
  * @property {boolean} [rgb]
  * @property {boolean} [hsl]
  * @property {boolean} [name]
  * @property {boolean} [transparent]
+ */
+
+/**
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ * @typedef {MinifyColorOptions & BrowserslistOptions} Options
  */
 
 /**
@@ -118,8 +123,10 @@ function pluginCreator(config = {}) {
   return {
     postcssPlugin: 'postcss-colormin',
 
+    /**
+     * @param {import('postcss').Result & {opts: BrowserslistOptions}} result
+     */
     prepare(result) {
-      /** @type {typeof result.opts & browserslist.Options} */
       const resultOptions = result.opts || {};
       const browsers = browserslist(null, {
         stats: resultOptions.stats,

--- a/packages/postcss-colormin/src/minifyColor.js
+++ b/packages/postcss-colormin/src/minifyColor.js
@@ -9,7 +9,7 @@ extend(/** @type {any[]} */ ([namesPlugin, minifierPlugin]));
  * Performs color value minification
  *
  * @param {string} input - CSS value
- * @param {Record<string, boolean>} options  object with colord.minify() options
+ * @param {import('./index.js').Options} options - object with colord.minify() options
  * @return {string}
  */
 module.exports = function minifyColor(input, options = {}) {

--- a/packages/postcss-colormin/src/minifyColor.js
+++ b/packages/postcss-colormin/src/minifyColor.js
@@ -9,7 +9,7 @@ extend(/** @type {any[]} */ ([namesPlugin, minifierPlugin]));
  * Performs color value minification
  *
  * @param {string} input - CSS value
- * @param {import('./index.js').Options} options - object with colord.minify() options
+ * @param {import('./index.js').MinifyColorOptions} options - object with colord.minify() options
  * @return {string}
  */
 module.exports = function minifyColor(input, options = {}) {

--- a/packages/postcss-colormin/types/index.d.ts
+++ b/packages/postcss-colormin/types/index.d.ts
@@ -1,10 +1,28 @@
 export = pluginCreator;
 /**
- * @type {import('postcss').PluginCreator<Record<string, boolean>>}
- * @param {Record<string, boolean>} config
+ * @typedef {object} Options
+ * @property {boolean} [hex]
+ * @property {boolean} [alphaHex]
+ * @property {boolean} [rgb]
+ * @property {boolean} [hsl]
+ * @property {boolean} [name]
+ * @property {boolean} [transparent]
+ */
+/**
+ * @type {import('postcss').PluginCreator<Options>}
+ * @param {Options} config
  * @return {import('postcss').Plugin}
  */
-declare function pluginCreator(config?: Record<string, boolean>): import('postcss').Plugin;
+declare function pluginCreator(config?: Options): import('postcss').Plugin;
 declare namespace pluginCreator {
-    let postcss: true;
+    export { postcss, Options };
 }
+type Options = {
+    hex?: boolean | undefined;
+    alphaHex?: boolean | undefined;
+    rgb?: boolean | undefined;
+    hsl?: boolean | undefined;
+    name?: boolean | undefined;
+    transparent?: boolean | undefined;
+};
+declare var postcss: true;

--- a/packages/postcss-colormin/types/index.d.ts
+++ b/packages/postcss-colormin/types/index.d.ts
@@ -1,6 +1,6 @@
 export = pluginCreator;
 /**
- * @typedef {object} Options
+ * @typedef {object} MinifyColorOptions
  * @property {boolean} [hex]
  * @property {boolean} [alphaHex]
  * @property {boolean} [rgb]
@@ -9,15 +9,21 @@ export = pluginCreator;
  * @property {boolean} [transparent]
  */
 /**
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ * @typedef {MinifyColorOptions & BrowserslistOptions} Options
+ */
+/**
  * @type {import('postcss').PluginCreator<Options>}
  * @param {Options} config
  * @return {import('postcss').Plugin}
  */
 declare function pluginCreator(config?: Options): import('postcss').Plugin;
 declare namespace pluginCreator {
-    export { postcss, Options };
+    export { postcss, MinifyColorOptions, BrowserslistOptions, Options };
 }
-type Options = {
+type Options = MinifyColorOptions & BrowserslistOptions;
+declare var postcss: true;
+type MinifyColorOptions = {
     hex?: boolean | undefined;
     alphaHex?: boolean | undefined;
     rgb?: boolean | undefined;
@@ -25,4 +31,5 @@ type Options = {
     name?: boolean | undefined;
     transparent?: boolean | undefined;
 };
-declare var postcss: true;
+type BrowserslistOptions = Pick<browserslist.Options, 'stats' | 'env'>;
+import browserslist = require("browserslist");

--- a/packages/postcss-colormin/types/minifyColor.d.ts
+++ b/packages/postcss-colormin/types/minifyColor.d.ts
@@ -1,2 +1,2 @@
-declare function _exports(input: string, options?: import('./index.js').Options): string;
+declare function _exports(input: string, options?: import('./index.js').MinifyColorOptions): string;
 export = _exports;

--- a/packages/postcss-colormin/types/minifyColor.d.ts
+++ b/packages/postcss-colormin/types/minifyColor.d.ts
@@ -1,2 +1,2 @@
-declare function _exports(input: string, options?: Record<string, boolean>): string;
+declare function _exports(input: string, options?: import('./index.js').Options): string;
 export = _exports;

--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -194,8 +194,11 @@ function transform(opts, browsers, decl) {
 }
 
 const plugin = 'postcss-convert-values';
+
 /**
- * @typedef {{precision: boolean | number, angle?: boolean, time?: boolean, length?: boolean} & browserslist.Options} Options */
+ * @typedef {{precision?: false | number, angle?: boolean, time?: boolean, length?: boolean} & browserslist.Options} Options
+ */
+
 /**
  * @type {import('postcss').PluginCreator<Options>}
  * @param {Options} opts

--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -196,7 +196,9 @@ function transform(opts, browsers, decl) {
 const plugin = 'postcss-convert-values';
 
 /**
- * @typedef {{precision?: false | number, angle?: boolean, time?: boolean, length?: boolean} & browserslist.Options} Options
+ * @typedef {Parameters<typeof convert>[2]} ConvertOptions
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ * @typedef {{precision?: false | number} & ConvertOptions & BrowserslistOptions} Options
  */
 
 /**

--- a/packages/postcss-convert-values/types/index.d.ts
+++ b/packages/postcss-convert-values/types/index.d.ts
@@ -1,6 +1,8 @@
 export = pluginCreator;
 /**
- * @typedef {{precision?: false | number, angle?: boolean, time?: boolean, length?: boolean} & browserslist.Options} Options
+ * @typedef {Parameters<typeof convert>[2]} ConvertOptions
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ * @typedef {{precision?: false | number} & ConvertOptions & BrowserslistOptions} Options
  */
 /**
  * @type {import('postcss').PluginCreator<Options>}
@@ -9,13 +11,22 @@ export = pluginCreator;
  */
 declare function pluginCreator(opts?: Options): import('postcss').Plugin;
 declare namespace pluginCreator {
-    export { postcss, Options };
+    export { postcss, ConvertOptions, BrowserslistOptions, Options };
 }
 type Options = {
     precision?: false | number;
-    angle?: boolean;
-    time?: boolean;
-    length?: boolean;
-} & browserslist.Options;
+} & ConvertOptions & BrowserslistOptions;
 declare var postcss: true;
+type ConvertOptions = [number: number, unit: string, {
+    time?: boolean | undefined;
+    /**
+     * @param {valueParser.Node} node
+     * @param {Options} opts
+     * @param {boolean} keepZeroUnit
+     * @return {void}
+     */
+    length?: boolean | undefined;
+    angle?: boolean | undefined;
+}][2];
+type BrowserslistOptions = Pick<browserslist.Options, 'stats' | 'env'>;
 import browserslist = require("browserslist");

--- a/packages/postcss-convert-values/types/index.d.ts
+++ b/packages/postcss-convert-values/types/index.d.ts
@@ -1,6 +1,7 @@
 export = pluginCreator;
 /**
- * @typedef {{precision: boolean | number, angle?: boolean, time?: boolean, length?: boolean} & browserslist.Options} Options */
+ * @typedef {{precision?: false | number, angle?: boolean, time?: boolean, length?: boolean} & browserslist.Options} Options
+ */
 /**
  * @type {import('postcss').PluginCreator<Options>}
  * @param {Options} opts
@@ -11,7 +12,7 @@ declare namespace pluginCreator {
     export { postcss, Options };
 }
 type Options = {
-    precision: boolean | number;
+    precision?: false | number;
     angle?: boolean;
     time?: boolean;
     length?: boolean;

--- a/packages/postcss-merge-rules/src/index.js
+++ b/packages/postcss-merge-rules/src/index.js
@@ -406,6 +406,11 @@ function selectorMerger(browsers, compatibilityCache) {
     cache = partialMerge(cache, rule);
   };
 }
+
+/**
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ */
+
 /**
  * @type {import('postcss').PluginCreator<void>}
  * @return {import('postcss').Plugin}
@@ -414,8 +419,10 @@ function pluginCreator() {
   return {
     postcssPlugin: 'postcss-merge-rules',
 
+    /**
+     * @param {import('postcss').Result & {opts: BrowserslistOptions}} result
+     */
     prepare(result) {
-      /** @type {typeof result.opts & browserslist.Options} */
       const resultOpts = result.opts || {};
       const browsers = browserslist(null, {
         stats: resultOpts.stats,

--- a/packages/postcss-merge-rules/types/index.d.ts
+++ b/packages/postcss-merge-rules/types/index.d.ts
@@ -1,9 +1,15 @@
 export = pluginCreator;
 /**
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ */
+/**
  * @type {import('postcss').PluginCreator<void>}
  * @return {import('postcss').Plugin}
  */
 declare function pluginCreator(): import('postcss').Plugin;
 declare namespace pluginCreator {
-    let postcss: true;
+    export { postcss, BrowserslistOptions };
 }
+declare var postcss: true;
+type BrowserslistOptions = Pick<browserslist.Options, 'stats' | 'env'>;
+import browserslist = require("browserslist");

--- a/packages/postcss-minify-params/src/index.js
+++ b/packages/postcss-minify-params/src/index.js
@@ -133,8 +133,13 @@ function transform(legacy, rule) {
 const allBugBrowers = new Set(['ie 10', 'ie 11']);
 
 /**
- * @type {import('postcss').PluginCreator<browserslist.Options>}
- * @param {browserslist.Options} options
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ * @typedef {BrowserslistOptions} Options
+ */
+
+/**
+ * @type {import('postcss').PluginCreator<Options>}
+ * @param {Options} options
  * @return {import('postcss').Plugin}
  */
 function pluginCreator(options = {}) {

--- a/packages/postcss-minify-params/types/index.d.ts
+++ b/packages/postcss-minify-params/types/index.d.ts
@@ -1,11 +1,18 @@
 export = pluginCreator;
 /**
- * @type {import('postcss').PluginCreator<browserslist.Options>}
- * @param {browserslist.Options} options
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ * @typedef {BrowserslistOptions} Options
+ */
+/**
+ * @type {import('postcss').PluginCreator<Options>}
+ * @param {Options} options
  * @return {import('postcss').Plugin}
  */
-declare function pluginCreator(options?: browserslist.Options): import('postcss').Plugin;
+declare function pluginCreator(options?: Options): import('postcss').Plugin;
 declare namespace pluginCreator {
-    let postcss: true;
+    export { postcss, BrowserslistOptions, Options };
 }
+type Options = BrowserslistOptions;
+declare var postcss: true;
+type BrowserslistOptions = Pick<browserslist.Options, 'stats' | 'env'>;
 import browserslist = require("browserslist");

--- a/packages/postcss-normalize-unicode/src/index.js
+++ b/packages/postcss-normalize-unicode/src/index.js
@@ -89,13 +89,20 @@ function transform(value, isLegacy = false) {
 }
 
 /**
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ */
+
+/**
  * @type {import('postcss').PluginCreator<void>}
  * @return {import('postcss').Plugin}
  */
 function pluginCreator() {
   return {
     postcssPlugin: 'postcss-normalize-unicode',
-    /** @param {import('postcss').Result & {opts: browserslist.Options}} result*/
+
+    /**
+     * @param {import('postcss').Result & {opts: BrowserslistOptions}} result
+     */
     prepare(result) {
       const cache = new Map();
       const resultOpts = result.opts || {};

--- a/packages/postcss-normalize-unicode/types/index.d.ts
+++ b/packages/postcss-normalize-unicode/types/index.d.ts
@@ -1,9 +1,15 @@
 export = pluginCreator;
 /**
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ */
+/**
  * @type {import('postcss').PluginCreator<void>}
  * @return {import('postcss').Plugin}
  */
 declare function pluginCreator(): import('postcss').Plugin;
 declare namespace pluginCreator {
-    let postcss: true;
+    export { postcss, BrowserslistOptions };
 }
+declare var postcss: true;
+type BrowserslistOptions = Pick<browserslist.Options, 'stats' | 'env'>;
+import browserslist = require("browserslist");

--- a/packages/postcss-reduce-initial/src/index.js
+++ b/packages/postcss-reduce-initial/src/index.js
@@ -8,7 +8,11 @@ const initial = 'initial';
 
 // In most of the browser including chrome the initial for `writing-mode` is not `horizontal-tb`. Ref https://github.com/cssnano/cssnano/pull/905
 const defaultIgnoreProps = ['writing-mode', 'transform-box'];
-/** @typedef {{ignore?: string[]}} Options */
+
+/**
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ * @typedef {{ignore?: string[]} & BrowserslistOptions} Options
+ */
 
 /**
  * @type {import('postcss').PluginCreator<Options>}
@@ -18,7 +22,10 @@ const defaultIgnoreProps = ['writing-mode', 'transform-box'];
 function pluginCreator(options = {}) {
   return {
     postcssPlugin: 'postcss-reduce-initial',
-    /** @param {import('postcss').Result & {opts: browserslist.Options & {ignore?: string[]}}} result */
+
+    /**
+     * @param {import('postcss').Result & {opts: BrowserslistOptions}} result
+     */
     prepare(result) {
       const resultOpts = result.opts || {};
       const browsers = browserslist(null, {

--- a/packages/postcss-reduce-initial/types/index.d.ts
+++ b/packages/postcss-reduce-initial/types/index.d.ts
@@ -1,5 +1,8 @@
 export = pluginCreator;
-/** @typedef {{ignore?: string[]}} Options */
+/**
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ * @typedef {{ignore?: string[]} & BrowserslistOptions} Options
+ */
 /**
  * @type {import('postcss').PluginCreator<Options>}
  * @param {Options} options
@@ -7,9 +10,11 @@ export = pluginCreator;
  */
 declare function pluginCreator(options?: Options): import('postcss').Plugin;
 declare namespace pluginCreator {
-    export { postcss, Options };
+    export { postcss, BrowserslistOptions, Options };
 }
 type Options = {
     ignore?: string[];
-};
+} & BrowserslistOptions;
 declare var postcss: true;
+type BrowserslistOptions = Pick<browserslist.Options, 'stats' | 'env'>;
+import browserslist = require("browserslist");

--- a/packages/stylehacks/src/index.js
+++ b/packages/stylehacks/src/index.js
@@ -2,7 +2,10 @@
 const browserslist = require('browserslist');
 const plugins = require('./plugins');
 
-/** @typedef {{lint?: boolean}} Options */
+/**
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ * @typedef {{lint?: boolean} & BrowserslistOptions} Options
+ */
 
 /**
  * @type {import('postcss').PluginCreator<Options>}
@@ -14,7 +17,7 @@ function pluginCreator(opts = {}) {
     postcssPlugin: 'stylehacks',
 
     OnceExit(css, { result }) {
-      /** @type {typeof result.opts & browserslist.Options} */
+      /** @type {typeof result.opts & BrowserslistOptions} */
       const resultOpts = result.opts || {};
       const browsers = browserslist(null, {
         stats: resultOpts.stats,

--- a/packages/stylehacks/types/index.d.ts
+++ b/packages/stylehacks/types/index.d.ts
@@ -1,5 +1,8 @@
 export = pluginCreator;
-/** @typedef {{lint?: boolean}} Options */
+/**
+ * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions
+ * @typedef {{lint?: boolean} & BrowserslistOptions} Options
+ */
 /**
  * @type {import('postcss').PluginCreator<Options>}
  * @param {Options} opts
@@ -7,10 +10,12 @@ export = pluginCreator;
  */
 declare function pluginCreator(opts?: Options): import('postcss').Plugin;
 declare namespace pluginCreator {
-    export { detect, postcss, Options };
+    export { detect, postcss, BrowserslistOptions, Options };
 }
 type Options = {
     lint?: boolean;
-};
+} & BrowserslistOptions;
 declare function detect(node: import('postcss').Node): boolean;
 declare var postcss: true;
+type BrowserslistOptions = Pick<browserslist.Options, 'stats' | 'env'>;
+import browserslist = require("browserslist");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.17
         version: 10.4.17(postcss@8.4.35)
+      browserslist:
+        specifier: ^4.23.0
+        version: 4.23.0
       cssnano-preset-default:
         specifier: workspace:^
         version: link:../cssnano-preset-default
@@ -104,6 +107,9 @@ importers:
 
   packages/cssnano-preset-default:
     dependencies:
+      browserslist:
+        specifier: ^4.23.0
+        version: 4.23.0
       css-declaration-sorter:
         specifier: ^7.1.1
         version: 7.1.1(postcss@8.4.35)


### PR DESCRIPTION
While looking at https://github.com/cssnano/cssnano/pull/1570 and https://github.com/alphagov/govuk-frontend/issues/4810 I noticed that plugin type definitions needed updating

This PR fixes a few missing things:

1. Plugin [`postcss-convert-values`](https://www.npmjs.com/package/postcss-convert-values) option `precision` should be optional
1. Plugin [`postcss-colormin`](https://www.npmjs.com/package/postcss-colormin) option `colormin` (via [`cssnano-preset-default`](https://www.npmjs.com/package/cssnano-preset-default)) is typed without property names
1. Plugin [`postcss-reduce-initial`](https://www.npmjs.com/package/postcss-reduce-initial) option `reduceInitial` (via [`cssnano-preset-default`](https://www.npmjs.com/package/cssnano-preset-default)) is not typed
1. Plugin [`css-declaration-sorter`](https://www.npmjs.com/package/css-declaration-sorter) option `cssDeclarationSorter` (via [`cssnano-preset-default`](https://www.npmjs.com/package/cssnano-preset-default)) is not typed
1. Plugins are not typed with Browserslist `path` and PostCSS context `env` where supported

These were spotted whilst fixing https://github.com/cssnano/cssnano/issues/1513 but I'll open another PR

## After

All plugin options are now included

<img width="358" alt="Type definitions newly updated" src="https://github.com/cssnano/cssnano/assets/415517/83438360-bbe9-4567-83e3-e162397fc4c3">