### PR TITLE
Add regression test for border custom property merging

### DIFF
--- a/packages/cssnano/test/issue1000.js
+++ b/packages/cssnano/test/issue1000.js
@@ -1,0 +1,23 @@
+'use strict';
+const { test } = require('node:test');
+const processCss = require('./_processCss');
+
+test(
+  'preserves border width when merging border shorthands with custom properties (#1000)',
+  processCss(
+    `:root {
+      --border--width--thick: 10px;
+    }
+
+    .a {
+      border-top: var(--border--width--thick) solid blue;
+      border-width: 1px;
+    }
+
+    .a > .b {
+      border-left: var(--border--width--thick) solid blue;
+      border-width: 1px;
+    }`,
+    ':root{--border--width--thick:10px}.a{border-top:solid blue;border-width:1px}.a>.b{border-left:solid blue;border-width:1px}'
+  )
+);


### PR DESCRIPTION
Refs cssnano/cssnano#1000.

## Summary
- Add an integration regression test for border shorthands with custom property widths followed by `border-width`.
- Assert cssnano's current full optimization pipeline preserves declaration order so the optimized output keeps the effective `1px` border width.
- This PR does not change optimizer implementation code; it codifies the current fixed behavior so the #1000 regression is caught if it comes back.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec node --test packages/cssnano/test/issue1000.js`
- `pnpm exec node --test packages/postcss-merge-longhand/test/borders.js`
- `git diff --check`

Note: the local Node version is v25.9.0, so pnpm reported the repository engine warning (expected ^22.11 || ^24.11 || >=26.0), but the focused checks above passed.
