### PR TITLE
fix: tests looping `toInitial.json` data should run

### DIFF
--- a/packages/postcss-reduce-initial/src/index.js
+++ b/packages/postcss-reduce-initial/src/index.js
@@ -3,11 +3,12 @@ const browserslist = require('browserslist');
 const { isSupported } = require('caniuse-api');
 const fromInitial = require('./data/fromInitial.json');
 const toInitial = require('./data/toInitial.json');
+const ignoreProps = require('./lib/ignoreProps.js');
 
 const initial = 'initial';
 
 // In most of the browser including chrome the initial for `writing-mode` is not `horizontal-tb`. Ref https://github.com/cssnano/cssnano/pull/905
-const defaultIgnoreProps = ['writing-mode', 'transform-box'];
+const defaultIgnoreProps = ignoreProps;
 
 /**
  * @typedef {Pick<browserslist.Options, 'stats' | 'env'>} BrowserslistOptions

--- a/packages/postcss-reduce-initial/src/lib/ignoreProps.js
+++ b/packages/postcss-reduce-initial/src/lib/ignoreProps.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = ['writing-mode', 'transform-box'];

--- a/packages/postcss-reduce-initial/test/index.js
+++ b/packages/postcss-reduce-initial/test/index.js
@@ -15,13 +15,13 @@ function convertInitial(property, value) {
   return processCSS(`${property}:initial`, `${property}:${value}`);
 }
 
-function convertToInitial(t, property, value) {
+function convertToInitial(property, value) {
   return () =>
     Promise.all([
-      processCSS(t, `${property}:${value}`, `${property}:initial`, {
+      processCSS(`${property}:${value}`, `${property}:initial`, {
         env: 'chrome58',
       }),
-      passthroughCSS(t, `${property}:${value}`, { env: 'ie6' }),
+      passthroughCSS(`${property}:${value}`, { env: 'ie6' }),
     ]);
 }
 

--- a/packages/postcss-reduce-initial/test/index.js
+++ b/packages/postcss-reduce-initial/test/index.js
@@ -20,8 +20,8 @@ function convertToInitial(property, value) {
     Promise.all([
       processCSS(`${property}:${value}`, `${property}:initial`, {
         env: 'chrome58',
-      }),
-      passthroughCSS(`${property}:${value}`, { env: 'ie6' }),
+      })(),
+      passthroughCSS(`${property}:${value}`, { env: 'ie6' })(),
     ]);
 }
 

--- a/packages/postcss-reduce-initial/test/index.js
+++ b/packages/postcss-reduce-initial/test/index.js
@@ -7,6 +7,7 @@ const {
 
 const fromInitial = require('../src/data/fromInitial.json');
 const toInitial = require('../src/data/toInitial.json');
+const ignoreProps = require('../src/lib/ignoreProps.js');
 const plugin = require('../src/index.js');
 
 const { processCSS, passthroughCSS } = processCSSFactory(plugin);
@@ -16,9 +17,11 @@ function convertInitial(property, value) {
 }
 
 function convertToInitial(property, value) {
+  const output = ignoreProps.includes(property) ? value : 'initial';
+
   return () =>
     Promise.all([
-      processCSS(`${property}:${value}`, `${property}:initial`, {
+      processCSS(`${property}:${value}`, `${property}:${output}`, {
         env: 'chrome58',
       })(),
       passthroughCSS(`${property}:${value}`, { env: 'ie6' })(),

--- a/packages/postcss-reduce-initial/tsconfig.json
+++ b/packages/postcss-reduce-initial/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/*", "src/data/fromInitial.json", "src/data/toInitial.json"],
+  "include": ["src/*", "src/lib/*", "src/data/fromInitial.json", "src/data/toInitial.json"],
   "compilerOptions": {
     "composite": true,
     "rootDir": "src/",

--- a/packages/postcss-reduce-initial/types/lib/ignoreProps.d.ts
+++ b/packages/postcss-reduce-initial/types/lib/ignoreProps.d.ts
@@ -1,0 +1,2 @@
+declare const _exports: string[];
+export = _exports;


### PR DESCRIPTION
This PR fixes the `Promise.all()` calls in **packages/postcss-reduce-initial/test/index.js** so they resolve

https://github.com/cssnano/cssnano/blob/c4be0f52a776da12caf0d37e86fc0c194d384e49/packages/postcss-reduce-initial/test/index.js#L20-L25

Two property tests for `'writing-mode'` and `'transform-box'` failed but these were handled in:

* https://github.com/cssnano/cssnano/pull/929
* https://github.com/cssnano/cssnano/pull/1242