### PR TITLE
chore: delete c8 config

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,9 +1,0 @@
-{
-  "include": [
-    "packages/*/src/**/*.js",
-    "packages/postcss-reduce-initial/script/lib/io.mjs",
-    "packages/postcss-reduce-initial/script/lib/mdnCssProps.mjs"
-  ],
-  "all": true,
-  "reporter": ["text", "lcovonly"]
-}


### PR DESCRIPTION
The repo is not using c8 for coverage anymore