### PR TITLE
perf: load default preset in startup

### DIFF
--- a/packages/cssnano/src/index.js
+++ b/packages/cssnano/src/index.js
@@ -3,6 +3,7 @@ const path = require('path');
 /** @type {any} */
 const postcss = require('postcss');
 const { lilconfigSync } = require('lilconfig');
+const defaultPreset = require('cssnano-preset-default');
 
 const cssnano = 'cssnano';
 
@@ -48,7 +49,7 @@ function resolvePreset(preset) {
 
   // Provide an alias for the default preset, as it is built-in.
   if (fn === 'default') {
-    return require('cssnano-preset-default')(options).plugins;
+    return defaultPreset(options).plugins;
   }
 
   // For non-JS setups; we'll need to invoke the preset ourselves.


### PR DESCRIPTION
The default preset is a widely relied on, especially by frameworks (e.g. nuxt).

Currently, this means the hot path will have to `require` the preset and _block until resolution finishes_.

If we load the default preset up front, it means the call to cssnano doesn't need to do this and will actually run faster.

This does mean initial load is likely technically slower, but the gain of the call performance seems to outweigh this.

of course this is a balance. if you don't want the cost of resolving one more module (for all users), feel free to close this. though i suspect most consumers are loading the default already
