### PR TITLE
chore: fix broken image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
     <br>
-    <img width="360" src="https://rawgit.com/cssnano/cssnano/master/media/logo.svg" alt="cssnano">
+    <img width="360" src="./media/logo.svg" alt="cssnano">
     <br>
     <br>
     <br>
@@ -8,10 +8,16 @@
 
 > A modular minifier, built on top of the [PostCSS](https://github.com/postcss/postcss) ecosystem.
 
-[![Backers on Open Collective](https://opencollective.com/cssnano/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/cssnano/sponsors/badge.svg)](#sponsors) [![NPM version](https://img.shields.io/npm/v/cssnano.svg)](https://www.npmjs.org/package/cssnano)
+<div align="center">
+
+[![Backers on Open Collective](https://img.shields.io/opencollective/backers/cssnano?logo=opencollective&logoColor=white)](#backers)
+[![Sponsors on Open Collective](https://img.shields.io/opencollective/sponsors/cssnano?logo=opencollective&logoColor=white)](#sponsors)
+[![NPM version](https://img.shields.io/npm/v/cssnano.svg?logo=npm)](https://www.npmjs.org/package/cssnano)
 [![Build Status](https://github.com/cssnano/cssnano/actions/workflows/test.yml/badge.svg)](https://github.com/cssnano/cssnano/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/cssnano/cssnano/branch/master/graph/badge.svg)](https://codecov.io/gh/cssnano/cssnano)
-[![Gitter](https://img.shields.io/badge/Gitter-Join_the_PostCSS_chat-brightgreen.svg)](https://gitter.im/postcss/postcss)
+[![Gitter](https://img.shields.io/badge/Gitter-Join_the_PostCSS_chat-brightgreen.svg?logo=gitter)](https://gitter.im/postcss/postcss)
+
+</div>
 
 cssnano is a modern, modular compression tool written on top of the PostCSS
 ecosystem, which allows us to use a lot of powerful features in order to compact


### PR DESCRIPTION
Changes the dead CDN link in the README to use jsDelivr instead.

I also changed some of the badges to use img.shields.io and give them the appropriate icons, and centered the lot. I realize this is a very opinionated visual change; I'll gladly withdraw it if it's undesirable.