### PR TITLE
fix(postcss-unique-selectors): trailing comma when including comments

### DIFF
--- a/packages/postcss-unique-selectors/src/index.js
+++ b/packages/postcss-unique-selectors/src/index.js
@@ -3,23 +3,45 @@ const selectorParser = require('postcss-selector-parser');
 
 /**
  * @param {string} selectors
- * @param {selectorParser.SyncProcessor<void>} callback
  * @return {string}
  */
-function parseSelectors(selectors, callback) {
-  return selectorParser(callback).processSync(selectors);
-}
+function generateUniqueSelector(selectors) {
+  /** @type {Map<string, string>} */
+  const uniqueSelectors = new Map();
 
-/**
- * @param {import('postcss').Rule} rule
- * @return {string}
- */
-function unique(rule) {
-  const selector = [...new Set(rule.selectors)];
-  selector.sort();
-  return selector.join();
-}
+  /** @type {selectorParser.SyncProcessor<void>} */
+  const collectUniqueSelectors = (selNode) => {
+    for (const node of selNode.nodes) {
+      /** @type {string[]} */
+      const comments = []
 
+      // Duplicates are removed by stripping the comments and using the results as the Map key.
+      const keyNode = node.clone();
+      keyNode.walk((sel) => {
+        if (sel.type === 'comment') {
+          comments.push(sel.value);
+          sel.remove();
+        }
+      });
+      const key = keyNode.toString().trim();
+      
+      const dupeSelector = uniqueSelectors.get(key)
+      if(!dupeSelector) {
+        uniqueSelectors.set(key, node.toString());
+      } else if(comments.length) {
+        // If the duplicate selector has a comment, it is concatenated to the end of the selector.
+        uniqueSelectors.set(key, `${dupeSelector}${comments.join('')}`);
+      }
+    }
+  };
+
+  selectorParser(collectUniqueSelectors).processSync(selectors);
+
+  return [...uniqueSelectors.entries()]
+    .sort(([a], [b]) => a > b ? 1 : a < b ? -1 : 0)
+    .map(([, selector]) => selector)
+    .join();
+}
 /**
  * @type {import('postcss').PluginCreator<void>}
  * @return {import('postcss').Plugin}
@@ -29,27 +51,11 @@ function pluginCreator() {
     postcssPlugin: 'postcss-unique-selectors',
     OnceExit(css) {
       css.walkRules((nodes) => {
-        /** @type {string[]} */
-        let comments = [];
-        /** @type {selectorParser.SyncProcessor<void>} */
-        const removeAndSaveComments = (selNode) => {
-          selNode.walk((sel) => {
-            if (sel.type === 'comment') {
-              comments.push(sel.value);
-              sel.remove();
-              return;
-            } else {
-              return;
-            }
-          });
-        };
         if (nodes.raws.selector && nodes.raws.selector.raw) {
-          parseSelectors(nodes.raws.selector.raw, removeAndSaveComments);
-          nodes.raws.selector.raw = unique(nodes);
+          nodes.raws.selector.raw = generateUniqueSelector(nodes.raws.selector.raw);
+        } else {
+          nodes.selector = generateUniqueSelector(nodes.selector);
         }
-        nodes.selector = parseSelectors(nodes.selector, removeAndSaveComments);
-        nodes.selector = unique(nodes);
-        nodes.selectors = nodes.selectors.concat(comments);
       });
     },
   };

--- a/packages/postcss-unique-selectors/test/index.js
+++ b/packages/postcss-unique-selectors/test/index.js
@@ -19,10 +19,32 @@ test(
 );
 
 test(
-  'should leave out comments in the selector',
+  'should keep comments in the selector',
   processCSS(
     '.newbackbtn,/*.searchall,*/.calNav{padding:5px;}',
-    '.calNav,.newbackbtn,/*.searchall,*/{padding:5px;}'
+    '/*.searchall,*/.calNav,.newbackbtn{padding:5px;}'
+  )
+);
+
+test(
+  'should keep comments in the selector (2)',
+  processCSS(
+    '.x/*a*/,/*b*/.y/*c*/,.x,.y{padding:5px;}',
+    '.x/*a*/,/*b*/.y/*c*/{padding:5px;}'
+  )
+);
+test(
+  'should keep comments in the selector (3)',
+  processCSS(
+    '.x,.y,/*a*/.x/*b*/,/*c*/.y/*d*/{padding:5px;}',
+    '.x/*a*//*b*/,.y/*c*//*d*/{padding:5px;}'
+  )
+);
+test(
+  'should keep comments in the selector (4)',
+  processCSS(
+    ':is(/*a*/.x/*b*/,/*c*/.y/*d*/), :is(.x,.y),{padding:5px;}',
+    ':is(/*a*/.x/*b*/,/*c*/.y/*d*/){padding:5px;}'
   )
 );
 


### PR DESCRIPTION
Fix #1618 

This PR fixes an issue in `postcss-unique-selectors` where if it contained a comment it would treat the comment as a selector list element (resulting in a trailing comma).

To fix the issue, `postcss-unique-selectors` has been changed to put comments in their original position when possible.

The easiest way to fix the issue would be to remove the comment, but checking the comments on the previous PR, it seems like the comment should remain.
https://github.com/cssnano/cssnano/pull/857#discussion_r358122107
