### PR TITLE
perf(postcss-merge-longhand): skip processors with no relevant decls

### DIFF
--- a/packages/postcss-merge-longhand/src/index.js
+++ b/packages/postcss-merge-longhand/src/index.js
@@ -1,5 +1,7 @@
 'use strict';
 const processors = require('./lib/decl');
+const [borders, columns, margin, padding] = processors;
+
 /**
  * @type {import('postcss').PluginCreator<void>}
  * @return {import('postcss').Plugin}
@@ -10,10 +12,43 @@ function pluginCreator() {
 
     OnceExit(css) {
       css.walkRules((rule) => {
-        processors.forEach((p) => {
-          p.explode(rule);
-          p.merge(rule);
-        });
+        // Scan the rule's props once, then run only the processors whose
+        // family is present.
+        let hasBorder = false;
+        let hasColumn = false;
+        let hasMargin = false;
+        let hasPadding = false;
+        for (const node of rule.nodes) {
+          if (node.type !== 'decl') {
+            continue;
+          }
+          const prop = node.prop.toLowerCase();
+          if (prop.startsWith('border')) {
+            hasBorder = true;
+          } else if (prop.startsWith('column')) {
+            hasColumn = true;
+          } else if (prop.startsWith('margin')) {
+            hasMargin = true;
+          } else if (prop.startsWith('padding')) {
+            hasPadding = true;
+          }
+        }
+        if (hasBorder) {
+          borders.explode(rule);
+          borders.merge(rule);
+        }
+        if (hasColumn) {
+          columns.explode(rule);
+          columns.merge(rule);
+        }
+        if (hasMargin) {
+          margin.explode(rule);
+          margin.merge(rule);
+        }
+        if (hasPadding) {
+          padding.explode(rule);
+          padding.merge(rule);
+        }
       });
     },
   };

--- a/packages/postcss-merge-longhand/types/index.d.ts.map
+++ b/packages/postcss-merge-longhand/types/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.js"],"names":[],"mappings":";AAEA;;;GAGG;AACH,kCAFY,OAAO,SAAS,EAAE,MAAM,CAenC"}
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.js"],"names":[],"mappings":";AAIA;;;GAGG;AACH,kCAFY,OAAO,SAAS,EAAE,MAAM,CAgDnC"}


### PR DESCRIPTION
## What

`postcss-merge-longhand` runs four longhand processors (borders, columns, margin, padding) on every rule; this scans each rule's declarations once and runs only the processors whose property family is present.

Full default preset over a corpus of 21 released framework CSS files (master = 100% of current time, lower is faster):

| | master | this PR |
|---|---|---|
| total time | 100% | **93% (−7%)** |


