### PR TITLE
perf(postcss-unique-selectors): add fast paths for the common cases

### DIFF
--- a/packages/postcss-unique-selectors/src/index.js
+++ b/packages/postcss-unique-selectors/src/index.js
@@ -6,15 +6,29 @@ const selectorParser = require('postcss-selector-parser');
  * @return {string}
  */
 function generateUniqueSelector(selectors) {
+  // No comma means a single selector; nothing to dedupe or sort.
+  if (selectors.indexOf(',') === -1) {
+    return selectors;
+  }
   /** @type {Map<string, string>} */
   const uniqueSelectors = new Map();
+  // Without comments the node's own toString is already a usable key.
+  const hasComments = selectors.indexOf('/*') !== -1;
 
   /** @type {selectorParser.SyncProcessor<void>} */
   const collectUniqueSelectors = (selNode) => {
     for (const node of selNode.nodes) {
+      if (!hasComments) {
+        const text = node.toString();
+        const key = text.trim();
+        if (!uniqueSelectors.has(key)) {
+          uniqueSelectors.set(key, text);
+        }
+        continue;
+      }
+
       /** @type {string[]} */
       const comments = [];
-
       // Duplicates are removed by stripping the comments and using the results as the Map key.
       const keyNode = node.clone();
       keyNode.walk((sel) => {

--- a/packages/postcss-unique-selectors/types/index.d.ts.map
+++ b/packages/postcss-unique-selectors/types/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.js"],"names":[],"mappings":";AA4CA;;;GAGG;AACH,kCAFY,OAAO,SAAS,EAAE,MAAM,CAiBnC"}
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.js"],"names":[],"mappings":";AA0DA;;;GAGG;AACH,kCAFY,OAAO,SAAS,EAAE,MAAM,CAiBnC"}


### PR DESCRIPTION
## What

Adds two fast paths to `generateUniqueSelector` so `postcss-unique-selectors` skips the selector parser and the per-node clone+walk when there is nothing to do.

Full default preset over a corpus of 21 released framework CSS files (master = 100% of current time, lower is faster):

| | master | this PR |
|---|---|---|
| total time | 100% | **81% (−19%)** |

