### PR TITLE
fix: add main and types to package manifests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run lint
         run: pnpm lint
 
+      - name: Check package manifests resolve for consumers
+        run: pnpm test:packaging
+
   test:
     name: Test
     needs: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Check committed types are up to date
         run: git diff --exit-code -- '**/types/*.d.ts'
 
+      - name: Check package manifests resolve for consumers
+        run: pnpm test:packaging
+
   test:
     name: Test
     needs: [matrix, lint]

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "oxfmt": "^0.65.0",
     "oxlint": "^1.80.0",
     "postcss": "catalog:",
+    "resolve": "^1.22.12",
     "typescript": "~7.0.2"
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:unit": "pnpm --recursive --workspace-concurrency=1 exec node --test --test-reporter=dot --test-skip-pattern=\"framework tests\"",
     "test:site": "node --test site/test/*.js",
     "test:integration": "node --test packages/cssnano-preset-default/test/integrations.js packages/cssnano-preset-advanced/test/integrations.js packages/cssnano-preset-lite/test/integrations.js",
+    "test:packaging": "node util/checkPackaging.mjs",
     "test:watch": "node --test --watch",
     "test:failed": "node --test --test-rerun-failures=.test-failures.json",
     "test:mutation": "node util/mutation-testing/mutation-runner.mjs --catalog packages/postcss-discard-empty/mutation-catalog.mjs --catalog packages/postcss-discard-comments/mutation-catalog.mjs --catalog packages/postcss-normalize-whitespace/mutation-catalog.mjs",

--- a/packages/cssnano-preset-advanced/package.json
+++ b/packages/cssnano-preset-advanced/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE-MIT",
     "src",

--- a/packages/cssnano-preset-default/package.json
+++ b/packages/cssnano-preset-default/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE-MIT",
     "src",

--- a/packages/cssnano-preset-lite/package.json
+++ b/packages/cssnano-preset-lite/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "scripts": {
     "test": "node --test"
   },

--- a/packages/cssnano-utils/package.json
+++ b/packages/cssnano-utils/package.json
@@ -10,8 +10,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "homepage": "https://github.com/cssnano/cssnano",
   "bugs": {
     "url": "https://github.com/cssnano/cssnano/issues"

--- a/packages/cssnano/package.json
+++ b/packages/cssnano/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/cssnano"

--- a/packages/postcss-colormin/package.json
+++ b/packages/postcss-colormin/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "imports": {
     "#getBrowsersList": {
       "node": "./src/lib/computeBrowsersToSupport.js",

--- a/packages/postcss-convert-values/package.json
+++ b/packages/postcss-convert-values/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "imports": {
     "#getBrowsersList": {
       "node": "./src/lib/computeBrowsersToSupport.js",

--- a/packages/postcss-discard-comments/package.json
+++ b/packages/postcss-discard-comments/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "src",
     "LICENSE-MIT",

--- a/packages/postcss-discard-duplicates/package.json
+++ b/packages/postcss-discard-duplicates/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "src",
     "LICENSE-MIT",

--- a/packages/postcss-discard-empty/package.json
+++ b/packages/postcss-discard-empty/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "src",
     "LICENSE-MIT",

--- a/packages/postcss-discard-overridden/package.json
+++ b/packages/postcss-discard-overridden/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE",
     "src",

--- a/packages/postcss-discard-unused/package.json
+++ b/packages/postcss-discard-unused/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE-MIT",
     "src",

--- a/packages/postcss-merge-idents/package.json
+++ b/packages/postcss-merge-idents/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "src",
     "LICENSE-MIT",

--- a/packages/postcss-merge-longhand/package.json
+++ b/packages/postcss-merge-longhand/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE-MIT",
     "src",

--- a/packages/postcss-merge-rules/package.json
+++ b/packages/postcss-merge-rules/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "imports": {
     "#getBrowsersList": {
       "node": "./src/lib/computeBrowsersToSupport.js",

--- a/packages/postcss-minify-font-values/package.json
+++ b/packages/postcss-minify-font-values/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "src",
     "LICENSE",

--- a/packages/postcss-minify-gradients/package.json
+++ b/packages/postcss-minify-gradients/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE-MIT",
     "src",

--- a/packages/postcss-minify-params/package.json
+++ b/packages/postcss-minify-params/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "imports": {
     "#getBrowsersList": {
       "node": "./src/lib/computeBrowsersToSupport.js",

--- a/packages/postcss-minify-selectors/package.json
+++ b/packages/postcss-minify-selectors/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "imports": {
     "#getBrowsersList": {
       "node": "./src/lib/computeBrowsersToSupport.js",

--- a/packages/postcss-normalize-charset/package.json
+++ b/packages/postcss-normalize-charset/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "keywords": [
     "postcss",
     "css",

--- a/packages/postcss-normalize-display-values/package.json
+++ b/packages/postcss-normalize-display-values/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE-MIT",
     "src",

--- a/packages/postcss-normalize-positions/package.json
+++ b/packages/postcss-normalize-positions/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "src",
     "LICENSE-MIT",

--- a/packages/postcss-normalize-repeat-style/package.json
+++ b/packages/postcss-normalize-repeat-style/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE-MIT",
     "src",

--- a/packages/postcss-normalize-string/package.json
+++ b/packages/postcss-normalize-string/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "src",
     "LICENSE-MIT",

--- a/packages/postcss-normalize-timing-functions/package.json
+++ b/packages/postcss-normalize-timing-functions/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE-MIT",
     "src",

--- a/packages/postcss-normalize-unicode/package.json
+++ b/packages/postcss-normalize-unicode/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "imports": {
     "#getBrowsersList": {
       "node": "./src/lib/computeBrowsersToSupport.js",

--- a/packages/postcss-normalize-url/package.json
+++ b/packages/postcss-normalize-url/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "imports": {
     "#path": {
       "node": "./src/lib/path_normalizer.js",

--- a/packages/postcss-normalize-whitespace/package.json
+++ b/packages/postcss-normalize-whitespace/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "src",
     "LICENSE-MIT",

--- a/packages/postcss-ordered-values/package.json
+++ b/packages/postcss-ordered-values/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "src",
     "LICENSE-MIT",

--- a/packages/postcss-reduce-idents/package.json
+++ b/packages/postcss-reduce-idents/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "src",
     "LICENSE-MIT",

--- a/packages/postcss-reduce-initial/package.json
+++ b/packages/postcss-reduce-initial/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "imports": {
     "#getBrowsersList": {
       "node": "./src/lib/computeBrowsersToSupport.js",

--- a/packages/postcss-reduce-transforms/package.json
+++ b/packages/postcss-reduce-transforms/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE-MIT",
     "src",

--- a/packages/postcss-svgo/package.json
+++ b/packages/postcss-svgo/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE-MIT",
     "src",

--- a/packages/postcss-unique-selectors/package.json
+++ b/packages/postcss-unique-selectors/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE-MIT",
     "src",

--- a/packages/postcss-zindex/package.json
+++ b/packages/postcss-zindex/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "files": [
     "LICENSE-MIT",
     "src",

--- a/packages/stylehacks/package.json
+++ b/packages/stylehacks/package.json
@@ -6,8 +6,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./src/index.js",
+  "types": "./types/index.d.ts",
   "imports": {
     "#getBrowsersList": {
       "node": "./src/lib/computeBrowsersToSupport.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       postcss:
         specifier: 'catalog:'
         version: 8.5.26
+      resolve:
+        specifier: ^1.22.12
+        version: 1.22.12
       typescript:
         specifier: ~7.0.2
         version: 7.0.2
@@ -1589,6 +1592,10 @@ packages:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1613,6 +1620,9 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-tsconfig@4.14.1:
     resolution: {integrity: sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==}
 
@@ -1621,9 +1631,17 @@ packages:
     peerDependencies:
       postcss: ^8.0.0
 
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
 
   is-eot@1.0.0:
     resolution: {integrity: sha512-hPQF4rLYEe9VGVGr6aGrc0Yf5s8MOaEsY8SUi/IySicowWu10/Cr60+JVsVEl7v2MD+TbhwBWjudCK6OycPr7g==}
@@ -1727,6 +1745,9 @@ packages:
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1780,6 +1801,11 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   sax@1.6.1:
     resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
     engines: {node: '>=11.0.0'}
@@ -1799,6 +1825,10 @@ packages:
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   svgo@4.1.0:
     resolution: {integrity: sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==}
@@ -2393,6 +2423,8 @@ snapshots:
 
   entities@8.0.0: {}
 
+  es-errors@1.3.0: {}
+
   escalade@3.2.0: {}
 
   fd-package-json@2.0.0:
@@ -2409,6 +2441,8 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  function-bind@1.1.2: {}
+
   get-tsconfig@4.14.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -2417,11 +2451,19 @@ snapshots:
     dependencies:
       postcss: 8.5.26
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
 
   is-eot@1.0.0: {}
 
@@ -2595,6 +2637,8 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  path-parse@1.0.7: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.7: {}
@@ -2638,6 +2682,13 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
   sax@1.6.1: {}
 
   saxes@6.0.0:
@@ -2649,6 +2700,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   strip-json-comments@5.0.3: {}
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   svgo@4.1.0:
     dependencies:

--- a/util/checkPackaging.mjs
+++ b/util/checkPackaging.mjs
@@ -1,80 +1,49 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 /**
- * Nothing in the workspace resolves a package through its manifest — tests
- * import the source by relative path — so a manifest can point nowhere and
- * every test still passes. That is how 8.0.3 shipped without `main`.
+ * Checks that every package can still be resolved by tools that predate
+ * `exports`, which read `main` and `types` instead.
  *
- * `exports` is read by Node and by modern bundlers. `main` and `types` are
- * read by resolvers that predate it, such as eslint-plugin-import and
- * TypeScript's classic `moduleResolution: node`. Both have to be present, and
- * every path they name has to exist and be published.
+ * Nothing else here covers that. The test suite imports the source by
+ * relative path, and Node resolves the workspace through `exports`, so a
+ * package can become unresolvable for those tools while everything passes.
+ * That is how 8.0.3 shipped without `main`.
+ *
+ * The resolving is done by `resolve`, the same package eslint-plugin-import
+ * uses, rather than by a copy of its algorithm kept here.
  */
 
-/**
- * Every string in a manifest value, however deeply nested.
- * @param {unknown} value
- * @param {string[]} found
- * @return {string[]}
- */
-function targets(value, found = []) {
-  if (typeof value === 'string') {
-    found.push(value);
-  } else if (value !== null && typeof value === 'object') {
-    for (const nested of Object.values(value)) {
-      targets(nested, found);
-    }
-  }
+const require = createRequire(import.meta.url);
+const resolve = require('resolve');
 
-  return found;
-}
-
-const packagesDir = new URL('../packages/', import.meta.url);
+const root = fileURLToPath(new URL('..', import.meta.url));
+const packagesDir = path.join(root, 'packages');
 const names = readdirSync(packagesDir).toSorted();
 let failed = 0;
 
 for (const name of names) {
-  const dir = fileURLToPath(new URL(name, packagesDir));
+  const dir = path.join(packagesDir, name);
   const manifest = JSON.parse(
     readFileSync(path.join(dir, 'package.json'), 'utf8')
   );
-  const files = manifest.files ?? [];
   /** @type {string[]} */
   const problems = [];
 
-  if (!manifest.exports?.['.']) {
-    problems.push('"exports" has no "." entry');
+  try {
+    resolve.sync(`./packages/${name}`, { basedir: root });
+  } catch {
+    problems.push('does not resolve without `exports` support, add `main`');
+  }
+
+  if (!manifest.types || !existsSync(path.join(dir, manifest.types))) {
+    problems.push('has no `types` file, TypeScript on `node` finds no types');
   }
 
   if (!manifest.exports?.['./package.json']) {
-    problems.push('"exports" does not expose "./package.json"');
-  }
-
-  if (!manifest.main) {
-    problems.push('no "main", so resolvers predating "exports" cannot find it');
-  }
-
-  if (!manifest.types) {
-    problems.push('no "types", so "moduleResolution": "node" finds no types');
-  }
-
-  for (const target of targets([
-    manifest.exports,
-    manifest.main,
-    manifest.types,
-  ])) {
-    const relative = target.replace(/^\.\//, '');
-
-    if (!existsSync(path.resolve(dir, relative))) {
-      problems.push(`${target} does not exist`);
-    } else if (
-      relative !== 'package.json' &&
-      !files.some((entry) => relative.startsWith(entry))
-    ) {
-      problems.push(`${target} is not in "files", so it is not published`);
-    }
+    problems.push('does not export `./package.json`');
   }
 
   if (problems.length) {
@@ -87,8 +56,8 @@ for (const name of names) {
 }
 
 if (failed) {
-  console.error(`\n${failed} of ${names.length} manifests are broken.`);
+  console.error(`\n${failed} of ${names.length} packages have problems.`);
   process.exitCode = 1;
 } else {
-  console.log(`Checked ${names.length} package manifests.`);
+  console.log(`Resolved ${names.length} packages.`);
 }

--- a/util/checkPackaging.mjs
+++ b/util/checkPackaging.mjs
@@ -1,0 +1,94 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/**
+ * Nothing in the workspace resolves a package through its manifest — tests
+ * import the source by relative path — so a manifest can point nowhere and
+ * every test still passes. That is how 8.0.3 shipped without `main`.
+ *
+ * `exports` is read by Node and by modern bundlers. `main` and `types` are
+ * read by resolvers that predate it, such as eslint-plugin-import and
+ * TypeScript's classic `moduleResolution: node`. Both have to be present, and
+ * every path they name has to exist and be published.
+ */
+
+/**
+ * Every string in a manifest value, however deeply nested.
+ * @param {unknown} value
+ * @param {string[]} found
+ * @return {string[]}
+ */
+function targets(value, found = []) {
+  if (typeof value === 'string') {
+    found.push(value);
+  } else if (value !== null && typeof value === 'object') {
+    for (const nested of Object.values(value)) {
+      targets(nested, found);
+    }
+  }
+
+  return found;
+}
+
+const packagesDir = new URL('../packages/', import.meta.url);
+const names = readdirSync(packagesDir).toSorted();
+let failed = 0;
+
+for (const name of names) {
+  const dir = fileURLToPath(new URL(name, packagesDir));
+  const manifest = JSON.parse(
+    readFileSync(path.join(dir, 'package.json'), 'utf8')
+  );
+  const files = manifest.files ?? [];
+  /** @type {string[]} */
+  const problems = [];
+
+  if (!manifest.exports?.['.']) {
+    problems.push('"exports" has no "." entry');
+  }
+
+  if (!manifest.exports?.['./package.json']) {
+    problems.push('"exports" does not expose "./package.json"');
+  }
+
+  if (!manifest.main) {
+    problems.push('no "main", so resolvers predating "exports" cannot find it');
+  }
+
+  if (!manifest.types) {
+    problems.push('no "types", so "moduleResolution": "node" finds no types');
+  }
+
+  for (const target of targets([
+    manifest.exports,
+    manifest.main,
+    manifest.types,
+  ])) {
+    const relative = target.replace(/^\.\//, '');
+
+    if (!existsSync(path.resolve(dir, relative))) {
+      problems.push(`${target} does not exist`);
+    } else if (
+      relative !== 'package.json' &&
+      !files.some((entry) => relative.startsWith(entry))
+    ) {
+      problems.push(`${target} is not in "files", so it is not published`);
+    }
+  }
+
+  if (problems.length) {
+    failed++;
+    console.error(`${name}:`);
+    for (const problem of problems) {
+      console.error(`- ${problem}`);
+    }
+  }
+}
+
+if (failed) {
+  console.error(`\n${failed} of ${names.length} manifests are broken.`);
+  process.exitCode = 1;
+} else {
+  console.log(`Checked ${names.length} package manifests.`);
+}


### PR DESCRIPTION
Fixes #1935

`main` and `types` were dropped in #1863 and first shipped in 8.0.3, so resolvers that predate `exports` (eslint-plugin-import, TypeScript `moduleResolution: node`) fail to resolve any package. 9.0 also dropped the ./package.json` subpath