### PR TITLE
Include postcss-discard-overridden types in package

### DIFF
--- a/packages/postcss-discard-overridden/package.json
+++ b/packages/postcss-discard-overridden/package.json
@@ -6,7 +6,8 @@
   "types": "types/index.d.ts",
   "files": [
     "LICENSE",
-    "src"
+    "src",
+    "types"
   ],
   "keywords": [
     "postcss",


### PR DESCRIPTION
## Summary
- include the postcss-discard-overridden types directory in the published package files
- keep the existing types entrypoint usable for TypeScript consumers

## Verification
- npm pack --dry-run --json --ignore-scripts
- installed the locally packed tarball into a clean TypeScript project and ran npx tsc --noEmit