### PR TITLE
fix(postcss-reduce-idents): support counter-set property

### DIFF
--- a/packages/postcss-reduce-idents/src/lib/counter.js
+++ b/packages/postcss-reduce-idents/src/lib/counter.js
@@ -25,7 +25,7 @@ module.exports = function () {
       }
       const { prop } = node;
 
-      if (/counter-(reset|increment)/i.test(prop)) {
+      if (/counter-(reset|increment|set)/i.test(prop)) {
         /** @type {unknown} */ (node.value) = valueParser(node.value).walk(
           (child) => {
             if (

--- a/packages/postcss-reduce-idents/test/index.js
+++ b/packages/postcss-reduce-idents/test/index.js
@@ -188,6 +188,22 @@ test(
 );
 
 test(
+  'should rename counters defined with counter-set',
+  processCSS(
+    'body{counter-set:section}h3:before{counter-increment:section;content:"Section" counter(section) ": "}',
+    'body{counter-set:a}h3:before{counter-increment:a;content:"Section" counter(a) ": "}'
+  )
+);
+
+test(
+  'should rename counters with counter-set and counter-reset together',
+  processCSS(
+    'body{counter-reset:section;counter-set:subsection}h3:before{counter-increment:subsection;content:counter(section) "." counter(subsection)}',
+    'body{counter-reset:a;counter-set:b}h3:before{counter-increment:b;content:counter(a) "." counter(b)}'
+  )
+);
+
+test(
   'should not touch counters that are not outputted',
   passthroughCSS('h1{counter-reset:chapter 1 section page 1}')
 );


### PR DESCRIPTION
`counter-set` was missing from the list of counter-defining properties in `postcss-reduce-idents`, causing inconsistent renaming `counter-increment` and `counter()` references were minified but `counter-set` was left unchanged.

Fixes #1471.