### PR TITLE
fix(postcss-minify-selectors): quotes are removed even when attribute selector escaping was required

### DIFF
--- a/packages/cssnano/test/issue1530.js
+++ b/packages/cssnano/test/issue1530.js
@@ -1,0 +1,21 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const postcss = require('postcss');
+const nano = require('..');
+
+const fixture = `
+[data--~="is½" i] {
+  color: red;
+}
+`;
+
+const expected = `[data--~="is½" i]{color:red}`;
+
+test('it should keep quote', () => {
+  const processor = postcss([nano()]);
+
+  return processor
+    .process(fixture, { from: undefined })
+    .then((r) => assert.strictEqual(r.css, expected));
+});

--- a/packages/postcss-minify-selectors/package.json
+++ b/packages/postcss-minify-selectors/package.json
@@ -26,6 +26,7 @@
   },
   "repository": "cssnano/cssnano",
   "dependencies": {
+    "cssesc": "^3.0.0",
     "postcss-selector-parser": "^6.1.0"
   },
   "bugs": {
@@ -35,6 +36,7 @@
     "node": "^18.12.0 || ^20.9.0 || >=22.0"
   },
   "devDependencies": {
+    "@types/cssesc": "^3.0.2",
     "postcss": "^8.4.38"
   },
   "peerDependencies": {

--- a/packages/postcss-minify-selectors/src/lib/canUnquote.js
+++ b/packages/postcss-minify-selectors/src/lib/canUnquote.js
@@ -1,4 +1,6 @@
 'use strict';
+
+const cssesc = require('cssesc');
 /**
  * Can unquote attribute detection from mothereff.in
  * Copyright Mathias Bynens <https://mathiasbynens.be/>
@@ -20,5 +22,9 @@ module.exports = function canUnquote(value) {
 
   value = value.replace(escapes, 'a').replace(/\\./g, 'a');
 
-  return !(range.test(value) || /^(?:-?\d|--)/.test(value));
+  return (
+    !(range.test(value) || /^(?:-?\d|--)/.test(value)) &&
+    // Do not remove the quotes if escaping is required.
+    cssesc(value) === value
+  );
 };

--- a/packages/postcss-minify-selectors/test/index.js
+++ b/packages/postcss-minify-selectors/test/index.js
@@ -286,6 +286,8 @@ test(
   )
 );
 
+test('should not change strings (6)', passthroughCSS("[a='½']{color:blue}"));
+
 test(
   'should transform qualified attribute selector inside not',
   processCSS(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,10 +397,16 @@ importers:
 
   packages/postcss-minify-selectors:
     dependencies:
+      cssesc:
+        specifier: ^3.0.0
+        version: 3.0.0
       postcss-selector-parser:
         specifier: ^6.1.0
         version: 6.1.0
     devDependencies:
+      '@types/cssesc':
+        specifier: ^3.0.2
+        version: 3.0.2
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
@@ -742,6 +748,9 @@ packages:
 
   '@types/caniuse-api@3.0.6':
     resolution: {integrity: sha512-yMGwHJaqwIEXc3x7EyY3CeS73QG9WeC00w2nZ0/inoRv9DiLIhfvrY6vmXMSKlpRLFxrLcAWJh3JTwYNPl3ihg==}
+
+  '@types/cssesc@3.0.2':
+    resolution: {integrity: sha512-Qii6nTRktvtI380EloxH/V7MwgrYxkPgBI+NklUjQuhzgAd1AqT3QDJd+eD+0doRADgfwvtagLRo7JFa7aMHXg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -2475,6 +2484,8 @@ snapshots:
   '@trysound/sax@0.2.0': {}
 
   '@types/caniuse-api@3.0.6': {}
+
+  '@types/cssesc@3.0.2': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 


### PR DESCRIPTION
Fix #1530

This PR fixes it by using `cssesc` to additionally check if escaping is needed, and not stripping quotes when escaping is needed.

This PR adds `cssesc` as a dependency, but since it is already a dependency of `postcss-selector-parser`, it is not effectively adding a new dependency.