### PR TITLE
fix(postcss-discard-comments): not remove comment-like strings from selectors

### DIFF
--- a/packages/postcss-discard-comments/package.json
+++ b/packages/postcss-discard-comments/package.json
@@ -23,6 +23,9 @@
     "url": "http://beneb.info"
   },
   "repository": "cssnano/cssnano",
+  "dependencies": {
+    "postcss-selector-parser": "^6.1.0"
+  },
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"
   },

--- a/packages/postcss-discard-comments/src/index.js
+++ b/packages/postcss-discard-comments/src/index.js
@@ -85,11 +85,15 @@ function pluginCreator(opts = {}) {
             node.remove();
           }
         }
-        if (node.rawSpaceAfter.trim()) {
-          node.rawSpaceAfter = replaceComments(node.rawSpaceAfter, space, '');
+        const rawSpaceAfter = replaceComments(node.rawSpaceAfter, space, '');
+        const rawSpaceBefore = replaceComments(node.rawSpaceBefore, space, '');
+        // If comments are not removed, the result of trim will be returned,
+        // so if we compare and there are no changes, skip it.
+        if (rawSpaceAfter !== node.rawSpaceAfter.trim()) {
+          node.rawSpaceAfter = rawSpaceAfter;
         }
-        if (node.rawSpaceBefore.trim()) {
-          node.rawSpaceBefore = replaceComments(node.rawSpaceBefore, space, '');
+        if (rawSpaceBefore !== node.rawSpaceBefore.trim()) {
+          node.rawSpaceBefore = rawSpaceBefore;
         }
       });
     }).processSync(source);

--- a/packages/postcss-discard-comments/test/index.js
+++ b/packages/postcss-discard-comments/test/index.js
@@ -168,6 +168,16 @@ test(
 );
 
 test(
+  'should keep special comments 14',
+  passthroughCSS('h1 /*!test comment*/, h2{color:#00f}')
+);
+
+test(
+  'should keep special comments 15',
+  passthroughCSS('h1 /*!test comment*/ span, h2{color:#00f}')
+);
+
+test(
   'should remove comments marked as @ but keep other',
   processCSS(
     '/* keep *//*@ remove */h1{color:#000;/*@ remove */font-weight:700}',

--- a/packages/postcss-discard-comments/test/index.js
+++ b/packages/postcss-discard-comments/test/index.js
@@ -211,6 +211,22 @@ test(
 );
 
 test(
+  'should remove only a comment',
+  processCSS(
+    '.a /*comment*/ [attr="/* not a comment */"]{color:#000}',
+    '.a [attr="/* not a comment */"]{color:#000}'
+  )
+);
+
+test(
+  'should remove only a comment 2',
+  processCSS(
+    ':not(/*comment*/ [attr="/* not a comment */"]){color:#000}',
+    ':not( [attr="/* not a comment */"]){color:#000}'
+  )
+);
+
+test(
   "should pass through when it doesn't find a comment",
   passthroughCSS('h1{color:#000;font-weight:700}')
 );

--- a/packages/postcss-discard-comments/test/index.js
+++ b/packages/postcss-discard-comments/test/index.js
@@ -231,6 +231,14 @@ test(
 test(
   'should remove only a comment 2',
   processCSS(
+    '.a [attr="/* not a comment */"] /*comment*/, .b {color:#000}',
+    '.a [attr="/* not a comment */"], .b{color:#000}'
+  )
+);
+
+test(
+  'should remove only a comment 3',
+  processCSS(
     ':not(/*comment*/ [attr="/* not a comment */"]){color:#000}',
     ':not( [attr="/* not a comment */"]){color:#000}'
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,10 @@ importers:
         version: 8.4.38
 
   packages/postcss-discard-comments:
+    dependencies:
+      postcss-selector-parser:
+        specifier: ^6.1.0
+        version: 6.1.0
     devDependencies:
       postcss:
         specifier: ^8.4.38


### PR DESCRIPTION

Fix #1622

This PR fixes postcss-discard-comments to not strip comment-like strings from selectors.

To fix the issue, I use postcss-selector-parser to ensure that we only strip comments. This change adds a dependency on postcss-selector-parser.