### PR TITLE
Fix SvgoParserError on data URIs mixing percent-encoding with a bare %

### DIFF
--- a/.changeset/fix-svgo-data-uri-bare-percent.md
+++ b/.changeset/fix-svgo-data-uri-bare-percent.md
@@ -1,0 +1,5 @@
+---
+"postcss-svgo": patch
+---
+
+Fix `SvgoParserError` on data URIs that mix percent-encoded characters with a bare, unencoded `%` (e.g. `rgb(0 0 0 / 80%)`). `decode` now decodes each contiguous run of `%XX` escapes as a unit instead of failing the whole string when it also contains a `%` that isn't part of a valid escape.

--- a/packages/postcss-svgo/src/lib/url.js
+++ b/packages/postcss-svgo/src/lib/url.js
@@ -1,5 +1,19 @@
 const encode = encodeURIComponent;
 
-const decode = decodeURIComponent;
+// A run of one or more contiguous %XX escapes is decoded as a unit so
+// multi-byte UTF-8 sequences (e.g. %C3%A9) round-trip correctly. A run
+// that isn't valid percent-encoding (e.g. it sits next to a bare `%`
+// that isn't part of an escape, like `80%` in `rgb(0 0 0 / 80%)`) is
+// left untouched instead of failing the whole string.
+// See: https://github.com/cssnano/cssnano/issues/1961
+function decode(str) {
+  return str.replace(/(?:%[0-9a-fA-F]{2})+/g, (run) => {
+    try {
+      return decodeURIComponent(run);
+    } catch {
+      return run;
+    }
+  });
+}
 
 export { encode, decode };

--- a/packages/postcss-svgo/test/index.js
+++ b/packages/postcss-svgo/test/index.js
@@ -299,4 +299,36 @@ test('should not crash on malformed urls when encoded', () => {
   assert.doesNotThrow(() => decode(svg));
 });
 
+test('decode should leave a bare percent sign next to valid escapes untouched', () => {
+  assert.strictEqual(decode('rgb(0 0 0 / 80%)'), 'rgb(0 0 0 / 80%)');
+  assert.strictEqual(decode('%3crgb(0 0 0 / 80%)'), '<rgb(0 0 0 / 80%)');
+});
+
+test('decode should still correctly decode multi-byte UTF-8 sequences', () => {
+  assert.strictEqual(decode('caf%C3%A9'), 'café');
+});
+
 test('should use the postcss plugin api', usePostCSSPlugin(plugin()));
+
+// https://github.com/cssnano/cssnano/issues/1961
+test(
+  'should not warn on a partially-encoded svg containing a bare percent sign',
+  processCSS(
+    "h1{background:url(\"data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' style='background: rgb(0 0 0 / 80%);' ></svg>\")}",
+    'h1{background:url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20style%3D%22background%3Argb(0%200%200%2F80%25)%22%20viewBox%3D%220%200%20100%20100%22%2F%3E")}'
+  )
+);
+
+test('should not warn on an unencoded svg containing a bare percent sign', async () => {
+  const css =
+    "h1{background:url(\"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' style='background: rgb(0 0 0 / 80%);' ></svg>\")}";
+  const result = await postcss(plugin()).process(css, { from: undefined });
+  assert.strictEqual(result.messages.length, 0);
+});
+
+test('should not warn on a fully-encoded svg with an encoded percent sign', async () => {
+  const css =
+    "h1{background:url(\"data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' style='background: rgb(0 0 0 / 80%25);' ></svg>\")}";
+  const result = await postcss(plugin()).process(css, { from: undefined });
+  assert.strictEqual(result.messages.length, 0);
+});


### PR DESCRIPTION
## Summary

Fixes #1961.

`postcss-svgo`'s `decode` calls `decodeURIComponent` on the whole data URI string. `decodeURIComponent` throws `URI malformed` whenever a `%` sits next to characters that don't form a valid escape — which happens for entirely ordinary CSS like `rgb(0 0 0 / 80%)`. The `try/catch` in `minifySVG` treats that as "this string isn't percent-encoded" and passes it straight to svgo unchanged.

That's fine when the string truly isn't encoded at all. But it's wrong when the string genuinely *is* percent-encoded (e.g. contains `%3c`) and *also* happens to contain a bare `%` elsewhere (e.g. `80%`) — the whole decode fails, so the still-encoded string (starting with `%3c...`) gets handed to svgo as if it were raw SVG, and svgo throws `SvgoParserError: Non-whitespace before first tag`.

### Reproduction (from the issue)

```css
:root {
  /* no percent-encoding, works fine */
  --var-1: url("data:image/svg+xml,<svg ... style='background: rgb(0 0 0 / 80%);' ></svg>");

  /* one %3c + bare 80% -> currently throws SvgoParserError */
  --var-2: url("data:image/svg+xml,%3csvg ... style='background: rgb(0 0 0 / 80%);' ></svg>");

  /* fully encoded (80% -> %25), works fine */
  --var-3: url("data:image/svg+xml,%3csvg ... style='background: rgb(0 0 0 / 80%25);' ></svg>");
}
```

Only `--var-2` reproduces the error.

## Fix

`decode` now decodes each **contiguous run** of `%XX` escapes as a unit, instead of decoding the whole string in one `decodeURIComponent` call:

```diff
 const encode = encodeURIComponent;
-const decode = decodeURIComponent;
+function decode(str) {
+  return str.replace(/(?:%[0-9a-fA-F]{2})+/g, (run) => {
+    try {
+      return decodeURIComponent(run);
+    } catch {
+      return run;
+    }
+  });
+}
```

A bare `%` that isn't part of a `%XX` escape is never matched by the regex, so it's left untouched rather than failing the whole decode. Runs (not individual `%XX` tokens) are decoded together so multi-byte UTF-8 escapes like `%C3%A9` still round-trip correctly — decoding a lone continuation byte on its own throws, which a naive per-token fix would silently regress.

## Test plan

- Added tests to `packages/postcss-svgo/test/index.js` reproducing all three cases from the issue (unencoded, partially-encoded-with-bare-%, fully-encoded), plus direct unit tests on `decode` for the bare-% and multi-byte-UTF-8 cases.
- Full `postcss-svgo` suite: 39 passed (34 existing + 5 new), 0 failed.
- `oxlint` and `oxfmt --check` clean on changed files.
- Added a changeset (`patch` bump for `postcss-svgo`) per CONTRIBUTING.md.