### PR TITLE
ci: fail lint if committed .d.ts files drift from source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run lint
         run: pnpm lint
 
+      - name: Check committed types are up to date
+        run: git diff --exit-code -- '**/types/*.d.ts'
+
   test:
     needs: lint
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fail lint if type definitions are out-of-sync