### PR TITLE
fix(postcss-ordered-values): incorrect order when using calc for animation property

### DIFF
--- a/packages/cssnano/test/issue1527.js
+++ b/packages/cssnano/test/issue1527.js
@@ -1,0 +1,26 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const postcss = require('postcss');
+const preset = require('cssnano-preset-default');
+const nano = require('..');
+
+const fixture = `
+.b {
+  animation: opacity 0ms calc(1000ms);
+}
+`;
+
+const expected = '.b{animation:opacity 0ms calc(1s)}';
+
+test('it should keep quote', () => {
+  const processor = postcss([
+    nano({
+      preset: preset({ calc: false }),
+    }),
+  ]);
+
+  return processor
+    .process(fixture, { from: undefined })
+    .then((r) => assert.strictEqual(r.css, expected));
+});

--- a/packages/postcss-ordered-values/test/rules.js
+++ b/packages/postcss-ordered-values/test/rules.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const valueParser = require('postcss-value-parser');
 const normalizeBorder = require('../src/rules/border.js');
 const normalizeBoxShadow = require('../src/rules/boxShadow.js');
+const normalizeAnimation = require('../src/rules/animation.js');
 
 test('border order handles max', () => {
   assert.strictEqual(
@@ -25,5 +26,19 @@ test('ordering box shadows handles functions in box shadows', () => {
   assert.strictEqual(
     normalizeBoxShadow(valueParser('inset 0 min(1em, 1px) 0 1px red')),
     'inset 0 min(1em, 1px) 0 1px red'
+  );
+});
+
+test('animation order handles calc', () => {
+  assert.strictEqual(
+    normalizeAnimation(valueParser('0ms opacity calc(1ms)')),
+    'opacity 0ms calc(1ms)'
+  );
+});
+
+test('animation order handles max', () => {
+  assert.strictEqual(
+    normalizeAnimation(valueParser('0ms opacity max(-1 * 1ms, 1ms)')),
+    'opacity 0ms max(-1 * 1ms, 1ms)'
   );
 });


### PR DESCRIPTION
This PR fixes postcss-ordered-values ​​to track units in math functions, fixing the incorrect ordering of animation property.

Fix #1527