### PR TITLE
fix(postcss-merge-longhand): preserve border-color var() fallback regardless of declaration order (#1682)

### DIFF
--- a/.changeset/fix-1682-border-color-var-fallback.md
+++ b/.changeset/fix-1682-border-color-var-fallback.md
@@ -1,0 +1,5 @@
+---
+'postcss-merge-longhand': patch
+---
+
+fix: preserve border-color/border-width custom-property var() fallback regardless of declaration order (#1682)

--- a/packages/postcss-merge-longhand/src/lib/decl/borders.js
+++ b/packages/postcss-merge-longhand/src/lib/decl/borders.js
@@ -320,6 +320,32 @@ function merge(rule) {
       return false;
     }
 
+    // Bail when a custom-property border shorthand sits between the
+    // directions being merged. The synthesized border-wsc declarations are
+    // inserted after the last direction, which would leapfrog and silently
+    // override the custom property, dropping its var() fallback (#1682).
+    const ruleNodes = /** @type {import('postcss').Declaration[]} */ (
+      rule.nodes
+    );
+    const firstIndex = Math.min(
+      ...rules.map((node) => ruleNodes.indexOf(node))
+    );
+    const lastIndex = Math.max(...rules.map((node) => ruleNodes.indexOf(node)));
+
+    if (
+      ruleNodes
+        .slice(firstIndex + 1, lastIndex)
+        .some(
+          (node) =>
+            node.type === 'decl' &&
+            isCustomProp(node) &&
+            (node.prop.toLowerCase() === 'border' ||
+              properties.includes(node.prop.toLowerCase()))
+        )
+    ) {
+      return false;
+    }
+
     const values = rules.map(({ value }) => value);
 
     if (!canMergeValues(values)) {

--- a/packages/postcss-merge-longhand/test/borders.js
+++ b/packages/postcss-merge-longhand/test/borders.js
@@ -1297,4 +1297,12 @@ test(
   )
 );
 
+test(
+  'should preserve border-color custom property fallback regardless of declaration order #1682',
+  processCSS(
+    '.arrow{border-style:solid;border-width:50px;border-color:#fff transparent;border-color:var(--col) transparent;border-top:none;height:0;width:0}',
+    '.arrow{border-color:#fff transparent;border-style:solid;border-width:50px;border-color:var(--col) transparent;border-top:none;height:0;width:0}'
+  )
+);
+
 test('should handle empty border', processCSS('h1{border:;}', 'h1{border:;}'));

--- a/packages/postcss-merge-longhand/types/lib/decl/borders.d.ts.map
+++ b/packages/postcss-merge-longhand/types/lib/decl/borders.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"borders.d.ts","sourceRoot":"","sources":["../../../src/lib/decl/borders.js"],"names":[],"mappings":"AAiLA;;;GAGG;AACH,8BAHW,OAAO,SAAS,EAAE,IAAI,GACrB,IAAI,CAyEf;AAED;;;GAGG;AACH,4BAHW,OAAO,SAAS,EAAE,IAAI,GACrB,IAAI,CAslBf"}
+{"version":3,"file":"borders.d.ts","sourceRoot":"","sources":["../../../src/lib/decl/borders.js"],"names":[],"mappings":"AAiLA;;;GAGG;AACH,8BAHW,OAAO,SAAS,EAAE,IAAI,GACrB,IAAI,CAyEf;AAED;;;GAGG;AACH,4BAHW,OAAO,SAAS,EAAE,IAAI,GACrB,IAAI,CAgnBf"}


### PR DESCRIPTION
# fix(postcss-merge-longhand): preserve border-color var() fallback regardless of declaration order

Closes #1682

## Problem

`postcss-merge-longhand` silently drops the CSS custom-property fallback
pattern for `border-color` when `border-style` / `border-width` are declared
**before** `border-color`.

Input:

```css
.arrow {
  border-style: solid;
  border-width: 50px;
  border-color: #fff transparent;
  border-color: var(--col) transparent;
  border-top: none;
  height: 0;
  width: 0;
}
```

Buggy output (v7.0.6 / current `master`):

```css
.arrow {
  border: 50px solid transparent;
  border-top: none;
  border-bottom: 50px solid #fff;
  height: 0;
  width: 0;
}
```

The `var(--col)` override is gone and the bottom border is hard-coded to the
`#fff` fallback, so runtime theme switching (changing `--col`) no longer
affects the border. Reordering the input so `border-color` comes first
already produced correct output, proving this is an order-dependent
processing defect rather than intended behaviour.

## Root cause

`packages/postcss-merge-longhand/src/lib/decl/borders.js`, the
`border-trbl -> border-wsc` merge (the `mergeRules(rule, directions, …)` block
starting at line ~318 of `merge()`).

A `border-color: var(--col) transparent` declaration is a custom property and
is therefore **not** exploded into per-side longhands (see the `explode()`
guard `if (isCustomProp(decl)) { decl.prop = decl.prop.toLowerCase(); return false; }`).
It stays in the rule as a standalone declaration whose only job is to override
the preceding concrete `border-color`.

When `border-style`/`border-width` precede `border-color` in the source, the
exploded per-side colours end up positioned so that this custom declaration
lands *in the middle* of the four `border-top/right/bottom/left` declarations
being merged. The merge synthesizes a concrete
`border-color: currentcolor transparent #fff` and inserts it **after** the last
direction — i.e. **after** the `border-color: var(--col)` declaration —
inverting the cascade. The now-shadowed custom declaration is later removed by
the clean-up pass, dropping the `var()` fallback.

When `border-color` is declared first, cssnano's existing conflict detection
(`isConflictingProp` in `mergeRules.js`) happens to see the custom declaration
sitting *between* the merge candidates and blocks the merge, which is why that
ordering was already correct. The bug is that the same protection is not
applied when the custom declaration is positioned differently.

## Fix

Add a guard to the `border-trbl -> border-wsc` merge: if a custom-property
`border` / `border-width` / `border-style` / `border-color` declaration sits
between the direction declarations being merged, bail out of the merge. This
generalizes the protection that already made the reordered case correct, so
the result is now order-independent and the `var()` fallback is preserved.

The output for the reported case becomes (cascade-equivalent to the input; the
two `border-color` declarations keep their relative order and `var()` is
retained):

```css
.arrow {
  border-color: #fff transparent;
  border-style: solid;
  border-width: 50px;
  border-color: var(--col) transparent;
  border-top: none;
  height: 0;
  width: 0;
}
```

This matches the conservative, preservation-first behaviour already applied to
similar custom-property border cases in this file (#561, #572, #619, #675,
#1044, #1354).

## Tests

Added a regression test in
`packages/postcss-merge-longhand/test/borders.js`
(`should preserve border-color custom property fallback regardless of
declaration order #1682`) using the exact reproduction from the issue.

- Fails on `master` (var() dropped, output collapses to `border`/`border-bottom`).
- Passes with the fix.

## Verification

```
# regression test alone
node --test --test-name-pattern="#1682" packages/postcss-merge-longhand/test/borders.js
  before fix: 1 fail
  after fix:  1 pass

# full postcss-merge-longhand suite
node --test packages/postcss-merge-longhand/test/*.js
  416 tests, 416 pass, 0 fail   (415 pre-existing + 1 new)

# integration suites
node --test packages/cssnano packages/cssnano-preset-default \
            packages/cssnano-preset-advanced packages/cssnano-preset-lite
  4/4 pass

# end-to-end through the default preset: var(--col) preserved

# toolchain
tsc -b --force        -> exit 0
eslint (changed files) -> clean
prettier --check       -> clean
```

The fix is also idempotent (processing the output again yields the same CSS).

## Compatibility

No public API change. Behaviour changes only for the specific pattern where a
custom-property border shorthand is interleaved with per-side border longhands
being merged: instead of dropping the `var()` fallback, cssnano now preserves
it (slightly less aggressive merging in that narrow case, which is the correct
trade-off — it was previously producing incorrect CSS). All existing tests,
including every existing custom-property border test, continue to pass.
