### PR TITLE
fix(convert-values): exclude `linear()` from stripping `%` from value 0

### DIFF
--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -50,6 +50,7 @@ const keepZeroPercentAlways = new Set([
   'hsl',
   'hsla',
   'hwb',
+  'linear',
 ]);
 
 const keepZeroPercentageInKeyframe = new Set([

--- a/packages/postcss-convert-values/test/index.js
+++ b/packages/postcss-convert-values/test/index.js
@@ -539,6 +539,11 @@ test(
 );
 
 test(
+  'should not strip the percentage from linear()',
+  passthroughCSS('transition-timing-function: linear(0 0%, 1 100%)')
+);
+
+test(
   'should not strip percentage from border-image-width',
   passthroughCSS('@keyframes test {0% {border-image-width: 0 0 100% 0%;}}')
 );


### PR DESCRIPTION
fix https://github.com/cssnano/cssnano/issues/1719

This fixes a problem where the `%` was stripped from 0 values in the `linear()` function.
I also added a test for it.