### PR TITLE
chore: create new versions to fix missing dependencies

### DIFF
--- a/packages/cssnano-preset-advanced/CHANGELOG.md
+++ b/packages/cssnano-preset-advanced/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 7.0.15
+
+### Patch Changes
+
+- fix: publish all dependencies with attestations
+- Updated dependencies
+  - cssnano-preset-default@7.0.15
+
 ## 7.0.14
 
 ### Patch Changes

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-advanced",
-  "version": "7.0.14",
+  "version": "7.0.15",
   "main": "src/index.js",
   "types": "types/index.d.ts",
   "description": "Advanced optimisations for cssnano; may or may not break your CSS!",

--- a/packages/cssnano-preset-default/CHANGELOG.md
+++ b/packages/cssnano-preset-default/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 7.0.15
+
+### Patch Changes
+
+- fix: publish all dependencies with attestations
+- Updated dependencies
+  - postcss-normalize-positions@7.0.3
+  - postcss-normalize-repeat-style@7.0.3
+
 ## 7.0.14
 
 ### Patch Changes

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssnano-preset-default",
-  "version": "7.0.14",
+  "version": "7.0.15",
   "main": "src/index.js",
   "types": "types/index.d.ts",
   "description": "Safe defaults for cssnano which require minimal configuration.",

--- a/packages/cssnano/CHANGELOG.md
+++ b/packages/cssnano/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 7.1.7
+
+### Patch Changes
+
+- fix: publish all dependencies with attestations
+- Updated dependencies
+  - cssnano-preset-default@7.0.15
+
 ## 7.1.6
 
 ### Patch Changes

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cssnano",
-    "version": "7.1.6",
+    "version": "7.1.7",
     "description": "A modular minifier, built on top of the PostCSS ecosystem.",
     "main": "src/index.js",
     "types": "types/index.d.ts",

--- a/packages/postcss-normalize-positions/CHANGELOG.md
+++ b/packages/postcss-normalize-positions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 7.0.3
+
+### Patch Changes
+
+- fix: publish all dependencies with attestations
+
 ## 7.0.2
 
 ### Patch Changes

--- a/packages/postcss-normalize-positions/package.json
+++ b/packages/postcss-normalize-positions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-normalize-positions",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "Normalize keyword values for position into length values.",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/packages/postcss-normalize-repeat-style/CHANGELOG.md
+++ b/packages/postcss-normalize-repeat-style/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 7.0.3
+
+### Patch Changes
+
+- fix: publish all dependencies with attestations
+
 ## 7.0.2
 
 ### Patch Changes

--- a/packages/postcss-normalize-repeat-style/package.json
+++ b/packages/postcss-normalize-repeat-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-normalize-repeat-style",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "Convert two value syntax for repeat-style into one value.",
   "main": "src/index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
Some packages failed to publish because OIDC was not configured on the npm registry end, so create a new version to fix this.