### PR TITLE
fix(postcss-convert-values): add transformCustomProperties option

### DIFF
--- a/packages/postcss-convert-values/src/index.js
+++ b/packages/postcss-convert-values/src/index.js
@@ -176,7 +176,7 @@ function transform(opts, browsers, decl) {
   const lowerCasedProp = decl.prop.toLowerCase();
   if (
     lowerCasedProp.includes('flex') ||
-    lowerCasedProp.indexOf('--') === 0 ||
+    (lowerCasedProp.indexOf('--') === 0 && !opts.transformCustomProperties) ||
     notALength.has(lowerCasedProp)
   ) {
     return;
@@ -217,7 +217,7 @@ const plugin = 'postcss-convert-values';
  * @typedef {Parameters<typeof convert>[2]} ConvertOptions
  * @typedef {{ overrideBrowserslist?: string | string[] }} AutoprefixerOptions
  * @typedef {Pick<browserslist.Options, 'stats' | 'path' | 'env'>} BrowserslistOptions
- * @typedef {{precision?: false | number} & ConvertOptions & AutoprefixerOptions & BrowserslistOptions} Options
+ * @typedef {{precision?: false | number, transformCustomProperties?: boolean} & ConvertOptions & AutoprefixerOptions & BrowserslistOptions} Options
  */
 
 /**

--- a/packages/postcss-convert-values/test/index.js
+++ b/packages/postcss-convert-values/test/index.js
@@ -41,6 +41,20 @@ test(
 );
 
 test(
+  'should not convert values in custom properties by default',
+  passthroughCSS('h1{--my-variable:500ms}')
+);
+
+test(
+  'should convert values in custom properties when transformCustomProperties is true',
+  processCSS(
+    'h1{--my-variable:500ms}',
+    'h1{--my-variable:.5s}',
+    { transformCustomProperties: true }
+  )
+);
+
+test(
   'should remove unnecessary plus signs',
   processCSS('h1{width:+14px}', 'h1{width:14px}')
 );


### PR DESCRIPTION
`postcss-convert-values` currently skips all custom property declarations to avoid unsafe transformations. However, some users explicitly want value conversion inside custom properties (e.g. `500ms` → `.5s`, `0.485` → `.485`).

Adds a `transformCustomProperties` option (default: `false` to preserve existing behavior). Set to `true` to enable value conversions inside custom property declarations.

```js
cssnano({ preset: ['default', { convertValues: { transformCustomProperties: true } }] })
```

Relates to #1488.