### PR TITLE
Add support for selector order preservation to postcss-minify-selectors

### DIFF
--- a/packages/cssnano-preset-default/src/index.js
+++ b/packages/cssnano-preset-default/src/index.js
@@ -60,7 +60,7 @@ const { rawCache } = require('cssnano-utils');
  * @property {SimpleOptions<import('postcss-calc').PostCssCalcOptions>} [calc]
  * @property {SimpleOptions<import('postcss-colormin').Options>} [colormin]
  * @property {SimpleOptions} [orderedValues]
- * @property {SimpleOptions} [minifySelectors]
+ * @property {SimpleOptions<import('postcss-minify-selectors').Options>} [minifySelectors]
  * @property {SimpleOptions<import('postcss-minify-params').Options>} [minifyParams]
  * @property {SimpleOptions<import('postcss-normalize-charset').Options>} [normalizeCharset]
  * @property {SimpleOptions<import('postcss-minify-font-values').Options>} [minifyFontValues]
@@ -130,6 +130,9 @@ function configurePlugins(plugins, opts = {}) {
     },
     cssDeclarationSorter: {
       keepOverrides: true,
+    },
+    minifySelectors: {
+      sort: true,
     },
     svgo: {
       plugins: [

--- a/packages/postcss-minify-selectors/src/index.js
+++ b/packages/postcss-minify-selectors/src/index.js
@@ -197,11 +197,15 @@ const reducers = new Map(
   ])
 );
 
+/** @typedef {object} Options
+ *  @property {boolean=} preserveOrder
+ */
 /**
  * @type {import('postcss').PluginCreator<void>}
+ * @param {Options} opts
  * @return {import('postcss').Plugin}
  */
-function pluginCreator() {
+function pluginCreator(opts = {}) {
   return {
     postcssPlugin: 'postcss-minify-selectors',
 
@@ -233,7 +237,9 @@ function pluginCreator() {
             }
           }
         });
-        selectors.nodes.sort();
+        if (opts.preserveOrder !== true) {
+          selectors.nodes.sort();
+        }
       });
 
       css.walkRules((rule) => {

--- a/packages/postcss-minify-selectors/src/index.js
+++ b/packages/postcss-minify-selectors/src/index.js
@@ -198,14 +198,14 @@ const reducers = new Map(
 );
 
 /** @typedef {object} Options
- *  @property {boolean=} preserveOrder
+ *  @property {boolean} [sort=true]
  */
 /**
  * @type {import('postcss').PluginCreator<void>}
  * @param {Options} opts
  * @return {import('postcss').Plugin}
  */
-function pluginCreator(opts = {}) {
+function pluginCreator(opts = { sort: true }) {
   return {
     postcssPlugin: 'postcss-minify-selectors',
 
@@ -237,7 +237,7 @@ function pluginCreator(opts = {}) {
             }
           }
         });
-        if (opts.preserveOrder !== true) {
+        if (opts.sort) {
           selectors.nodes.sort();
         }
       });

--- a/packages/postcss-minify-selectors/test/index.js
+++ b/packages/postcss-minify-selectors/test/index.js
@@ -105,6 +105,15 @@ test(
 );
 
 test(
+  'should preserve order',
+  processCSS(
+    '.item1, .item2, .item10, .item11{color:blue}',
+    '.item1,.item2,.item10,.item11{color:blue}',
+    { preserveOrder: true },
+  )
+);
+
+test(
   'should dedupe selectors',
   processCSS(
     'h1,h2,h3,h4,h5,h5,h6{color:blue}',

--- a/packages/postcss-minify-selectors/test/index.js
+++ b/packages/postcss-minify-selectors/test/index.js
@@ -105,11 +105,11 @@ test(
 );
 
 test(
-  'should preserve order',
+  'should not sort',
   processCSS(
     '.item1, .item2, .item10, .item11{color:blue}',
     '.item1,.item2,.item10,.item11{color:blue}',
-    { preserveOrder: true },
+    { sort: false },
   )
 );
 

--- a/packages/postcss-minify-selectors/types/index.d.ts
+++ b/packages/postcss-minify-selectors/types/index.d.ts
@@ -1,10 +1,18 @@
 export = pluginCreator;
+/** @typedef {object} Options
++ *  @property {boolean=} preserveOrder
++ */
 /**
  * @type {import('postcss').PluginCreator<void>}
+ * @param {Options} opts
  * @return {import('postcss').Plugin}
  */
-declare function pluginCreator(): import("postcss").Plugin;
+declare function pluginCreator(opts?: Options): import("postcss").Plugin;
 declare namespace pluginCreator {
-    let postcss: true;
+    export { postcss, Options };
 }
+declare var postcss: true;
+type Options = {
+    preserveOrder?: boolean | undefined;
+};
 //# sourceMappingURL=index.d.ts.map

--- a/packages/postcss-minify-selectors/types/index.d.ts
+++ b/packages/postcss-minify-selectors/types/index.d.ts
@@ -1,7 +1,7 @@
 export = pluginCreator;
 /** @typedef {object} Options
-+ *  @property {boolean=} sort
-+ */
+ *  @property {boolean=} sort
+ */
 /**
  * @type {import('postcss').PluginCreator<void>}
  * @param {Options} opts

--- a/packages/postcss-minify-selectors/types/index.d.ts
+++ b/packages/postcss-minify-selectors/types/index.d.ts
@@ -1,6 +1,6 @@
 export = pluginCreator;
 /** @typedef {object} Options
-+ *  @property {boolean=} preserveOrder
++ *  @property {boolean=} sort
 + */
 /**
  * @type {import('postcss').PluginCreator<void>}
@@ -13,6 +13,6 @@ declare namespace pluginCreator {
 }
 declare var postcss: true;
 type Options = {
-    preserveOrder?: boolean | undefined;
+    sort?: boolean | undefined;
 };
 //# sourceMappingURL=index.d.ts.map


### PR DESCRIPTION
feat(minify-selectors): Add the ability to disable sorting when minifying selectors