### PR TITLE
chore: add `packageManager` field & move pnpm setting

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ permissions:
 on:
   release:
     types: [published]
-    
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,24 +12,22 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - name: Install pnpm
         uses: pnpm/action-setup@v4.1.0
-        with:
-          version: 10.10.0
-          
+
       - name: Setup .npmrc file to publish to npm
         uses: actions/setup-node@v4.4.0
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
-          
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Run lint
         run: pnpm lint
-        
+
       - name: Test
         run: pnpm test:only
-        
+
       - name: Publish
         run: pnpm all-publish
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - name: Install pnpm
         uses: pnpm/action-setup@v4.1.0
-        with:
-          version: 10.10.0
+
       - name: Install Node.js 22.x
         uses: actions/setup-node@v4.4.0
         with:
@@ -46,8 +45,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4.1.0
-        with:
-          version: 10.10.0
 
       - name: Install Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4.4.0

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-auto-install-peers=true

--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
     "production": [
       "IE 11 and last 2 versions"
     ]
-  }
+  },
+  "packageManager": "pnpm@10.10.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'packages/**'
   - '!site/**'
+autoInstallPeers: true


### PR DESCRIPTION
To ease management and avoid conflicts with npm, pnpm supports moving all configurations to the pnpm-workspace.yaml file. For more [github.com/orgs/pnpm/discussions/9037](https://github.com/orgs/pnpm/discussions/9037)

Add the `packageManager` field to facilitate users to automatically switch to the specified version of pnpm when installing dependencies locally to prevent unnecessary conflicts.