### PR TITLE
Fix layer rule deduping

### DIFF
--- a/.changeset/wild-scissors-grab.md
+++ b/.changeset/wild-scissors-grab.md
@@ -1,0 +1,5 @@
+---
+'postcss-discard-duplicates': patch
+---
+
+Prevents deduping of @layer rules which should not be deduped

--- a/packages/postcss-discard-duplicates/src/index.js
+++ b/packages/postcss-discard-duplicates/src/index.js
@@ -144,7 +144,7 @@ function dedupe(root) {
     dedupe(last);
     if (last.type === 'rule') {
       dedupeRule(last, nodes);
-    } else if (last.type === 'atrule' || last.type === 'decl') {
+    } else if ((last.type === 'atrule' && last.name !== 'layer') || last.type === 'decl') {
       dedupeNode(last, nodes);
     }
   }

--- a/packages/postcss-discard-duplicates/test/index.js
+++ b/packages/postcss-discard-duplicates/test/index.js
@@ -110,7 +110,7 @@ test(
   'should not crash on @layer syntax',
   processCSS(
     '@layer ui-components { } @layer ui-components',
-    '@layer ui-components'
+    '@layer ui-components { } @layer ui-components'
   )
 );
 


### PR DESCRIPTION
Closes https://github.com/cssnano/cssnano/issues/1655

I'm reasonably sure the @layer cannot be deduplicated as it may affect order. Let me know if I've misunderstood.