### PR TITLE
chore(postcss-svgo): update svgo version

### DIFF
--- a/.changeset/wicked-kings-notice.md
+++ b/.changeset/wicked-kings-notice.md
@@ -1,0 +1,5 @@
+---
+"postcss-svgo": patch
+---
+
+chore(svgo): update svgo version as svgo 3.3.0 and 3.3.1 contain unintended breaking changes

--- a/packages/postcss-svgo/package.json
+++ b/packages/postcss-svgo/package.json
@@ -28,7 +28,7 @@
   "repository": "cssnano/cssnano",
   "dependencies": {
     "postcss-value-parser": "^4.2.0",
-    "svgo": "^3.2.0"
+    "svgo": "^3.3.2"
   },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,8 +548,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       svgo:
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.3.2
+        version: 3.3.2
     devDependencies:
       pleeease-filters:
         specifier: ^4.0.0
@@ -2028,8 +2028,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svgo@3.2.0:
-    resolution: {integrity: sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==}
+  svgo@3.3.2:
+    resolution: {integrity: sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -3816,7 +3816,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svgo@3.2.0:
+  svgo@3.3.2:
     dependencies:
       '@trysound/sax': 0.2.0
       commander: 7.2.0


### PR DESCRIPTION
svgo 3.3.0 and 3.3.1 accidentally broke CJS compatibility: https://github.com/svg/svgo/releases