### PR TITLE
fix: preserve apostrophes in svg data uris

### DIFF
--- a/.changeset/quiet-buckets-encode.md
+++ b/.changeset/quiet-buckets-encode.md
@@ -1,0 +1,5 @@
+---
+"postcss-svgo": patch
+---
+
+Encode apostrophes as XML entities in SVG data URIs so optimized attributes remain valid when SVGO emits values containing apostrophes.

--- a/packages/postcss-svgo/src/lib/url.js
+++ b/packages/postcss-svgo/src/lib/url.js
@@ -5,6 +5,7 @@
  */
 function encode(data) {
   return data
+    .replace(/'/g, '&apos;')
     .replace(/"/g, "'")
     .replace(/%/g, '%25')
     .replace(/</g, '%3C')

--- a/packages/postcss-svgo/test/index.js
+++ b/packages/postcss-svgo/test/index.js
@@ -105,6 +105,14 @@ test(
 );
 
 test(
+  'should preserve apostrophes in uri-encoded svg attributes',
+  processCSS(
+    'h1{background:url("data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%3E%3Ctext%20font-size=%2720%27%20font-family=%27%26apos;Arial%26apos;%27%20transform=%27translate%280%2C20%29%27%3E?%3C/text%3E%3C/svg%3E")}',
+    "h1{background:url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Ctext font-family='%26apos;Arial%26apos;' font-size='20' transform='translate(0 20)'%3E?%3C/text%3E%3C/svg%3E\")}"
+  )
+);
+
+test(
   'should allow users to customise the output',
   processCSS(
     'h1{background:url(\'data:image/svg+xml;utf-8,<?xml version="1.0" encoding="utf-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"><circle cx="50" cy="50" r="40" fill="yellow" /><!--test comment--></svg>\')}',

--- a/packages/postcss-svgo/types/lib/url.d.ts.map
+++ b/packages/postcss-svgo/types/lib/url.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"url.d.ts","sourceRoot":"","sources":["../../src/lib/url.js"],"names":[],"mappings":"AACA;;;GAGG;AACH,6BAHW,MAAM,GACL,MAAM,CAWjB;AAED,+CAAkC"}
+{"version":3,"file":"url.d.ts","sourceRoot":"","sources":["../../src/lib/url.js"],"names":[],"mappings":"AACA;;;GAGG;AACH,6BAHW,MAAM,GACL,MAAM,CAYjB;AAED,+CAAkC"}


### PR DESCRIPTION
Fixes #1783.

This keeps apostrophes inside optimized SVG data URI content as XML entities before the existing URL encoding step converts double-quoted SVG attributes to single quotes. Without this, SVGO output such as `font-family="'Arial'"` becomes invalid XML after encoding as `font-family=''Arial''`.

Changes:

- encode apostrophes as `&apos;` before percent-encoding SVG data URI output
- add a regression test for an encoded SVG attribute containing `&apos;Arial&apos;`
- add a patch changeset for `postcss-svgo`

Verification:

- `pnpm test:only packages/postcss-svgo/test/index.js --test-name-pattern "preserve apostrophes"`
- `pnpm test:only packages/postcss-svgo/test/index.js`
- `pnpm lint`
- `pnpm types`
- `pnpm test:only`
- `pnpm exec prettier --check .changeset/quiet-buckets-encode.md packages/postcss-svgo/src/lib/url.js packages/postcss-svgo/test/index.js`
- `git diff --check`