### PR TITLE
fix(postcss-convert-values): add transformCustomProperties option

### DIFF
--- a/packages/postcss-colormin/src/index.js
+++ b/packages/postcss-colormin/src/index.js
@@ -108,6 +108,7 @@ function addPluginDefaults(options, browsers) {
  * @property {boolean} [hsl]
  * @property {boolean} [name]
  * @property {boolean} [transparent]
+ * @property {boolean} [transformCustomProperties] Whether to minify colors inside custom property values (default: true)
  */
 
 /**
@@ -147,6 +148,10 @@ function pluginCreator(config = {}) {
                 decl.prop
               )
             ) {
+              return;
+            }
+
+            if (config.transformCustomProperties === false && decl.prop.startsWith('--')) {
               return;
             }
 

--- a/packages/postcss-colormin/test/index.js
+++ b/packages/postcss-colormin/test/index.js
@@ -231,6 +231,16 @@ test(
 );
 
 test(
+  'should minify colors inside custom properties by default',
+  processCSS('a{--foo:rgb(0 0 0)}', 'a{--foo:#000}')
+);
+
+test(
+  'should not minify colors inside custom properties when transformCustomProperties is false',
+  passthroughCSS('a{--foo:rgb(0 0 0)}', { transformCustomProperties: false })
+);
+
+test(
   'should respect CSS variables',
   passthroughCSS('div{background-color:rgba(51,153,255,var(--tw-bg-opacity))}')
 );

--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -176,7 +176,7 @@ function transform(opts, browsers, decl) {
   const lowerCasedProp = decl.prop.toLowerCase();
   if (
     lowerCasedProp.includes('flex') ||
-    lowerCasedProp.indexOf('--') === 0 ||
+    (lowerCasedProp.indexOf('--') === 0 && !opts.transformCustomProperties) ||
     notALength.has(lowerCasedProp)
   ) {
     return;
@@ -217,7 +217,7 @@ const plugin = 'postcss-convert-values';
  * @typedef {Parameters<typeof convert>[2]} ConvertOptions
  * @typedef {{ overrideBrowserslist?: string | string[] }} AutoprefixerOptions
  * @typedef {Pick<browserslist.Options, 'stats' | 'path' | 'env'>} BrowserslistOptions
- * @typedef {{precision?: false | number} & ConvertOptions & AutoprefixerOptions & BrowserslistOptions} Options
+ * @typedef {{precision?: false | number, transformCustomProperties?: boolean} & ConvertOptions & AutoprefixerOptions & BrowserslistOptions} Options
  */
 
 /**

--- a/packages/postcss-convert-values/test/index.js
+++ b/packages/postcss-convert-values/test/index.js
@@ -41,6 +41,20 @@ test(
 );
 
 test(
+  'should not convert values in custom properties by default',
+  passthroughCSS('h1{--my-variable:500ms}')
+);
+
+test(
+  'should convert values in custom properties when transformCustomProperties is true',
+  processCSS(
+    'h1{--my-variable:500ms}',
+    'h1{--my-variable:.5s}',
+    { transformCustomProperties: true }
+  )
+);
+
+test(
   'should remove unnecessary plus signs',
   processCSS('h1{width:+14px}', 'h1{width:14px}')
 );

--- a/packages/postcss-reduce-idents/src/lib/counter.js
+++ b/packages/postcss-reduce-idents/src/lib/counter.js
@@ -25,7 +25,7 @@ module.exports = function () {
       }
       const { prop } = node;
 
-      if (/counter-(reset|increment)/i.test(prop)) {
+      if (/counter-(reset|increment|set)/i.test(prop)) {
         /** @type {unknown} */ (node.value) = valueParser(node.value).walk(
           (child) => {
             if (

--- a/packages/postcss-reduce-idents/test/index.js
+++ b/packages/postcss-reduce-idents/test/index.js
@@ -188,6 +188,22 @@ test(
 );
 
 test(
+  'should rename counters defined with counter-set',
+  processCSS(
+    'body{counter-set:section}h3:before{counter-increment:section;content:"Section" counter(section) ": "}',
+    'body{counter-set:a}h3:before{counter-increment:a;content:"Section" counter(a) ": "}'
+  )
+);
+
+test(
+  'should rename counters with counter-set and counter-reset together',
+  processCSS(
+    'body{counter-reset:section;counter-set:subsection}h3:before{counter-increment:subsection;content:counter(section) "." counter(subsection)}',
+    'body{counter-reset:a;counter-set:b}h3:before{counter-increment:b;content:counter(a) "." counter(b)}'
+  )
+);
+
+test(
   'should not touch counters that are not outputted',
   passthroughCSS('h1{counter-reset:chapter 1 section page 1}')
 );


### PR DESCRIPTION
`postcss-convert-values` currently skips all custom property declarations to avoid unsafe transformations. However, some users explicitly want value conversion inside custom properties (e.g. `500ms` → `.5s`, `0.485` → `.485`).

Adds a `transformCustomProperties` option (default: `false` to preserve existing behavior). Set to `true` to enable value conversions inside custom property declarations.

```js
cssnano({ preset: ['default', { convertValues: { transformCustomProperties: true } }] })
```

Relates to #1488.