### PR TITLE
fix(postcss-colormin): add transformCustomProperties option

### DIFF
--- a/packages/postcss-colormin/src/index.js
+++ b/packages/postcss-colormin/src/index.js
@@ -108,6 +108,7 @@ function addPluginDefaults(options, browsers) {
  * @property {boolean} [hsl]
  * @property {boolean} [name]
  * @property {boolean} [transparent]
+ * @property {boolean} [transformCustomProperties] Whether to minify colors inside custom property values (default: true)
  */
 
 /**
@@ -147,6 +148,10 @@ function pluginCreator(config = {}) {
                 decl.prop
               )
             ) {
+              return;
+            }
+
+            if (config.transformCustomProperties === false && decl.prop.startsWith('--')) {
               return;
             }
 

--- a/packages/postcss-colormin/test/index.js
+++ b/packages/postcss-colormin/test/index.js
@@ -231,6 +231,16 @@ test(
 );
 
 test(
+  'should minify colors inside custom properties by default',
+  processCSS('a{--foo:rgb(0 0 0)}', 'a{--foo:#000}')
+);
+
+test(
+  'should not minify colors inside custom properties when transformCustomProperties is false',
+  passthroughCSS('a{--foo:rgb(0 0 0)}', { transformCustomProperties: false })
+);
+
+test(
   'should respect CSS variables',
   passthroughCSS('div{background-color:rgba(51,153,255,var(--tw-bg-opacity))}')
 );


### PR DESCRIPTION
Custom property values may be read by JavaScript (e.g. via `getComputedStyle`), where `rgb(0 0 0)` and `#000` are not equivalent. By default, `postcss-colormin` transforms colors inside custom properties, which can break such use cases.

Adds a `transformCustomProperties` option (default: `true` to preserve existing behavior). Set to `false` to skip color minification inside custom property declarations.

```js
cssnano({ preset: ['default', { colormin: { transformCustomProperties: false } }] })
```

Fixes #1456.