### PR TITLE
perf(postcss-discard-duplicates): bucket rules by selector

### DIFF
--- a/packages/postcss-discard-duplicates/src/index.js
+++ b/packages/postcss-discard-duplicates/src/index.js
@@ -84,23 +84,26 @@ function equals(nodeA, nodeB) {
 
 /**
  * @param {import('postcss').Rule} last
- * @param {import('postcss').AnyNode[]} nodes
+ * @param {import('postcss').Rule[]} group rules sharing last's selector, in document order
  * @return {void}
  */
-function dedupeRule(last, nodes) {
-  let index = nodes.indexOf(last) - 1;
-  while (index >= 0) {
-    const node = nodes[index--];
-    if (node && node.type === 'rule' && node.selector === last.selector) {
-      last.each((child) => {
-        if (child.type === 'decl') {
-          dedupeNode(child, node.nodes);
-        }
-      });
-
-      if (empty(node)) {
-        node.remove();
+function dedupeRule(last, group) {
+  for (let i = 0; i < group.length; i++) {
+    const node = group[i];
+    if (node === last) {
+      break;
+    }
+    if (!node.parent) {
+      continue;
+    }
+    last.each((child) => {
+      if (child.type === 'decl') {
+        dedupeNode(child, node.nodes);
       }
+    });
+
+    if (empty(node)) {
+      node.remove();
     }
   }
 }
@@ -135,6 +138,24 @@ function dedupe(root) {
     return;
   }
 
+  // Group rules by selector so each only dedupes against same-selector rules.
+  /** @type {Map<string, import('postcss').Rule[]> | undefined} */
+  let ruleGroups;
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    if (node.type === 'rule') {
+      if (!ruleGroups) {
+        ruleGroups = new Map();
+      }
+      const group = ruleGroups.get(node.selector);
+      if (group) {
+        group.push(node);
+      } else {
+        ruleGroups.set(node.selector, [node]);
+      }
+    }
+  }
+
   let index = nodes.length - 1;
   while (index >= 0) {
     let last = nodes[index--];
@@ -143,7 +164,10 @@ function dedupe(root) {
     }
     dedupe(last);
     if (last.type === 'rule') {
-      dedupeRule(last, nodes);
+      const group = ruleGroups && ruleGroups.get(last.selector);
+      if (group && group.length > 1) {
+        dedupeRule(last, group);
+      }
     } else if (
       (last.type === 'atrule' && last.name !== 'layer') ||
       last.type === 'decl'

--- a/packages/postcss-discard-duplicates/types/index.d.ts.map
+++ b/packages/postcss-discard-duplicates/types/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.js"],"names":[],"mappings":";AA2JA;;;GAGG;AACH,kCAFY,OAAO,SAAS,EAAE,MAAM,CASnC"}
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.js"],"names":[],"mappings":";AAmLA;;;GAGG;AACH,kCAFY,OAAO,SAAS,EAAE,MAAM,CASnC"}


### PR DESCRIPTION
## What

Replaces the O(N²) duplicate-rule scan in `postcss-discard-duplicates` with a single selector-bucketing pass: each rule dedupes only against earlier rules sharing its selector instead of scanning every preceding sibling.

Full default preset over a corpus of 21 released framework CSS files (master = 100% of current time, lower is faster):

| | master | this PR |
|---|---|---|
| total time | 100% | **93% (−7%)** |

The scan is quadratic *even when there are no duplicates*, so the win grows with rule count. Synthetic stylesheets of N distinct-selector rules (this plugin only):

| rules (N) | master | this PR |
|---|---|---|
| 500 | 100% (1.69 ms) | 71% (1.20 ms) |
| 1000 | 100% (4.84 ms) | 52% (2.52 ms) |
| 2000 | 100% (13.78 ms) | 43% (5.90 ms) |
| 4000 | 100% (45.16 ms) | 28% (12.78 ms) |

Document order and last-wins semantics are unchanged.
