### PR TITLE
fix(postcss-reduce-idents): only rename a referenced counter style

### DIFF
--- a/.changeset/counter-style-reused-instance.md
+++ b/.changeset/counter-style-reused-instance.md
@@ -1,0 +1,5 @@
+---
+"postcss-reduce-idents": patch
+---
+
+Do not rename an unreferenced `@counter-style` when the plugin instance is reused across files. The counter-style reducer now tracks references per file like the keyframes reducer, so a stale reference count from an earlier file no longer renames an unreferenced counter style in a later one.

--- a/packages/postcss-reduce-idents/src/lib/counter-style.js
+++ b/packages/postcss-reduce-idents/src/lib/counter-style.js
@@ -97,11 +97,17 @@ module.exports = function () {
     },
 
     transform() {
+      const referenced = new Set();
+
       // Iterate each property and change their names
       decls.forEach((decl) => {
         decl.value = valueParser(decl.value)
           .walk((node) => {
             if (node.type === 'word' && node.value in cache) {
+              if (!referenced.has(node.value)) {
+                referenced.add(node.value);
+              }
+
               cache[node.value].count++;
 
               node.value = cache[node.value].ident;
@@ -114,7 +120,7 @@ module.exports = function () {
       atRules.forEach((rule) => {
         const cached = cache[rule.params];
 
-        if (cached && cached.count > 0) {
+        if (cached && cached.count > 0 && referenced.has(rule.params)) {
           rule.params = cached.ident;
         }
       });

--- a/packages/postcss-reduce-idents/test/index.js
+++ b/packages/postcss-reduce-idents/test/index.js
@@ -569,6 +569,30 @@ test('should not generate same ident when plugin instance is reused', () => {
   });
 });
 
+test('should not rename an unreferenced counter style when plugin instance is reused', () => {
+  const instance = postcss(plugin);
+
+  return Promise.all([
+    instance.process(
+      '@counter-style custom{system:extends decimal;suffix:"> "}ol{list-style:custom}',
+      { from: undefined }
+    ),
+    instance.process(
+      '@counter-style custom{system:extends decimal;suffix:"> "}',
+      { from: undefined }
+    ),
+  ]).then(([result1, result2]) => {
+    assert.strictEqual(
+      result1.css,
+      '@counter-style a{system:extends decimal;suffix:"> "}ol{list-style:a}'
+    );
+    assert.strictEqual(
+      result2.css,
+      '@counter-style custom{system:extends decimal;suffix:"> "}'
+    );
+  });
+});
+
 test('encoder', () => {
   let iterations = new Array(1984);
   let arr = Array.apply([], iterations).map((a, b) => b);


### PR DESCRIPTION
`postcss-reduce-idents` keeps a per-instance cache of idents so names stay unique when one plugin instance processes several files. The keyframes reducer renames an `@keyframes` at-rule only when its name was actually referenced in the current file. The counter-style reducer is missing that check: it renames an `@counter-style` whenever the cached reference count is above zero, and that count is never reset between files.

So when the same plugin instance runs over more than one file, a counter style that was referenced in an earlier file still has a count above zero, and an unrelated `@counter-style` with the same name in a later file gets renamed even though nothing references it there.

### Reproduction

```js
const postcss = require('postcss');
const reduceIdents = require('postcss-reduce-idents');

const instance = postcss([reduceIdents()]);

instance.process(
  '@counter-style custom{system:extends decimal;suffix:"> "}ol{list-style:custom}',
  { from: undefined }
).css;
// @counter-style a{...}ol{list-style:a}   (correct, custom is referenced)

instance.process(
  '@counter-style custom{system:extends decimal;suffix:"> "}',
  { from: undefined }
).css;
// before: @counter-style a{...}            (wrong: custom is not referenced here)
// after:  @counter-style custom{...}       (left untouched)
```

The fix mirrors the guard the keyframes reducer already uses, added in `d5b929106` ("Prevent name collision when parsing multiple files"): collect the names referenced in the current file and only rename the at-rule when its name is in that set.

I added a regression test next to the existing keyframes reuse test. The package test suite passes (50 tests).
