### PR TITLE
fix(postcss-convert-values): preserve percent sign in percentage values in at-rules with double quotes 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -72,3 +72,4 @@ Thanks goes to these wonderful people:
 - Xiaojun Zhou
 - Seth Falco
 - Seiya
+- Aleksandr Kondrashov

--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -157,7 +157,7 @@ function shouldKeepZeroUnit(decl, browsers) {
         (node) =>
           node.type === 'decl' &&
           node.prop.toLowerCase() === 'syntax' &&
-          node.value === "'<percentage>'"
+          (node.value === "'<percentage>'" || node.value === '"<percentage>"')
       )) ||
     keepWhenZero.has(lowerCasedProp)
   );

--- a/packages/postcss-convert-values/test/index.js
+++ b/packages/postcss-convert-values/test/index.js
@@ -505,6 +505,14 @@ test(
 );
 
 test(
+  `should not strip the percentage from 0 in @property, for initial-value (syntax string in double quotes)`,
+  processCSS(
+    `@property --percent{syntax:"<percentage>";inherits:false;initial-value:0%;}`,
+    `@property --percent{syntax:"<percentage>";inherits:false;initial-value:0%;}`
+  )
+);
+
+test(
   'should not strip the percentage from background-color',
   passthroughCSS('background-color:color-mix(#000, #FFF 0%);')
 );

--- a/packages/postcss-minify-selectors/test/index.js
+++ b/packages/postcss-minify-selectors/test/index.js
@@ -109,7 +109,7 @@ test(
   processCSS(
     '.item1, .item2, .item10, .item11{color:blue}',
     '.item1,.item2,.item10,.item11{color:blue}',
-    { sort: false },
+    { sort: false }
   )
 );
 


### PR DESCRIPTION
Fixes https://github.com/cssnano/cssnano/issues/1694

The `shouldKeepZeroUnit` check previously expected the syntax value `<percentage>` to be enclosed only in single quotes. However, in CSS, string values can also be surrounded by double quotes. I've added an additional check to handle both quote styles and updated the test cases to include the double-quoted variant.

NOTE: I didn't change any logic in `packages/postcss-minify-selectors/test/index.js`, but the file was automatically updated after running the `pnpm fixlint` command. 